### PR TITLE
feat: logo-only startup mode with session-triggered reveal

### DIFF
--- a/dashboard-overlay/modules/js/config.js
+++ b/dashboard-overlay/modules/js/config.js
@@ -549,6 +549,7 @@ function getCarAdjustability(model) {
 // ═══════════════════════════════════════════════════════════════
 
 const _defaultSettings = {
+  logoOnlyStart: true, // Start in logo-only mode; HUD reveals when session goes active
   showFuel: true, showTyres: true, showControls: true, showPedals: true,
   showMaps: true, showPosition: true, showTacho: true, showCommentary: true,
   showK10Logo: true, showCarLogo: true, showGameLogo: true, simhubUrl: 'http://localhost:8889/k10mediabroadcaster/',

--- a/dashboard-overlay/modules/js/poll-engine.js
+++ b/dashboard-overlay/modules/js/poll-engine.js
@@ -118,6 +118,8 @@
       } else {
         document.body.classList.remove('idle-state');
         if (idleLogo) idleLogo.classList.remove('idle-visible');
+        // Session going active — reveal HUD from logo-only startup
+        if (typeof revealFromLogoOnly === 'function') revealFromLogoOnly();
       }
     }
     // Skip rest of update in idle (except settings remain responsive)

--- a/dashboard-overlay/modules/js/settings.js
+++ b/dashboard-overlay/modules/js/settings.js
@@ -98,6 +98,23 @@
 
     // Datastream field toggles
     applyDsFieldToggles();
+
+    // Logo-only startup: apply body class so CSS hides everything except logos
+    if (_settings.logoOnlyStart !== false) {
+      document.body.classList.add('logo-only');
+    }
+  }
+
+  // Called by poll-engine when session goes active (game running + session state > 0).
+  // Removes logo-only mode with a reveal transition.
+  let _logoOnlyRevealed = false;
+  function revealFromLogoOnly() {
+    if (_logoOnlyRevealed) return;
+    _logoOnlyRevealed = true;
+    document.body.classList.add('logo-only-reveal');
+    document.body.classList.remove('logo-only');
+    // Clean up the reveal class after transition completes
+    setTimeout(() => document.body.classList.remove('logo-only-reveal'), 1200);
   }
 
   function _collapseParentColumns() {

--- a/dashboard-overlay/modules/styles/effects.css
+++ b/dashboard-overlay/modules/styles/effects.css
@@ -315,6 +315,51 @@
   }
 
   /* ═══════════════════════════════════════════════
+     LOGO-ONLY STARTUP — clean broadcast intro
+     Only logos visible until session goes active
+     ═══════════════════════════════════════════════ */
+  body.logo-only #dashboard .panel:not(.k10-logo-square):not(.car-logo-square),
+  body.logo-only .leaderboard-panel,
+  body.logo-only .datastream-panel,
+  body.logo-only .pitbox-panel,
+  body.logo-only .incidents-panel,
+  body.logo-only .spotter-panel,
+  body.logo-only .pit-banner,
+  body.logo-only .rc-banner,
+  body.logo-only .grid-module,
+  body.logo-only .commentary-col,
+  body.logo-only .fuel-tyres-col,
+  body.logo-only .controls-pedals-block,
+  body.logo-only .tacho-block,
+  body.logo-only .pos-gaps-col,
+  body.logo-only .maps-col,
+  body.logo-only .pedals-area {
+    opacity: 0 !important;
+    pointer-events: none !important;
+  }
+  /* Reveal transition: panels fade in when session starts */
+  body.logo-only-reveal #dashboard .panel,
+  body.logo-only-reveal .leaderboard-panel,
+  body.logo-only-reveal .datastream-panel,
+  body.logo-only-reveal .pitbox-panel,
+  body.logo-only-reveal .incidents-panel,
+  body.logo-only-reveal .spotter-panel,
+  body.logo-only-reveal .commentary-col,
+  body.logo-only-reveal .fuel-tyres-col,
+  body.logo-only-reveal .controls-pedals-block,
+  body.logo-only-reveal .tacho-block,
+  body.logo-only-reveal .pos-gaps-col,
+  body.logo-only-reveal .maps-col,
+  body.logo-only-reveal .pedals-area {
+    transition: opacity 1s ease-out;
+  }
+  /* Settings always accessible */
+  body.logo-only .settings-overlay {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  /* ═══════════════════════════════════════════════
      PIT LIMITER — WARNING FLASH (limiter OFF in pit)
      ═══════════════════════════════════════════════ */
   .pit-banner.pit-warning .pit-inner {


### PR DESCRIPTION
## Summary
- Dashboard boots in logo-only mode: only K10 and manufacturer logos visible, everything else hidden
- When poll-engine detects session going active (game running + session state > 0), all panels fade in over 1 second
- Enabled by default via `logoOnlyStart` setting; settings panel always accessible
- Clean broadcast intro — no half-loaded HUD before data flows

## Test plan
- [ ] On startup, only K10 logo and car manufacturer logo are visible
- [ ] Settings panel opens and functions normally during logo-only state
- [ ] When joining a session, all HUD panels fade in smoothly
- [ ] After reveal, all section toggles behave normally
- [ ] Demo mode: HUD should reveal immediately (demo is never idle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)