### PR TITLE
Fix current lap time ellipsis and centering

### DIFF
--- a/dashboard-overlay/modules/styles/dashboard.css
+++ b/dashboard-overlay/modules/styles/dashboard.css
@@ -826,9 +826,6 @@
     letter-spacing: -0.02em;
     display: block;
     text-align: center;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
   .pos-meta-row.delta-row {
     text-align: center;


### PR DESCRIPTION
## Summary
- `.current-row .val` had `overflow: hidden` + `text-overflow: ellipsis` + `white-space: nowrap` which was clipping the lap timer text and preventing visible centering
- Removed overflow/ellipsis/nowrap — a lap time should never be truncated
- `text-align: center` was already set but was fighting the clipping

## Test plan
- [ ] Verify lap timer displays fully centered, no ellipsis, even with long times (e.g. 1:45:23.456)

🤖 Generated with [Claude Code](https://claude.com/claude-code)