### PR TITLE
Fix pit box tire wear and fuel unit mismatch (#11)

### DIFF
--- a/dashboard-overlay/modules/js/pitbox.js
+++ b/dashboard-overlay/modules/js/pitbox.js
@@ -113,8 +113,31 @@
   }
 
   // ── Wear bar helpers ──
+  // Parse tyre wear with null-awareness and raw telemetry fallback.
+  // Returns null when no data available, otherwise 0-1 (1=new, 0=worn).
+  function _parseTyreWear(gameDataVal, rawL, rawM, rawR) {
+    // Try GameData value first
+    if (gameDataVal != null && gameDataVal !== '') {
+      var v = parseFloat(gameDataVal);
+      if (!isNaN(v)) return v;
+    }
+    // Fallback: raw telemetry wear points (average of inner/mid/outer)
+    var l = parseFloat(rawL), m = parseFloat(rawM), r = parseFloat(rawR);
+    if (!isNaN(l) && !isNaN(m) && !isNaN(r) && (l + m + r) > 0) {
+      return (l + m + r) / 3;
+    }
+    return null; // No data available yet
+  }
+
   function updateWearBar(fillEl, valEl, wear) {
     if (!fillEl || !valEl) return;
+    if (wear === null || wear === undefined) {
+      // No data — show placeholder instead of fake 100%
+      fillEl.style.width = '0%';
+      fillEl.className = 'pb-tire-bar-fill';
+      valEl.textContent = '—';
+      return;
+    }
     var pct = Math.max(0, Math.min(100, (1 - wear) * 100));
     var remaining = Math.round(pct);
     fillEl.style.width = remaining + '%';
@@ -168,11 +191,18 @@
     updateTire('LR', _els.tireLR, _els.pressLR, pb('TireLR'), pb('PressureLR'));
     updateTire('RR', _els.tireRR, _els.pressRR, pb('TireRR'), pb('PressureRR'));
 
-    // Wear bars
-    updateWearBar(_els.wearLF, _els.wearLFVal, parseFloat(gd('TyreWearFrontLeft')) || 0);
-    updateWearBar(_els.wearRF, _els.wearRFVal, parseFloat(gd('TyreWearFrontRight')) || 0);
-    updateWearBar(_els.wearLR, _els.wearLRVal, parseFloat(gd('TyreWearRearLeft')) || 0);
-    updateWearBar(_els.wearRR, _els.wearRRVal, parseFloat(gd('TyreWearRearRight')) || 0);
+    // Wear bars — iRacing sends 0-1 where 1=new, 0=worn.
+    // Use null-aware parsing: null/undefined means "no data yet" (show —),
+    // whereas 0 means "fully worn" (show 0%).
+    // Fall back to raw telemetry average if GameData returns null (first lap).
+    var wearFL = _parseTyreWear(gd('TyreWearFrontLeft'), dc('LFwearL'), dc('LFwearM'), dc('LFwearR'));
+    var wearFR = _parseTyreWear(gd('TyreWearFrontRight'), dc('RFwearL'), dc('RFwearM'), dc('RFwearR'));
+    var wearRL = _parseTyreWear(gd('TyreWearRearLeft'), dc('LRwearL'), dc('LRwearM'), dc('LRwearR'));
+    var wearRR = _parseTyreWear(gd('TyreWearRearRight'), dc('RRwearL'), dc('RRwearM'), dc('RRwearR'));
+    updateWearBar(_els.wearLF, _els.wearLFVal, wearFL);
+    updateWearBar(_els.wearRF, _els.wearRFVal, wearFR);
+    updateWearBar(_els.wearLR, _els.wearLRVal, wearRL);
+    updateWearBar(_els.wearRR, _els.wearRRVal, wearRR);
 
     // Tyre temps
     if (_els.tempLF) _els.tempLF.textContent = formatTemp(gd('TyreTempFrontLeft'), units);

--- a/dashboard-overlay/modules/js/poll-engine.js
+++ b/dashboard-overlay/modules/js/poll-engine.js
@@ -180,15 +180,21 @@
     const fuel = +d('DataCorePlugin.GameData.Fuel', 'Demo.Fuel') || 0;
     const fuelPct = +(p[dsPre + 'FuelPct']) || 0;
     const fuelRem = document.querySelector('.fuel-remaining');
-    if (fuelRem) fuelRem.innerHTML = fuel > 0 ? fuel.toFixed(1) + ' <span class="unit">L</span>' : '— <span class="unit">L</span>';
+    // Respect DisplayUnits for fuel label (0=imperial/gal, 1=metric/L)
+    const _rawFuelUnits = p[dsPre + 'DisplayUnits'];
+    const _fuelImperial = _rawFuelUnits !== '' && _rawFuelUnits != null && parseInt(_rawFuelUnits) === 0;
+    const fuelDisplay = _fuelImperial ? fuel / 3.78541 : fuel;
+    const fuelUnitLabel = _fuelImperial ? 'gal' : 'L';
+    if (fuelRem) fuelRem.innerHTML = fuelDisplay > 0 ? fuelDisplay.toFixed(1) + ' <span class="unit">' + fuelUnitLabel + '</span>' : '— <span class="unit">' + fuelUnitLabel + '</span>';
     updateFuelBar(fuelPct, 0);
 
-    const fuelPerLap = _demo ? (+v('K10Motorsports.Plugin.Demo.FuelPerLap') || 0) : (+v('DataCorePlugin.Computed.Fuel_LitersPerLap') || 0);
-    const fuelLapsEst = +(p[dsPre + 'FuelLapsRemaining']) || (fuelPerLap > 0 ? fuel / fuelPerLap : 0);
+    const fuelPerLapRaw = _demo ? (+v('K10Motorsports.Plugin.Demo.FuelPerLap') || 0) : (+v('DataCorePlugin.Computed.Fuel_LitersPerLap') || 0);
+    const fuelPerLap = _fuelImperial ? fuelPerLapRaw / 3.78541 : fuelPerLapRaw;
+    const fuelLapsEst = +(p[dsPre + 'FuelLapsRemaining']) || (fuelPerLapRaw > 0 ? fuel / fuelPerLapRaw : 0);
     const completedLaps = +(p[dsPre + 'CompletedLaps']) || 0;
     const fuelVals = document.querySelectorAll('.fuel-stats .val');
     if (fuelVals.length >= 2) {
-      // Fix #10: Show "calculating..." during lap 1 when fuelPerLap hasn't stabilized yet
+      // Show "calculating..." during lap 1 when fuelPerLap hasn't stabilized yet
       if (fuelPerLap > 0) {
         fuelVals[0].textContent = fuelPerLap.toFixed(2);
       } else if (completedLaps < 2 && fuel > 0) {


### PR DESCRIPTION
## Summary
- Tire wear now uses null-aware parsing — shows "—" when no data instead of fake 100%
- Falls back to raw telemetry wear points (LFwearL/M/R averages) when GameData is null during first lap
- Main dashboard fuel display now respects DisplayUnits (converts L→gal when imperial), matching the pitbox
- Fuel-per-lap also converted to match user's unit preference

## Root cause
**Tires**: `parseFloat(value) || 0` defaulted null to 0, then `(1-0)*100 = 100%` — fake full health.
**Fuel**: Main dashboard hardcoded "L" label regardless of iRacing DisplayUnits setting.

## Test plan
- [ ] Start session — tire wear shows "—" until data arrives, then shows real percentages
- [ ] Set iRacing to imperial — both dashboard and pitbox show gallons
- [ ] Set iRacing to metric — both show liters
- [ ] Verify fuel-per-lap matches the unit system

🤖 Generated with [Claude Code](https://claude.com/claude-code)