### PR TITLE
feat: GitHub Actions CI for dashboard and SimHub plugin

### DIFF
--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -1,0 +1,41 @@
+name: Dashboard CI
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - "dashboard-overlay/**"
+  pull_request:
+    branches: [main, master]
+    paths:
+      - "dashboard-overlay/**"
+
+jobs:
+
+  # ---------------------------------------------------------------
+  # Electron dashboard: install deps + Playwright unit tests
+  # ---------------------------------------------------------------
+  dashboard-tests:
+    name: Dashboard Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: dashboard-overlay/package-lock.json
+
+      - name: Install dependencies
+        working-directory: dashboard-overlay
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: dashboard-overlay
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright unit tests
+        working-directory: dashboard-overlay
+        run: npm test

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -1,0 +1,42 @@
+name: SimHub Plugin CI
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - "simhub-plugin/**"
+  pull_request:
+    branches: [main, master]
+    paths:
+      - "simhub-plugin/**"
+
+jobs:
+
+  # ---------------------------------------------------------------
+  # C# .NET 4.8 plugin build — uses SimHub stubs from lib/simhub-refs/
+  # ---------------------------------------------------------------
+  plugin-build:
+    name: Build SimHub Plugin
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.x"
+
+      - name: Restore NuGet packages
+        working-directory: simhub-plugin/plugin/K10Motorsports.Plugin
+        run: dotnet restore
+
+      - name: Build plugin
+        working-directory: simhub-plugin/plugin/K10Motorsports.Plugin
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: K10Motorsports.Plugin
+          path: simhub-plugin/build/K10Motorsports.Plugin.dll


### PR DESCRIPTION
## Summary
- **`dashboard-ci.yml`**: triggers on push/PR to `dashboard-overlay/**`; runs Node 20, `npm ci`, Playwright chromium install, then `npm test`
- **`plugin-ci.yml`**: triggers on push/PR to `simhub-plugin/**`; runs on `windows-latest` (required for net48 + WPF); `dotnet restore` + `dotnet build --configuration Release`; uploads `K10Motorsports.Plugin.dll` as a build artifact. Uses `lib/simhub-refs/` stubs already in the repo — no SimHub install needed on the runner.

## Test plan
- [ ] Merge and verify both workflows appear in the Actions tab
- [ ] Open a follow-up PR touching `dashboard-overlay/`; verify dashboard CI runs
- [ ] Open a follow-up PR touching `simhub-plugin/`; verify plugin CI runs on Windows