### PR TITLE
fix: green lights, rolling start dashboard, pit limiter holdover

### DIFF
--- a/dashboard-overlay/modules/js/formation.js
+++ b/dashboard-overlay/modules/js/formation.js
@@ -13,6 +13,11 @@
     } catch (e) { console.warn('Failed to load country flags:', e); }
   }
 
+  // Simulated green light holdover — when plugin doesn't send LightsPhase,
+  // we generate a synthetic sequence and hold it for 3 seconds
+  let _simLightsPhase = 0;
+  let _simLightsTimer = null;
+
   function updateGrid(p, isDemo) {
     const pre = isDemo ? 'K10Motorsports.Plugin.Demo.Grid.' : 'K10Motorsports.Plugin.Grid.';
     const sessionState = +(p[pre + 'SessionState']) || 0;
@@ -21,19 +26,24 @@
     const paceMode     = +(p[pre + 'PaceMode']) || 0;
     let lightsPhase    = +(p[pre + 'LightsPhase']) || 0;
     const startType    = (p[pre + 'StartType'] || 'rolling').toLowerCase();
+    const isRolling    = startType === 'rolling';
 
     const mod  = document.getElementById('gridModule');
     const info = document.getElementById('gridInfo');
     const lights = document.getElementById('startLights');
     if (!mod || !info || !lights) return;
 
-    // Detect transition from ParadeLaps (3) to Racing (4): this is when lights should show
-    // If plugin doesn't send LightsPhase, we trigger a simulated sequence
+    // Detect transition from ParadeLaps (3) to Racing (4): this is when lights should show.
+    // If plugin doesn't send LightsPhase, we generate a synthetic green sequence
+    // and hold it for 3 seconds so it's actually visible.
     const transitioningToRace = _gridPrevSessionState === 3 && sessionState === 4;
-    if (transitioningToRace && lightsPhase === 0) {
-      // Plugin hasn't sent lightsPhase, so simulate a quick green light sequence
-      lightsPhase = 7; // Jump straight to green (GO!) for rolling starts
+    if (transitioningToRace && lightsPhase === 0 && _simLightsPhase === 0) {
+      _simLightsPhase = 7;
+      clearTimeout(_simLightsTimer);
+      _simLightsTimer = setTimeout(() => { _simLightsPhase = 0; }, 3000);
     }
+    // Use synthetic phase when plugin isn't sending one
+    if (lightsPhase === 0 && _simLightsPhase > 0) lightsPhase = _simLightsPhase;
 
     // SessionState 3 = ParadeLaps (formation), or lights sequence active
     // Phase 8 = post-green holdover — keep module visible while it fades naturally
@@ -69,9 +79,21 @@
       clearTimeout(_gridFadeTimer);
       mod.classList.remove('grid-fadeout');
       mod.classList.add('grid-visible');
-      document.body.classList.add('grid-active');
+      // Rolling starts: don't dim the dashboard during formation — driver needs instruments.
+      // Only dim for standing starts or when the lights sequence is actively playing.
+      if (!isRolling || isLightsActive) {
+        document.body.classList.add('grid-active');
+      }
       _gridActive = true;
       if (window.setGridFlagGL) window.setGridFlagGL(true);
+    }
+    // If we're in a rolling formation and lights just started, apply dim now
+    if (isRolling && isLightsActive) {
+      document.body.classList.add('grid-active');
+    }
+    // If rolling formation without lights, ensure dashboard stays at 100%
+    if (isRolling && !isLightsActive && isFormation) {
+      document.body.classList.remove('grid-active');
     }
 
     // Toggle between info card and lights

--- a/dashboard-overlay/modules/js/pit-limiter.js
+++ b/dashboard-overlay/modules/js/pit-limiter.js
@@ -6,6 +6,9 @@
   let _wasInPit = false;
   let _bonkersActive = false;
   let _sparkTimer = null;
+  // Bonkers holdover: when entering pit at speed, lock bonkers for 3s
+  // so the animation is visible even after the auto-limiter slows the car
+  let _bonkersHoldUntil = 0;
 
   function updatePitLimiter(p, isDemo) {
     const pre = isDemo ? 'K10Motorsports.Plugin.Demo.DS.' : 'K10Motorsports.Plugin.DS.';
@@ -23,6 +26,15 @@
     // Pit limiter blue glow on tacho module
     const tacho = document.querySelector('.tacho-block');
     if (tacho) tacho.classList.toggle('pit-limiter-engaged', inPitLane && pitLimiterOn);
+
+    // Detect pit entry while speeding — lock bonkers for 3s so it's visible
+    // even after the car's auto-limiter kicks in and drops speed
+    const now = Date.now();
+    const isSpeeding = +(p[pre + 'IsPitSpeeding']) > 0 || (pitLimitKmh > 0 && speedKmh > pitLimitKmh);
+    if (!_wasInPit && inPitLane && isSpeeding) {
+      _bonkersHoldUntil = now + 3000;
+    }
+    const bonkersHeld = now < _bonkersHoldUntil;
 
     if (inPitLane) {
       banner.classList.add('pit-visible');
@@ -44,11 +56,8 @@
       }
 
       // ── State priority: BONKERS > WARNING > NORMAL ──
-      // Prefer server-computed DS.IsPitSpeeding, fallback to client check
-      const isSpeeding = +(p[pre + 'IsPitSpeeding']) > 0 || (pitLimitKmh > 0 && speedKmh > pitLimitKmh);
-
-      if (isSpeeding) {
-        // BONKERS — actually over the speed limit (regardless of limiter state)
+      if (isSpeeding || bonkersHeld) {
+        // BONKERS — over the speed limit, or held from entry
         banner.classList.add('pit-bonkers');
         banner.classList.remove('pit-warning');
         if (labelEl) labelEl.textContent = 'SPEEDING';
@@ -71,11 +80,23 @@
         if (window.setBonkersGL) window.setBonkersGL(false);
       }
     } else {
-      banner.classList.remove('pit-visible', 'pit-warning', 'pit-bonkers');
-      document.body.classList.remove('pit-mode');
-      if (labelEl) labelEl.textContent = 'Pit Limiter';
-      if (_bonkersActive) _stopBonkersSparks(banner);
-      if (window.setBonkersGL) window.setBonkersGL(false);
+      // Not in pit lane — but if approaching pit at speed, show early warning
+      if (pitLimitKmh > 0 && speedKmh > pitLimitKmh && bonkersHeld) {
+        // Holdover from entering pit — keep bonkers visible during transition
+        banner.classList.add('pit-visible', 'pit-bonkers');
+        banner.classList.remove('pit-warning');
+        if (labelEl) labelEl.textContent = 'SPEEDING';
+        if (speedEl) {
+          const mph = Math.round(+(p[pre + 'SpeedMph']) || speedKmh * 0.621371);
+          speedEl.textContent = mph > 0 ? mph + ' mph' : '';
+        }
+      } else {
+        banner.classList.remove('pit-visible', 'pit-warning', 'pit-bonkers');
+        document.body.classList.remove('pit-mode');
+        if (labelEl) labelEl.textContent = 'Pit Limiter';
+        if (_bonkersActive) _stopBonkersSparks(banner);
+        if (window.setBonkersGL) window.setBonkersGL(false);
+      }
     }
     _wasInPit = inPitLane;
   }

--- a/dashboard-overlay/modules/styles/effects.css
+++ b/dashboard-overlay/modules/styles/effects.css
@@ -721,7 +721,7 @@
     margin-bottom: 2px;
   }
   .sp-message {
-    font-size: 14px;
+    font-size: 48px;
     font-weight: var(--fw-semi);
     color: hsla(220, 50%, 80%, 0.90);
     line-height: 1.3;


### PR DESCRIPTION
## Summary
- **Green lights**: simulated green phase now holds 3 seconds instead of 1 poll frame (~50ms) that was invisible. Uses a timer-backed synthetic phase instead of single-frame detection
- **Rolling start dashboard**: panels stay at 100% opacity during formation lap so driver has full instruments. Only dims briefly for the lights sequence. Standing starts still dim as before
- **Pit limiter bonkers holdover**: 3-second lock on SPEEDING state when entering pit lane at speed. The auto-limiter was slowing the car before the next poll, so the animation never showed. Now persists so the driver sees the warning
- **Spotter electronics font**: bumped from 14px to 48px

## Test plan
- [ ] Rolling start: verify dashboard stays at full opacity during formation, dims briefly for green lights, then returns to 100%
- [ ] Standing start: verify dashboard still dims during grid phase and lights sequence
- [ ] Green lights: verify green GO! sequence is visible for ~3 seconds on race start
- [ ] Pit entry at speed: verify bonkers animation shows and holds for 3s when entering pit lane above the speed limit
- [ ] Pit limiter normal: verify blue limiter banner still shows correctly when entering at safe speed
- [ ] Spotter: verify electronics adjustment numbers display at 48px

🤖 Generated with [Claude Code](https://claude.com/claude-code)