### PR TITLE
feat: add data validation for strategy commentary

### DIFF
--- a/simhub-plugin/plugin/K10Motorsports.Plugin/Engine/Strategy/FuelComputer.cs
+++ b/simhub-plugin/plugin/K10Motorsports.Plugin/Engine/Strategy/FuelComputer.cs
@@ -30,6 +30,14 @@ namespace K10Motorsports.Plugin.Engine.Strategy
         private double _avgBurnEarly;  // average burn from first 5 laps
         private bool _avgBurnEarlySet;
 
+        // ── Validation constants ──────────────────────────────────────────
+        /// <summary>Maximum plausible fuel level in liters (largest GT/prototype tanks).</summary>
+        private const double MaxFuelCapacity = 200.0;
+        /// <summary>Maximum plausible fuel burn per lap in liters (worst-case big-displacement car).</summary>
+        private const double MaxBurnPerLap = 25.0;
+        /// <summary>Previous frame fuel for delta sanity check.</summary>
+        private double _prevFuel = -1;
+
         // ── Public state for dashboard ──────────────────────────────────
 
         /// <summary>Fuel remaining in liters.</summary>
@@ -74,7 +82,14 @@ namespace K10Motorsports.Plugin.Engine.Strategy
 
         public void UpdateFrame(TelemetrySnapshot s)
         {
-            FuelRemaining = s.FuelLevel;
+            // ── Validate fuel level ──────────────────────────────────────
+            double fuel = s.FuelLevel;
+            if (double.IsNaN(fuel) || double.IsInfinity(fuel) || fuel < 0)
+                fuel = _prevFuel >= 0 ? _prevFuel : 0;
+            fuel = Math.Min(fuel, MaxFuelCapacity);
+            _prevFuel = fuel;
+
+            FuelRemaining = fuel;
 
             // Detect pit lane entry/exit for pit time calibration
             if (s.IsInPitLane && !_calibratingPitTime)
@@ -100,6 +115,21 @@ namespace K10Motorsports.Plugin.Engine.Strategy
         public void OnLapCompleted(StintData stint, TelemetrySnapshot s, double fuelUsedThisLap)
         {
             if (stint == null) return;
+
+            // ── Validate fuel burn ───────────────────────────────────────
+            // Reject negative burns (refueling mid-lap shouldn't count as usage),
+            // NaN/Infinity, and impossibly high single-lap burns.
+            if (double.IsNaN(fuelUsedThisLap) || double.IsInfinity(fuelUsedThisLap))
+                fuelUsedThisLap = 0;
+            fuelUsedThisLap = Math.Max(0, Math.Min(MaxBurnPerLap, fuelUsedThisLap));
+
+            // Reject outlier laps: if we have history, reject burns > 3× average
+            if (stint.FuelPerLap.Count >= 3)
+            {
+                double avg = stint.AvgFuelPerLap;
+                if (avg > 0.01 && fuelUsedThisLap > avg * 3.0)
+                    fuelUsedThisLap = avg; // substitute average for the spike
+            }
 
             stint.FuelPerLap.Add(fuelUsedThisLap);
 
@@ -144,6 +174,7 @@ namespace K10Motorsports.Plugin.Engine.Strategy
             _avgBurnEarlySet = false;
             FuelSavingDetected = false;
             FuelSavingLapsGained = 0;
+            _prevFuel = -1; // reset fuel tracking for spike rejection
         }
 
         // ═══════════════════════════════════════════════════════════════

--- a/simhub-plugin/plugin/K10Motorsports.Plugin/Engine/Strategy/TireTracker.cs
+++ b/simhub-plugin/plugin/K10Motorsports.Plugin/Engine/Strategy/TireTracker.cs
@@ -34,6 +34,18 @@ namespace K10Motorsports.Plugin.Engine.Strategy
         private double[] _tempAccumFL = new double[0];
         private int _tempSampleCount;
 
+        // ── Validation: previous-frame wear for spike rejection ─────────
+        private double[] _prevWear = new double[4];
+        private bool _prevWearValid;
+        /// <summary>Max wear jump per frame before value is rejected as a spike.
+        /// At 60 FPS the fastest realistic wear is ~0.02/s → 0.00033/frame.
+        /// We allow 15× headroom for physics hiccups and low-FPS scenarios.</summary>
+        private const double MaxWearDeltaPerFrame = 0.005;
+
+        // ── Temperature sanity range ────────────────────────────────────
+        private const double TempAbsoluteMin = 0.0;    // °C
+        private const double TempAbsoluteMax = 300.0;   // °C — above this is sensor garbage
+
         // ── Cooldowns ───────────────────────────────────────────────────
         private DateTime _lastTempCall  = DateTime.MinValue;
         private DateTime _lastWearCall  = DateTime.MinValue;
@@ -81,16 +93,38 @@ namespace K10Motorsports.Plugin.Engine.Strategy
             _absWasActive = s.AbsActive;
             _tcWasActive = s.TcActive;
 
-            // Update current values
-            CurrentWear[0] = s.TyreWearFL;
-            CurrentWear[1] = s.TyreWearFR;
-            CurrentWear[2] = s.TyreWearRL;
-            CurrentWear[3] = s.TyreWearRR;
+            // ── Validate & update wear values ────────────────────────────
+            double[] rawWear = { s.TyreWearFL, s.TyreWearFR, s.TyreWearRL, s.TyreWearRR };
+            for (int i = 0; i < 4; i++)
+            {
+                double w = rawWear[i];
 
-            CurrentTemp[0] = s.TyreTempFL;
-            CurrentTemp[1] = s.TyreTempFR;
-            CurrentTemp[2] = s.TyreTempRL;
-            CurrentTemp[3] = s.TyreTempRR;
+                // Clamp to valid 0-1 range (garbage data or unit mismatch)
+                w = Math.Max(0.0, Math.Min(1.0, w));
+
+                // Spike rejection: if we have a prior frame and the jump is
+                // impossibly large, hold the previous value instead
+                if (_prevWearValid && Math.Abs(w - _prevWear[i]) > MaxWearDeltaPerFrame)
+                {
+                    // Allow the jump if wear DECREASED (pit stop / tire change)
+                    if (w >= _prevWear[i])
+                        w = _prevWear[i]; // reject upward spike, hold previous
+                }
+
+                CurrentWear[i] = w;
+                _prevWear[i] = w;
+            }
+            _prevWearValid = true;
+
+            // ── Validate & update temperature values ─────────────────────
+            double[] rawTemp = { s.TyreTempFL, s.TyreTempFR, s.TyreTempRL, s.TyreTempRR };
+            for (int i = 0; i < 4; i++)
+            {
+                double t = rawTemp[i];
+                // Clamp to physically plausible range
+                t = Math.Max(TempAbsoluteMin, Math.Min(TempAbsoluteMax, t));
+                CurrentTemp[i] = t;
+            }
 
             // Temperature states
             for (int i = 0; i < 4; i++)
@@ -108,6 +142,9 @@ namespace K10Motorsports.Plugin.Engine.Strategy
         {
             if (stint == null) return;
 
+            // Use validated wear from CurrentWear (already clamped & spike-filtered by UpdateFrame)
+            double[] validatedWear = (double[])CurrentWear.Clone();
+
             // Record wear delta this lap
             double[] wearDelta = new double[4];
             if (stint.WearPerLap.Count > 0)
@@ -115,17 +152,17 @@ namespace K10Motorsports.Plugin.Engine.Strategy
                 // Wear delta = current wear minus wear at start of this lap
                 // Since wear accumulates, we track the difference
                 var prevCumulative = stint.CumulativeWear;
-                wearDelta[0] = Math.Max(0, s.TyreWearFL - (stint.StartLap > 0 ? prevCumulative[0] : 0));
-                wearDelta[1] = Math.Max(0, s.TyreWearFR - (stint.StartLap > 0 ? prevCumulative[1] : 0));
-                wearDelta[2] = Math.Max(0, s.TyreWearRL - (stint.StartLap > 0 ? prevCumulative[2] : 0));
-                wearDelta[3] = Math.Max(0, s.TyreWearRR - (stint.StartLap > 0 ? prevCumulative[3] : 0));
+                wearDelta[0] = Math.Max(0, validatedWear[0] - (stint.StartLap > 0 ? prevCumulative[0] : 0));
+                wearDelta[1] = Math.Max(0, validatedWear[1] - (stint.StartLap > 0 ? prevCumulative[1] : 0));
+                wearDelta[2] = Math.Max(0, validatedWear[2] - (stint.StartLap > 0 ? prevCumulative[2] : 0));
+                wearDelta[3] = Math.Max(0, validatedWear[3] - (stint.StartLap > 0 ? prevCumulative[3] : 0));
             }
 
             stint.WearPerLap.Add(wearDelta);
             stint.PeakLatG.Add(_peakLatGThisLap);
             stint.AbsActivationsPerLap.Add(_absCountThisLap);
             stint.TcActivationsPerLap.Add(_tcCountThisLap);
-            stint.TempPerLap.Add(new[] { s.TyreTempFL, s.TyreTempFR, s.TyreTempRL, s.TyreTempRR });
+            stint.TempPerLap.Add((double[])CurrentTemp.Clone());
 
             // Estimate remaining tire life
             EstimatedLapsRemaining = stint.EstimateLapsToWearThreshold(CurrentWear, WearCritical);
@@ -156,6 +193,8 @@ namespace K10Motorsports.Plugin.Engine.Strategy
             GripScore = 0;
             TireHealthState = 0;
             EstimatedLapsRemaining = 99;
+            // Reset spike rejection — new tires will have a large wear jump
+            _prevWearValid = false;
         }
 
         // ═══════════════════════════════════════════════════════════════

