### PR TITLE
feat: Dashboard subtabs + Branding as own settings tab

### DIFF
--- a/dashboard-overlay/dashboard.html
+++ b/dashboard-overlay/dashboard.html
@@ -804,7 +804,8 @@
 
     <div class="settings-body">
       <div class="settings-sidebar">
-        <div class="settings-sidebar-item active" data-tab="sections" onclick="switchSettingsTab(this)">Sections</div>
+        <div class="settings-sidebar-item active" data-tab="sections" onclick="switchSettingsTab(this)">Dashboard</div>
+        <div class="settings-sidebar-item" data-tab="branding" onclick="switchSettingsTab(this)">Branding</div>
         <div class="settings-sidebar-item" data-tab="layout" onclick="switchSettingsTab(this)">Layout</div>
         <div class="settings-sidebar-item" data-tab="commentary" onclick="switchSettingsTab(this)">Commentary</div>
         <div class="settings-sidebar-item" data-tab="connections" onclick="switchSettingsTab(this)">Connections</div>
@@ -817,7 +818,8 @@
 
     <!-- Old tab bar (hidden — replaced by sidebar) -->
     <div class="settings-tabs">
-      <div class="settings-tab active" data-tab="sections" onclick="switchSettingsTab(this)">Sections</div>
+      <div class="settings-tab active" data-tab="sections" onclick="switchSettingsTab(this)">Dashboard</div>
+      <div class="settings-tab" data-tab="branding" onclick="switchSettingsTab(this)">Branding</div>
       <div class="settings-tab" data-tab="layout" onclick="switchSettingsTab(this)">Layout</div>
       <div class="settings-tab" data-tab="connections" onclick="switchSettingsTab(this)">Connections</div>
       <div class="settings-tab disabled" data-tab="iracing" id="iracingTab" onclick="switchSettingsTab(this)">iRacing</div>
@@ -825,58 +827,88 @@
       <div class="settings-tab" data-tab="system" onclick="switchSettingsTab(this)">System</div>
     </div>
 
-    <!-- ── Tab: Sections — module toggles grouped by dashboard hierarchy ── -->
+    <!-- ── Tab: Dashboard — module toggles with subtabs per group ── -->
     <div class="settings-tab-content active" id="settingsTabSections">
