### PR TITLE
Fix settings panel disappearing on drag and second monitor (#10)

### DIFF
--- a/dashboard-overlay/main.js
+++ b/dashboard-overlay/main.js
@@ -463,6 +463,8 @@ function openSettingsWindow() {
     alwaysOnTop: true,
     transparent: false,
     backgroundColor: '#1a1a1a',
+    // Skip taskbar so it doesn't fight with the sim for alt-tab focus
+    skipTaskbar: true,
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
@@ -473,17 +475,73 @@ function openSettingsWindow() {
     }
   });
 
+  // Use 'screen-saver' level so the window stays above fullscreen sims
+  settingsWindow.setAlwaysOnTop(true, 'screen-saver');
+
   // Load the same dashboard with a query flag so renderer knows to show settings only
   settingsWindow.loadFile(path.join(__dirname, getDashboardFile()), {
     query: { settingsPopout: '1' }
   });
 
-  const onDisplayRemoved = (display) => {
-    if (settingsWindow && !settingsWindow.isDestroyed() && settingsWindow.webContents.getURL().includes(getDashboardFile())) {
-      const displays = screen.getAllDisplays();
-      const settingsDisplay = displays.find(d => d.id === secondary.id);
-      if (!settingsDisplay) {
-        closeSettingsWindow();
+  // Recover visibility: when the window is ready, force it visible and
+  // on top in case the sim stole focus during load.
+  settingsWindow.once('ready-to-show', () => {
+    if (settingsWindow && !settingsWindow.isDestroyed()) {
+      settingsWindow.show();
+      settingsWindow.setAlwaysOnTop(true, 'screen-saver');
+    }
+  });
+
+  // If the sim steals focus and the window somehow gets hidden, restore it
+  settingsWindow.on('hide', () => {
+    if (settingsWindow && !settingsWindow.isDestroyed()) {
+      settingsWindow.show();
+    }
+  });
+
+  // Verify the window ended up on a valid display; if the target display
+  // has unexpected bounds (e.g., removed between detection and creation),
+  // move it to center of primary display.
+  settingsWindow.once('show', () => {
+    if (settingsWindow && !settingsWindow.isDestroyed()) {
+      const bounds = settingsWindow.getBounds();
+      const allDisplays = screen.getAllDisplays();
+      const onAnyDisplay = allDisplays.some(d => {
+        return bounds.x < d.bounds.x + d.bounds.width &&
+               bounds.x + bounds.width > d.bounds.x &&
+               bounds.y < d.bounds.y + d.bounds.height &&
+               bounds.y + bounds.height > d.bounds.y;
+      });
+      if (!onAnyDisplay) {
+        const pri = screen.getPrimaryDisplay();
+        settingsWindow.setPosition(
+          pri.bounds.x + Math.round((pri.bounds.width - winW) / 2),
+          pri.bounds.y + Math.round((pri.bounds.height - winH) / 2)
+        );
+        logToFile('[K10] Settings window was off-screen, moved to primary display');
+      }
+    }
+  });
+
+  const onDisplayRemoved = () => {
+    if (settingsWindow && !settingsWindow.isDestroyed()) {
+      // Check if the window is still on a valid display
+      const bounds = settingsWindow.getBounds();
+      const allDisplays = screen.getAllDisplays();
+      const onAnyDisplay = allDisplays.some(d => {
+        return bounds.x < d.bounds.x + d.bounds.width &&
+               bounds.x + bounds.width > d.bounds.x &&
+               bounds.y < d.bounds.y + d.bounds.height &&
+               bounds.y + bounds.height > d.bounds.y;
+      });
+      if (!onAnyDisplay) {
+        // Display was removed — move to primary instead of closing
+        const pri = screen.getPrimaryDisplay();
+        settingsWindow.setPosition(
+          pri.bounds.x + Math.round((pri.bounds.width - winW) / 2),
+          pri.bounds.y + Math.round((pri.bounds.height - winH) / 2)
+        );
+        logToFile('[K10] Display removed, moved settings to primary display');
       }
     }
   };

--- a/dashboard-overlay/modules/js/settings.js
+++ b/dashboard-overlay/modules/js/settings.js
@@ -195,11 +195,16 @@
         if (!_isDragging) return;
         var rawLeft = e.clientX - _dragOffX;
         var rawTop  = e.clientY - _dragOffY;
-        // Clamp so the panel can't be dragged fully off-screen
-        var maxLeft = window.innerWidth  - 40;
-        var maxTop  = window.innerHeight - 40;
+        // Clamp aggressively: keep at least half the panel width and the
+        // full titlebar height visible on-screen at all times. The previous
+        // 40px margin was too loose — the panel could be dragged almost
+        // entirely off-screen in all directions.
+        var minVisible = Math.max(200, Math.round(panel.offsetWidth * 0.5));
+        var maxLeft = window.innerWidth  - minVisible;
+        var minLeft = -(panel.offsetWidth - minVisible);
+        var maxTop  = window.innerHeight - 60; // keep titlebar reachable
         panel.style.position = 'fixed';
-        panel.style.left = Math.max(-panel.offsetWidth + 40, Math.min(maxLeft, rawLeft)) + 'px';
+        panel.style.left = Math.max(minLeft, Math.min(maxLeft, rawLeft)) + 'px';
         panel.style.top  = Math.max(0, Math.min(maxTop, rawTop)) + 'px';
         panel.style.margin = '0';
       });


### PR DESCRIPTION
## Summary
- **Drag fix**: tightened clamp bounds — requires at least 50% of panel width (min 200px) visible horizontally, titlebar always reachable (60px from bottom edge)
- **Popout fix**: upgraded alwaysOnTop to `screen-saver` level to stay above fullscreen sims. Added ready-to-show visibility recovery, hide event handler, display bounds validation, and graceful relocation to primary display when secondary is disconnected

## Root cause
**Drag**: previous 40px clamp allowed dragging panel almost entirely off-screen in all directions.
**Popout**: plain `alwaysOnTop: true` gets overridden by fullscreen simulators. No recovery mechanism existed if the window ended up off-screen or hidden.

## Test plan
- [ ] Drag settings panel to all screen edges — panel stays at least half visible
- [ ] Click popout button — settings window appears on secondary monitor above the sim
- [ ] Alt-tab to sim and back — settings window stays visible
- [ ] Disconnect secondary monitor — settings window moves to primary display

🤖 Generated with [Claude Code](https://claude.com/claude-code)