--- a/simhub-plugin/plugin/K10Motorsports.Plugin/Engine/TelemetrySnapshot.Capture.cs
+++ b/simhub-plugin/plugin/K10Motorsports.Plugin/Engine/TelemetrySnapshot.Capture.cs
@@ -101,34 +101,36 @@ namespace K10Motorsports.Plugin.Engine
             // Fallback for iRacing: GameData.TyreWear* is only updated after a
             // full lap, so the bars stay at 0 until then. Fall back to the raw
             // per-zone wear telemetry values (LFwearL/M/R etc.) which ARE live.
-            // Convention: 0.0=new, 1.0=fully worn (same as GameData scale).
+            // IMPORTANT: iRacing raw wear values use 1.0=new, 0.0=worn convention
+            // but our internal convention is 0.0=new, 1.0=fully worn. We must
+            // invert when using the raw telemetry fallback.
             if (s.TyreWearFL == 0)
             {
                 float wL = GetRaw<float>(pm, "LFwearL");
                 float wM = GetRaw<float>(pm, "LFwearM");
                 float wR = GetRaw<float>(pm, "LFwearR");
-                if (wL > 0 || wM > 0 || wR > 0) s.TyreWearFL = (wL + wM + wR) / 3f;
+                if (wL > 0 || wM > 0 || wR > 0) s.TyreWearFL = 1.0 - ((wL + wM + wR) / 3f);
             }
             if (s.TyreWearFR == 0)
             {
                 float wL = GetRaw<float>(pm, "RFwearL");
                 float wM = GetRaw<float>(pm, "RFwearM");
                 float wR = GetRaw<float>(pm, "RFwearR");
-                if (wL > 0 || wM > 0 || wR > 0) s.TyreWearFR = (wL + wM + wR) / 3f;
+                if (wL > 0 || wM > 0 || wR > 0) s.TyreWearFR = 1.0 - ((wL + wM + wR) / 3f);
             }
             if (s.TyreWearRL == 0)
             {
                 float wL = GetRaw<float>(pm, "LRwearL");
                 float wM = GetRaw<float>(pm, "LRwearM");
                 float wR = GetRaw<float>(pm, "LRwearR");
-                if (wL > 0 || wM > 0 || wR > 0) s.TyreWearRL = (wL + wM + wR) / 3f;
+                if (wL > 0 || wM > 0 || wR > 0) s.TyreWearRL = 1.0 - ((wL + wM + wR) / 3f);
             }
             if (s.TyreWearRR == 0)
             {
                 float wL = GetRaw<float>(pm, "RRwearL");
                 float wM = GetRaw<float>(pm, "RRwearM");
                 float wR = GetRaw<float>(pm, "RRwearR");
-                if (wL > 0 || wM > 0 || wR > 0) s.TyreWearRR = (wL + wM + wR) / 3f;
+                if (wL > 0 || wM > 0 || wR > 0) s.TyreWearRR = 1.0 - ((wL + wM + wR) / 3f);
             }
 
             // ── Physics: iRacing raw → normalized fallback ───────────────────


### PR DESCRIPTION
## Summary

- **TireTracker**: Clamp wear to 0-1, reject frame-to-frame spikes (>0.005/frame), allow downward jumps for pit stops, clamp temps to 0-300°C, reset validation on new stint
- **FuelComputer**: Reject NaN/Infinity/negative fuel, cap at 200L, reject impossible burn rates (>25L/lap or >3× average), reset on new stint
- **TelemetrySnapshot.Capture**: Invert iRacing raw wear values in the fallback path (iRacing uses 1=new/0=worn, our convention is 0=new/1=worn)

## Why

Bad telemetry data (sensor spikes, unit mismatches, NaN values from disconnected hardware) was causing the strategy commentary to produce incorrect or misleading calls — e.g. premature "pit now" warnings from a single wear spike, or fuel projections thrown off by a single anomalous burn reading.

## Test plan

- [ ] Run a stint in iRacing and verify wear values stay in 0-1 range
- [ ] Verify fuel burn outliers are smoothed (check console logs)
- [ ] Confirm strategy calls are sensible after a pit stop (no false critical-wear alerts from tire change jump)
- [ ] Verify temperature readings stay within 0-300°C bounds

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)