+      <div class="settings-subtabs" id="sectionSubtabs">
+        <div class="settings-subtab active" data-subtab="hud" onclick="switchSectionSubtab(this)">Main HUD</div>
+        <div class="settings-subtab" data-subtab="leaderboard" onclick="switchSectionSubtab(this)">Leaderboard</div>
+        <div class="settings-subtab" data-subtab="pitbox" onclick="switchSectionSubtab(this)">Pit Box</div>
+        <div class="settings-subtab" data-subtab="datastream" onclick="switchSectionSubtab(this)">Datastream</div>
+        <div class="settings-subtab" data-subtab="overlays" onclick="switchSectionSubtab(this)">Overlays</div>
+      </div>
+
+      <!-- Subtab: Main HUD -->
+      <div class="settings-subtab-page active" data-subtab-page="hud">
+        <div class="settings-two-col">
+        <div class="settings-row"><span class="settings-label">Tachometer</span><div class="settings-toggle on" data-section="tacho-block" data-key="showTacho" onclick="toggleSetting(this)"></div></div>
+        <div class="settings-row"><span class="settings-label">Position &amp; Gaps</span><div class="settings-toggle on" data-section="pos-gaps-col" data-key="showPosition" onclick="toggleSetting(this)"></div></div>
+        <div class="settings-row"><span class="settings-label">Track Maps</span><div class="settings-toggle on" data-section="maps-col" data-key="showMaps" onclick="toggleSetting(this)"></div></div>
+        <div class="settings-row"><span class="settings-label">Fuel</span><div class="settings-toggle on" data-section="fuel-block" data-key="showFuel" onclick="toggleSetting(this)"></div></div>
+        <div class="settings-row"><span class="settings-label">Tyres</span><div class="settings-toggle on" data-section="tyres-block" data-key="showTyres" onclick="toggleSetting(this)"></div></div>
+        <div class="settings-row"><span class="settings-label">Controls (BB/TC/ABS)</span><div class="settings-toggle on" data-section="car-controls" data-key="showControls" onclick="toggleSetting(this)"></div></div>
+        <div class="settings-row"><span class="settings-label">Pedals</span><div class="settings-toggle on" data-section="pedals-area" data-key="showPedals" onclick="toggleSetting(this)"></div></div>
+        <div class="settings-row"><span class="settings-label">Commentary</span><div class="settings-toggle on" data-section="commentary-col" data-key="showCommentary" onclick="toggleSetting(this)"></div></div>
+        </div>
+      </div>
+
+      <!-- Subtab: Leaderboard -->
+      <div class="settings-subtab-page" data-subtab-page="leaderboard">
+        <div class="settings-two-col">
+        <div class="settings-row"><span class="settings-label">Show</span><div class="settings-toggle on" data-section="leaderboardPanel" data-key="showLeaderboard" onclick="toggleSetting(this)"></div></div>
+        <div class="settings-row settings-sub"><span class="settings-label">Focus</span>
+          <select class="settings-select" id="settingsLbFocus" onchange="updateLbFocus(this.value)">
+            <option value="me">Focus on Me</option>
+            <option value="lead">Focus on Lead</option>
+          </select>
+        </div>
+        <div class="settings-row settings-sub"><span class="settings-label">Opponents</span>
+          <select class="settings-select" id="settingsLbMaxRows" onchange="updateLbMaxRows(this.value)">
+            <option value="3">3</option>
+            <option value="5" selected>5</option>
+            <option value="7">7</option>
+            <option value="10">10</option>
+            <option value="15">15</option>
+            <option value="20">20</option>
+          </select>
+        </div>
+        <div class="settings-row settings-sub"><span class="settings-label">Expand to Fill</span><div class="settings-toggle" id="lbExpandToggle" onclick="toggleLbExpand(this)"></div></div>
+        </div>
+      </div>
+
+      <!-- Subtab: Pit Box -->
+      <div class="settings-subtab-page" data-subtab-page="pitbox">
+        <div class="settings-two-col">
+        <div class="settings-row"><span class="settings-label">Show</span><div class="settings-toggle on" data-section="pitBoxPanel" data-key="showPitBox" onclick="toggleSetting(this)"></div></div>
+        </div>
+      </div>
+
+      <!-- Subtab: Datastream -->
+      <div class="settings-subtab-page" data-subtab-page="datastream">
+        <div class="settings-two-col">
+        <div class="settings-row"><span class="settings-label">Show</span><div class="settings-toggle on" data-section="datastreamPanel" data-key="showDatastream" onclick="toggleSetting(this)"></div></div>
+        <div class="settings-row settings-sub"><span class="settings-label">G-Force</span><div class="settings-toggle on" data-key="dsShowGforce" onclick="toggleDsSetting(this)"></div></div>
+        <div class="settings-row settings-sub"><span class="settings-label">Yaw Rate</span><div class="settings-toggle on" data-key="dsShowYaw" onclick="toggleDsSetting(this)"></div></div>
+        <div class="settings-row settings-sub"><span class="settings-label">FFB / Steer</span><div class="settings-toggle on" data-key="dsShowFfb" onclick="toggleDsSetting(this)"></div></div>
+        <div class="settings-row settings-sub"><span class="settings-label">Lap Delta</span><div class="settings-toggle on" data-key="dsShowDelta" onclick="toggleDsSetting(this)"></div></div>
+        <div class="settings-row settings-sub"><span class="settings-label">Track Temp</span><div class="settings-toggle on" data-key="dsShowTrackTemp" onclick="toggleDsSetting(this)"></div></div>
+        <div class="settings-row settings-sub"><span class="settings-label">FPS</span><div class="settings-toggle on" data-key="dsShowFps" onclick="toggleDsSetting(this)"></div></div>
+        </div>
+      </div>
+
+      <!-- Subtab: Overlays -->
+      <div class="settings-subtab-page" data-subtab-page="overlays">
+        <div class="settings-two-col">
+        <div class="settings-row"><span class="settings-label">Incidents</span><div class="settings-toggle on" data-section="incidentsPanel" data-key="showIncidents" onclick="toggleSetting(this)"></div></div>
+        <div class="settings-row"><span class="settings-label">Spotter</span><div class="settings-toggle on" data-section="spotterPanel" data-key="showSpotter" onclick="toggleSetting(this)"></div></div>
+        <div class="settings-row"><span class="settings-label">Pit Limiter Animation</span><div class="settings-toggle on" data-key="showBonkers" id="bonkersToggle" onclick="toggleBonkers(this)"></div></div>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- ── Tab: Branding — logos, effects, ambient light ── -->
+    <div class="settings-tab-content" id="settingsTabBranding">
       <div class="settings-two-col">
