### PR TITLE
fix: invert tire wear display from worn% to remaining%

### DIFF
--- a/dashboard-overlay/modules/js/poll-engine.js
+++ b/dashboard-overlay/modules/js/poll-engine.js
@@ -241,16 +241,18 @@
     }
 
     // ─── Tyres ───
+    // Backend sends wear as 0=new, 1=gone. Convert to remaining % for display
+    // (100 = full life, 0 = destroyed) so bar width + color thresholds are correct.
     if (_demo) {
-      updateTyreCell(0, +v('K10Motorsports.Plugin.Demo.TyreTempFL'), (+v('K10Motorsports.Plugin.Demo.TyreWearFL') || 1) * 100);
-      updateTyreCell(1, +v('K10Motorsports.Plugin.Demo.TyreTempFR'), (+v('K10Motorsports.Plugin.Demo.TyreWearFR') || 1) * 100);
-      updateTyreCell(2, +v('K10Motorsports.Plugin.Demo.TyreTempRL'), (+v('K10Motorsports.Plugin.Demo.TyreWearRL') || 1) * 100);
-      updateTyreCell(3, +v('K10Motorsports.Plugin.Demo.TyreTempRR'), (+v('K10Motorsports.Plugin.Demo.TyreWearRR') || 1) * 100);
+      updateTyreCell(0, +v('K10Motorsports.Plugin.Demo.TyreTempFL'), (1 - (+v('K10Motorsports.Plugin.Demo.TyreWearFL') || 0)) * 100);
+      updateTyreCell(1, +v('K10Motorsports.Plugin.Demo.TyreTempFR'), (1 - (+v('K10Motorsports.Plugin.Demo.TyreWearFR') || 0)) * 100);
+      updateTyreCell(2, +v('K10Motorsports.Plugin.Demo.TyreTempRL'), (1 - (+v('K10Motorsports.Plugin.Demo.TyreWearRL') || 0)) * 100);
+      updateTyreCell(3, +v('K10Motorsports.Plugin.Demo.TyreTempRR'), (1 - (+v('K10Motorsports.Plugin.Demo.TyreWearRR') || 0)) * 100);
     } else {
-      updateTyreCell(0, +v('DataCorePlugin.GameData.TyreTempFrontLeft'), (p['DataCorePlugin.GameData.TyreWearFrontLeft'] != null ? +p['DataCorePlugin.GameData.TyreWearFrontLeft'] * 100 : 100));
-      updateTyreCell(1, +v('DataCorePlugin.GameData.TyreTempFrontRight'), (p['DataCorePlugin.GameData.TyreWearFrontRight'] != null ? +p['DataCorePlugin.GameData.TyreWearFrontRight'] * 100 : 100));
-      updateTyreCell(2, +v('DataCorePlugin.GameData.TyreTempRearLeft'), (p['DataCorePlugin.GameData.TyreWearRearLeft'] != null ? +p['DataCorePlugin.GameData.TyreWearRearLeft'] * 100 : 100));
-      updateTyreCell(3, +v('DataCorePlugin.GameData.TyreTempRearRight'), (p['DataCorePlugin.GameData.TyreWearRearRight'] != null ? +p['DataCorePlugin.GameData.TyreWearRearRight'] * 100 : 100));
+      updateTyreCell(0, +v('DataCorePlugin.GameData.TyreTempFrontLeft'), (p['DataCorePlugin.GameData.TyreWearFrontLeft'] != null ? (1 - +p['DataCorePlugin.GameData.TyreWearFrontLeft']) * 100 : 100));
+      updateTyreCell(1, +v('DataCorePlugin.GameData.TyreTempFrontRight'), (p['DataCorePlugin.GameData.TyreWearFrontRight'] != null ? (1 - +p['DataCorePlugin.GameData.TyreWearFrontRight']) * 100 : 100));
+      updateTyreCell(2, +v('DataCorePlugin.GameData.TyreTempRearLeft'), (p['DataCorePlugin.GameData.TyreWearRearLeft'] != null ? (1 - +p['DataCorePlugin.GameData.TyreWearRearLeft']) * 100 : 100));
+      updateTyreCell(3, +v('DataCorePlugin.GameData.TyreTempRearRight'), (p['DataCorePlugin.GameData.TyreWearRearRight'] != null ? (1 - +p['DataCorePlugin.GameData.TyreWearRearRight']) * 100 : 100));
     }
 
     // ─── Controls (BB / TC / ABS) ───
