### PR TITLE
Fix track country flags not showing in live sessions

### DIFF
--- a/simhub-plugin/plugin/K10Motorsports.Plugin/Engine/TelemetrySnapshot.Capture.cs
+++ b/simhub-plugin/plugin/K10Motorsports.Plugin/Engine/TelemetrySnapshot.Capture.cs
@@ -629,18 +629,21 @@ namespace K10Motorsports.Plugin.Engine
             // ── Grid / Formation state ────────────────────────────────────
             s.SessionState = GetRaw<int>(pm, "SessionState");
             s.PaceMode     = GetRaw<int>(pm, "PaceMode");
-            // Track country — try iRacing WeekendInfo.TrackCountry, fall back to SimHub property
-            try
+            // Track country — only use SimHub fallback if SDK bridge didn't already provide it
+            if (string.IsNullOrEmpty(s.TrackCountry))
             {
-                string country = GetPluginProp<string>(pm, "DataCorePlugin.GameData.TrackCountry") ?? "";
-                if (string.IsNullOrEmpty(country))
-                    country = GetRaw<string>(pm, "WeekendInfo.TrackCountry") ?? "";
-                s.TrackCountry = NormalizeCountryCode(country);
-            }
-            catch (Exception ex)
-            {
-                SimHub.Logging.Current.Warn($"[K10Motorsports] Track country lookup failed: {ex.Message}");
-                s.TrackCountry = "";
+                try
+                {
+                    string country = GetPluginProp<string>(pm, "DataCorePlugin.GameData.TrackCountry") ?? "";
+                    if (string.IsNullOrEmpty(country))
+                        country = GetRaw<string>(pm, "WeekendInfo.TrackCountry") ?? "";
+                    if (!string.IsNullOrEmpty(country))
+                        s.TrackCountry = NormalizeCountryCode(country);
+                }
+                catch (Exception ex)
+                {
+                    SimHub.Logging.Current.Warn($"[K10Motorsports] Track country lookup failed: {ex.Message}");
+                }
             }
 
             // Count gridded cars: cars NOT on pit road from CarIdxOnPitRoad array


### PR DESCRIPTION
## Summary

- **Bug**: Track country flag stripes on the grid module and manufacturer aurora wisps never appeared during live iRacing sessions — only in demo mode
- **Root cause**: The SimHub fallback path for `TrackCountry` in `TelemetrySnapshot.Capture.cs` always ran (line 632), even when the SDK bridge had already provided a valid country code. When `DataCorePlugin.GameData.TrackCountry` returned empty (common for iRacing), it overwrote the good SDK bridge value with an empty string.
- **Fix**: The SimHub fallback now only runs when `s.TrackCountry` is still empty, preserving the SDK bridge value.

## Test plan

- [ ] Start an iRacing session — verify grid module shows track country flag stripes during formation
- [ ] Verify manufacturer aurora wisps fire at green lights with correct country colors
- [ ] Demo mode still works (was not affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)