-
-      <div class="settings-group-label">Main HUD</div>
-      <div class="settings-row"><span class="settings-label">Tachometer</span><div class="settings-toggle on" data-section="tacho-block" data-key="showTacho" onclick="toggleSetting(this)"></div></div>
-      <div class="settings-row"><span class="settings-label">Position &amp; Gaps</span><div class="settings-toggle on" data-section="pos-gaps-col" data-key="showPosition" onclick="toggleSetting(this)"></div></div>
-      <div class="settings-row"><span class="settings-label">Track Maps</span><div class="settings-toggle on" data-section="maps-col" data-key="showMaps" onclick="toggleSetting(this)"></div></div>
-      <div class="settings-row"><span class="settings-label">Fuel</span><div class="settings-toggle on" data-section="fuel-block" data-key="showFuel" onclick="toggleSetting(this)"></div></div>
-      <div class="settings-row"><span class="settings-label">Tyres</span><div class="settings-toggle on" data-section="tyres-block" data-key="showTyres" onclick="toggleSetting(this)"></div></div>
-      <div class="settings-row"><span class="settings-label">Controls (BB/TC/ABS)</span><div class="settings-toggle on" data-section="car-controls" data-key="showControls" onclick="toggleSetting(this)"></div></div>
-      <div class="settings-row"><span class="settings-label">Pedals</span><div class="settings-toggle on" data-section="pedals-area" data-key="showPedals" onclick="toggleSetting(this)"></div></div>
-      <div class="settings-row"><span class="settings-label">Commentary</span><div class="settings-toggle on" data-section="commentary-col" data-key="showCommentary" onclick="toggleSetting(this)"></div></div>
-
-      <div class="settings-group-label">Leaderboard</div>
-      <div class="settings-row"><span class="settings-label">Show</span><div class="settings-toggle on" data-section="leaderboardPanel" data-key="showLeaderboard" onclick="toggleSetting(this)"></div></div>
-      <div class="settings-row settings-sub"><span class="settings-label">Focus</span>
-        <select class="settings-select" id="settingsLbFocus" onchange="updateLbFocus(this.value)">
-          <option value="me">Focus on Me</option>
-          <option value="lead">Focus on Lead</option>
-        </select>
-      </div>
-      <div class="settings-row settings-sub"><span class="settings-label">Opponents</span>
-        <select class="settings-select" id="settingsLbMaxRows" onchange="updateLbMaxRows(this.value)">
-          <option value="3">3</option>
-          <option value="5" selected>5</option>
-          <option value="7">7</option>
-          <option value="10">10</option>
-          <option value="15">15</option>
-          <option value="20">20</option>
-        </select>
-      </div>
-      <div class="settings-row settings-sub"><span class="settings-label">Expand to Fill</span><div class="settings-toggle" id="lbExpandToggle" onclick="toggleLbExpand(this)"></div></div>
-
-      <div class="settings-group-label">Pit Box</div>
-      <div class="settings-row"><span class="settings-label">Show</span><div class="settings-toggle on" data-section="pitBoxPanel" data-key="showPitBox" onclick="toggleSetting(this)"></div></div>
-
-      <div class="settings-group-label">Datastream</div>
-      <div class="settings-row"><span class="settings-label">Show</span><div class="settings-toggle on" data-section="datastreamPanel" data-key="showDatastream" onclick="toggleSetting(this)"></div></div>
-      <div class="settings-row settings-sub"><span class="settings-label">G-Force</span><div class="settings-toggle on" data-key="dsShowGforce" onclick="toggleDsSetting(this)"></div></div>
-      <div class="settings-row settings-sub"><span class="settings-label">Yaw Rate</span><div class="settings-toggle on" data-key="dsShowYaw" onclick="toggleDsSetting(this)"></div></div>
-      <div class="settings-row settings-sub"><span class="settings-label">FFB / Steer</span><div class="settings-toggle on" data-key="dsShowFfb" onclick="toggleDsSetting(this)"></div></div>
-      <div class="settings-row settings-sub"><span class="settings-label">Lap Delta</span><div class="settings-toggle on" data-key="dsShowDelta" onclick="toggleDsSetting(this)"></div></div>
-      <div class="settings-row settings-sub"><span class="settings-label">Track Temp</span><div class="settings-toggle on" data-key="dsShowTrackTemp" onclick="toggleDsSetting(this)"></div></div>
-      <div class="settings-row settings-sub"><span class="settings-label">FPS</span><div class="settings-toggle on" data-key="dsShowFps" onclick="toggleDsSetting(this)"></div></div>
-
-      <div class="settings-group-label">Overlays</div>
-      <div class="settings-row"><span class="settings-label">Incidents</span><div class="settings-toggle on" data-section="incidentsPanel" data-key="showIncidents" onclick="toggleSetting(this)"></div></div>
-      <div class="settings-row"><span class="settings-label">Spotter</span><div class="settings-toggle on" data-section="spotterPanel" data-key="showSpotter" onclick="toggleSetting(this)"></div></div>
-      <div class="settings-row"><span class="settings-label">Pit Limiter Animation</span><div class="settings-toggle on" data-key="showBonkers" id="bonkersToggle" onclick="toggleBonkers(this)"></div></div>
-
-      <div class="settings-group-label">Branding</div>
       <div class="settings-row"><span class="settings-label">K10 Logo</span><div class="settings-toggle on" data-section="k10LogoSquare" data-key="showK10Logo" onclick="toggleSetting(this)"></div></div>
       <div class="settings-row"><span class="settings-label">Car Manufacturer</span><div class="settings-toggle on" data-section="carLogoSquare" data-key="showCarLogo" onclick="toggleSetting(this)"></div></div>
       <div class="settings-row"><span class="settings-label">Game Logo</span><div class="settings-toggle on" data-key="showGameLogo" onclick="toggleGameLogo(this)"></div></div>