@@ -971,8 +973,8 @@
           ? [+v('K10Motorsports.Plugin.Demo.TyreTempFL'), +v('K10Motorsports.Plugin.Demo.TyreTempFR'), +v('K10Motorsports.Plugin.Demo.TyreTempRL'), +v('K10Motorsports.Plugin.Demo.TyreTempRR')]
           : [+v('DataCorePlugin.GameData.TyreTempFrontLeft'), +v('DataCorePlugin.GameData.TyreTempFrontRight'), +v('DataCorePlugin.GameData.TyreTempRearLeft'), +v('DataCorePlugin.GameData.TyreTempRearRight')],
         tyreWears: _demo
-          ? [(+v('K10Motorsports.Plugin.Demo.TyreWearFL') || 1) * 100, (+v('K10Motorsports.Plugin.Demo.TyreWearFR') || 1) * 100, (+v('K10Motorsports.Plugin.Demo.TyreWearRL') || 1) * 100, (+v('K10Motorsports.Plugin.Demo.TyreWearRR') || 1) * 100]
-          : [(p['DataCorePlugin.GameData.TyreWearFrontLeft'] != null ? +p['DataCorePlugin.GameData.TyreWearFrontLeft'] * 100 : 100), (p['DataCorePlugin.GameData.TyreWearFrontRight'] != null ? +p['DataCorePlugin.GameData.TyreWearFrontRight'] * 100 : 100), (p['DataCorePlugin.GameData.TyreWearRearLeft'] != null ? +p['DataCorePlugin.GameData.TyreWearRearLeft'] * 100 : 100), (p['DataCorePlugin.GameData.TyreWearRearRight'] != null ? +p['DataCorePlugin.GameData.TyreWearRearRight'] * 100 : 100)]
+          ? [(1 - (+v('K10Motorsports.Plugin.Demo.TyreWearFL') || 0)) * 100, (1 - (+v('K10Motorsports.Plugin.Demo.TyreWearFR') || 0)) * 100, (1 - (+v('K10Motorsports.Plugin.Demo.TyreWearRL') || 0)) * 100, (1 - (+v('K10Motorsports.Plugin.Demo.TyreWearRR') || 0)) * 100]
+          : [(p['DataCorePlugin.GameData.TyreWearFrontLeft'] != null ? (1 - +p['DataCorePlugin.GameData.TyreWearFrontLeft']) * 100 : 100), (p['DataCorePlugin.GameData.TyreWearFrontRight'] != null ? (1 - +p['DataCorePlugin.GameData.TyreWearFrontRight']) * 100 : 100), (p['DataCorePlugin.GameData.TyreWearRearLeft'] != null ? (1 - +p['DataCorePlugin.GameData.TyreWearRearLeft']) * 100 : 100), (p['DataCorePlugin.GameData.TyreWearRearRight'] != null ? (1 - +p['DataCorePlugin.GameData.TyreWearRearRight']) * 100 : 100)]
       });
     }
 

--- a/dashboard-overlay/modules/js/webgl-helpers.js
+++ b/dashboard-overlay/modules/js/webgl-helpers.js
@@ -503,7 +503,8 @@
     return 'danger';                       // > 132°C
   }
 
-  // Update a single tyre cell: temp value + color class + wear bar
+  // Update a single tyre cell: temp value + color class + wear bar.
+  // wearPct is REMAINING life: 100 = brand new, 0 = destroyed.
   function updateTyreCell(index, tempF, wearPct) {
     const cells = document.querySelectorAll('.tyre-cell');
     const wearFills = document.querySelectorAll('.tyre-wear-fill');
@@ -513,7 +514,7 @@
     cell.className = 'tyre-cell ' + getTyreTempClass(tempF);
     if (index < wearFills.length) {
       wearFills[index].style.width = Math.max(0, Math.min(100, wearPct)) + '%';
-      // Color wear bar: green > 50%, amber > 25%, red below
+      // Color by remaining life: > 50% green, > 25% amber, below = red
       if (wearPct > 50) wearFills[index].style.background = 'var(--green)';
       else if (wearPct > 25) wearFills[index].style.background = 'var(--amber)';
       else wearFills[index].style.background = 'var(--red)';


### PR DESCRIPTION
## Summary
- **poll-engine.js** passed raw worn% (0=new, 100=gone) to `updateTyreCell()`, but the color thresholds and bar width treated higher values as healthier — 70%-worn tires showed green, fresh tires showed red
- Converted all `updateTyreCell` call sites to remaining% (`(1-wear)*100`), fixing HUD tire bars, demo mode, and commentary data
- Fixed demo fallback `||1` → `||0` which was defaulting new tires (wear=0, falsy) to fully worn

## Test plan
- [ ] Verify HUD tire bars show green on fresh tires, transition amber → red as wear increases
- [ ] Verify demo mode tire display matches live behavior
- [ ] Verify pitbox tire remaining % still reads correctly (no change to pitbox.js)
- [ ] Verify strategy events fire at correct wear levels (C# thresholds unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)