### PR TITLE
Fix sector display showing full lap time (#8)

### DIFF
--- a/dashboard-overlay/modules/js/drive-hud.js
+++ b/dashboard-overlay/modules/js/drive-hud.js
@@ -156,6 +156,19 @@
         }
       } else if (splits[si - 1] > 0) {
         var split = splits[si - 1];
+        // Sanity check: iRacing sometimes sends cumulative lap time as
+        // the final sector split. Never display a full lap time here.
+        var sumOther = 0, otherCount = 0;
+        for (var sc = 0; sc < sectorCount; sc++) {
+          if (sc !== si - 1 && splits[sc] > 0) { sumOther += splits[sc]; otherCount++; }
+        }
+        var exceedsOthers = sumOther > 0 && split >= sumOther;
+        var exceedsBest = bestLap > 0 && split >= bestLap * 0.85;
+        var lastNoCtx = si === sectorCount && sectorCount >= 2 && otherCount === 0;
+        if (exceedsOthers || exceedsBest || lastNoCtx) {
+          timeEl.textContent = '—';
+          if (sDeltaEl) sDeltaEl.textContent = '';
+        } else {
         var m = Math.floor(split / 60);
         var s = split % 60;
         timeEl.textContent = (m > 0 ? m + ':' : '') + (m > 0 && s < 10 ? '0' : '') + s.toFixed(1);
@@ -165,6 +178,7 @@
           if (states[si - 1] === 1) sDeltaEl.textContent = 'PB';
           else if (d !== 0) sDeltaEl.textContent = (d >= 0 ? '+' : '') + d.toFixed(2);
           else sDeltaEl.textContent = '';
+        }
         }
       } else {
         timeEl.textContent = '—';

--- a/dashboard-overlay/modules/js/poll-engine.js
+++ b/dashboard-overlay/modules/js/poll-engine.js
@@ -647,15 +647,29 @@
           }
         } else if (splits[si - 1] > 0) {
           // Completed sector: show sector time + delta to my best.
-          // Sanity check: a single sector time must never be >= the sum of
-          // all other known sector splits — that would mean the plugin
-          // accidentally sent the cumulative lap time here instead.
+          // Multi-layered sanity check: iRacing sometimes sends the
+          // cumulative lap time as the final sector split. We must
+          // never display a full lap time inside a sector cell.
           const split = splits[si - 1];
           let sumOtherSplits = 0;
+          let otherSplitCount = 0;
           for (let k = 0; k < sectorCount; k++) {
-            if (k !== si - 1 && splits[k] > 0) sumOtherSplits += splits[k];
+            if (k !== si - 1 && splits[k] > 0) {
+              sumOtherSplits += splits[k];
+              otherSplitCount++;
+            }
           }
-          const looksLikeFullLap = sumOtherSplits > 0 && split >= sumOtherSplits;
+          // Check 1: split >= sum of all other known sectors (original check)
+          const exceedsOthers = sumOtherSplits > 0 && split >= sumOtherSplits;
+          // Check 2: split >= 85% of best lap — no single sector should be
+          // that large relative to the full lap
+          const exceedsBestLap = bestLap > 0 && split >= bestLap * 0.85;
+          // Check 3: last sector with no other splits populated yet —
+          // this is the classic case where iRacing sends cumulative time
+          // before the earlier sectors are filled in
+          const lastSectorNoContext = si === sectorCount && sectorCount >= 2
+            && otherSplitCount === 0;
+          const looksLikeFullLap = exceedsOthers || exceedsBestLap || lastSectorNoContext;
           if (looksLikeFullLap) {
             // Suppress — never show a full lap time inside a sector cell
             timeEl.textContent = '—';


### PR DESCRIPTION
## Summary
- Three-layer sanity check prevents iRacing cumulative lap time from leaking into sector cells
- Catches the edge case where other sectors are all zero (start of new lap)
- Added missing sanity check to drive-hud.js (had none at all)

## Root cause
The previous check `sumOtherSplits > 0 && split >= sumOtherSplits` silently passed when other sectors were 0 — which is exactly when iRacing sends cumulative time as the final sector.

## Test plan
- [ ] Start a practice session, cross S/F line — verify last sector never shows full lap time
- [ ] Complete multiple laps — verify sector times display correctly
- [ ] Switch to Drive HUD mode — verify sectors also display correctly there

🤖 Generated with [Claude Code](https://claude.com/claude-code)