@@ -897,8 +929,7 @@
         <div id="ambientPreviewSwatch" style="width:100%;height:40px;border-radius:4px;background:#111;border:1px solid hsla(0,0%,100%,0.1);"></div>
         <div class="ambient-preview-info" id="ambientPreviewInfo">No capture active</div>
       </div>
-
-      </div><!-- /settings-two-col -->
+      </div>
     </div>
 
     <!-- ── Tab: Layout — positioning and spacing for all module groups ── -->

--- a/dashboard-overlay/modules/js/settings.js
+++ b/dashboard-overlay/modules/js/settings.js
@@ -134,6 +134,15 @@
     if (tabName === 'connections') updateConnectionsTab();
   }
 
+  // Subtab switching within a settings tab (e.g. Dashboard → Main HUD / Leaderboard / etc.)
+  function switchSectionSubtab(el) {
+    const subtab = el.dataset.subtab;
+    const container = el.closest('.settings-tab-content');
+    if (!container) return;
+    container.querySelectorAll('.settings-subtab').forEach(t => t.classList.toggle('active', t.dataset.subtab === subtab));
+    container.querySelectorAll('.settings-subtab-page').forEach(p => p.classList.toggle('active', p.dataset.subtabPage === subtab));
+  }
+
   // ── Leaderboard settings ──
 
   function updateLbFocus(value) {

--- a/dashboard-overlay/modules/styles/settings.css
+++ b/dashboard-overlay/modules/styles/settings.css
@@ -495,6 +495,41 @@
     letter-spacing: 0.1em;
     margin: 14px 0 6px;
   }
+
+  /* ── Subtab bar within a settings tab ── */
+  .settings-subtabs {
+    display: flex;
+    gap: 2px;
+    padding: 0 0 12px;
+    border-bottom: 1px solid hsla(0,0%,100%,0.06);
+    margin-bottom: 12px;
+    flex-wrap: wrap;
+  }
+  .settings-subtab {
+    font-size: 12px;
+    font-weight: 600;
+    color: hsla(0,0%,100%,0.35);
+    padding: 5px 10px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .settings-subtab:hover {
+    color: hsla(0,0%,100%,0.6);
+    background: hsla(0,0%,100%,0.04);
+  }
+  .settings-subtab.active {
+    color: hsla(0,0%,100%,0.9);
+    background: hsla(0,0%,100%,0.08);
+  }
+  .settings-subtab-page {
+    display: none;
+  }
+  .settings-subtab-page.active {
+    display: block;
+  }
   .settings-row {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- Renames **Sections** sidebar item to **Dashboard** and splits its groups into subtabs: Main HUD, Leaderboard, Pit Box, Datastream, Overlays
- Extracts **Branding** (logos, WebGL effects, ambient light, capture region) into its own main sidebar tab
- Adds `switchSectionSubtab()` JS function and `.settings-subtab` / `.settings-subtab-page` CSS classes

## Test plan
- [ ] Open Settings → Dashboard tab shows subtab bar with 5 subtabs
- [ ] Click each subtab — only its toggles are visible
- [ ] Branding tab in sidebar shows logos, WebGL, ambient light, capture area
- [ ] All toggles still function correctly (sections hide/show, datastream sub-toggles, etc.)
- [ ] Legacy tab bar (if visible) also shows updated names

🤖 Generated with [Claude Code](https://claude.com/claude-code)