### PR TITLE
Fix track map rotation cropping and heading jitter (#4)

### DIFF
--- a/dashboard-overlay/modules/js/drive-hud.js
+++ b/dashboard-overlay/modules/js/drive-hud.js
@@ -9,6 +9,7 @@
 
   let _active = false;
   let _dhHeadingSmooth = 0; // LERP-smoothed heading (degrees) to reduce judder
+  let _dhLastMapTime = 0;   // timestamp for time-based LERP
 
   function toggleDriveMode() {
     _active = !_active;
@@ -235,25 +236,33 @@
         dhPlayer.setAttribute('cy', py.toFixed(1));
       }
 
-      // Zoom viewBox: always centered on player, no edge clamping
-      // Use a wider view (±22 units) and rotate so driving direction is up
+      // Zoom viewBox: centered on player with expanded radius to accommodate
+      // rotation. A 22-unit visible radius needs ~31 units (22 × √2) so the
+      // rotated track content isn't clipped by the viewBox rectangle.
       var dhSvg = document.getElementById('dhMapSvg');
       if (dhSvg) {
-        var zr = 22; // wider zoom — less claustrophobic
-        // Center on player without clamping — no premature cropping
+        var zrVisible = 22; // visible zoom radius
+        var zr = Math.ceil(zrVisible * 1.42); // ×√2 for rotation headroom
         var vx = px - zr;
         var vy = py - zr;
         dhSvg.setAttribute('viewBox', vx.toFixed(1) + ' ' + vy.toFixed(1) + ' ' + (zr * 2) + ' ' + (zr * 2));
 
         // Rotate map so driving direction always points up.
-        // Apply LERP smoothing to eliminate heading judder, with correct
-        // wrap-around handling at the 0°/360° boundary.
+        // Time-based LERP smoothing eliminates heading judder regardless
+        // of poll rate. Dead-zone ignores sub-degree noise.
         var rawHeading = +(p['K10Motorsports.Plugin.TrackMap.PlayerHeading']) || 0;
         var diff = rawHeading - _dhHeadingSmooth;
         // Normalise diff to [-180, 180] to pick the shortest rotation arc
         while (diff > 180) diff -= 360;
         while (diff < -180) diff += 360;
-        _dhHeadingSmooth += diff * 0.18; // LERP factor — tweak for more/less lag
+        // Dead-zone: ignore tiny heading jitter (< 0.5°)
+        if (Math.abs(diff) < 0.5) diff = 0;
+        // Time-based LERP: smooth factor ~0.10 per 33ms (30 FPS baseline)
+        var now = performance.now();
+        var dt = Math.min(100, now - (_dhLastMapTime || now)); // cap at 100ms
+        _dhLastMapTime = now;
+        var alpha = 1 - Math.pow(1 - 0.10, dt / 33);
+        _dhHeadingSmooth += diff * alpha;
         _dhHeadingSmooth = ((_dhHeadingSmooth % 360) + 360) % 360;
 
         // Rotate the inner group around the player's SVG coordinate, NOT the

--- a/dashboard-overlay/modules/styles/base.css
+++ b/dashboard-overlay/modules/styles/base.css
@@ -175,7 +175,11 @@
     justify-content: center;
     background: hsla(0,0%,100%,0.02);
     position: relative;
-    overflow: hidden;
+    /* overflow:visible allows the SVG to extend slightly during rotation
+       without rectangular clipping. A circular clip-path gives a clean
+       edge while accommodating the rotated content. */
+    overflow: visible;
+    clip-path: inset(0 round var(--corner-r));
     border-radius: var(--corner-r);
   }
   .dh-map-name {


### PR DESCRIPTION
## Summary
- **Cropping fix**: replaced `overflow:hidden` on `.dh-map` with `overflow:visible` + `clip-path:inset(0 round var(--corner-r))` — clean rounded clipping without cutting off rotated content. Expanded viewBox radius by √2 (22→31 units) so rotated paths stay within SVG viewport.
- **Jitter fix**: replaced fixed per-frame LERP (0.18) with time-based smoothing using `performance.now()` delta — consistent behavior regardless of poll rate. Added 0.5° dead-zone to filter sub-degree heading noise.

## Root cause
**Cropping**: `.dh-map { overflow: hidden }` clips to a rectangle. When the SVG group rotates, track paths extending beyond the rectangle get cut off.
**Jitter**: Fixed LERP factor applied per-poll means smoothing varies with poll rate. At higher rates, 0.18 per frame is too responsive.

## Test plan
- [ ] Load any track — track outline should not get clipped during rotation
- [ ] Drive through corners — heading rotation should be smooth without micro-jitter
- [ ] Player dot stays centered and upright
- [ ] Map container keeps its rounded corners

🤖 Generated with [Claude Code](https://claude.com/claude-code)