### PR TITLE
fix: map label improvements — initial + last name, track name on full map

### DIFF
--- a/dashboard-overlay/dashboard.html
+++ b/dashboard-overlay/dashboard.html
@@ -194,7 +194,6 @@
     <!-- COL: Maps stacked — rendered dynamically from TrackMapProvider -->
     <div class="maps-col">
       <div class="panel map-panel">
-        <div class="map-track-name" id="mapTrackName"></div>
         <svg class="map-svg" id="fullMapSvg" viewBox="0 0 100 100">
           <path class="map-track" id="fullMapTrack" d="" />
           <path class="map-sector" id="mapSector1" d="" />
@@ -210,7 +209,7 @@
           <g id="fullMapOpponents"></g>
           <circle class="map-player" id="fullMapPlayer" cx="50" cy="50" r="4" />
         </svg>
-        <div class="map-zoom-label">Full</div>
+        <div class="map-zoom-label" id="fullMapLabel">Full</div>
       </div>
       <div class="panel map-zoom-panel">
         <svg class="map-zoom-svg" id="zoomMapSvg" viewBox="0 0 100 100" overflow="visible">

--- a/dashboard-overlay/modules/js/poll-engine.js
+++ b/dashboard-overlay/modules/js/poll-engine.js
@@ -986,10 +986,10 @@
     if (dfn || dln) {
       _driverDisplayName = (dfn && dln) ? dfn.charAt(0) + '. ' + dln : (dfn || dln);
     }
-    // Zoom map label: first 3 letters of driver's last name (uppercase), fallback "Local"
+    // Zoom map label: first initial + last name, fallback "Local"
     const _zoomLbl = document.getElementById('zoomMapLabel');
     if (_zoomLbl) {
-      _zoomLbl.textContent = dln.length >= 3 ? dln.substring(0, 3).toUpperCase() : (dln || 'Local');
+      _zoomLbl.textContent = (dfn && dln) ? dfn.charAt(0) + '. ' + dln : (dln || 'Local');
     }
 
     // ─── Track map ───
@@ -1001,14 +1001,13 @@
     const mapHeading = +v('K10Motorsports.Plugin.TrackMap.PlayerHeading') || 0;
     // Use plugin path if available; show no track when map isn't ready
     updateTrackMap(mapPath, mapPX, mapPY, mapOpp, speed, mapHeading);
-    const mapNameEl = document.getElementById('mapTrackName');
-    if (mapNameEl) {
-      // Prefer the plugin's TrackMap.TrackName (always matches the saved map file),
-      // fall back to GameData.TrackName from SimHub.
+    // Full map label: show track name instead of "Full"
+    const fullMapLbl = document.getElementById('fullMapLabel');
+    if (fullMapLbl) {
       const trackName = vs('K10Motorsports.Plugin.TrackMap.TrackName')
                      || vs('DataCorePlugin.GameData.TrackName')
                      || '';
-      if (trackName && trackName !== mapNameEl.textContent) mapNameEl.textContent = trackName;
+      if (trackName && trackName !== fullMapLbl.textContent) fullMapLbl.textContent = trackName;
     }
 
     // ─── Datastream ───

--- a/dashboard-overlay/modules/styles/dashboard.css
+++ b/dashboard-overlay/modules/styles/dashboard.css
@@ -1233,21 +1233,6 @@
     justify-content: center;
     position: relative;
   }
-  .map-track-name {
-    font-size: 11px;
-    font-weight: 700;
-    color: hsla(0,0%,100%,0.65);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    text-align: center;
-    padding: 5px 8px 2px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    position: absolute;
-    top: 0; left: 0; right: 0;
-    z-index: 2;
-  }
   .map-svg { width: 92%; height: 92%; }
   .map-track {
     fill: none;


### PR DESCRIPTION
## Summary
- Local/zoom map label now shows first initial + last name (e.g. "K. Raikkonen") instead of first 3 letters ("RAI")
- Full map label dynamically shows the track name instead of static "Full"
- Removed redundant `map-track-name` element and its CSS from the top of the map panel

## Test plan
- [ ] Verify zoom map label shows "K. Raikkonen" format during session
- [ ] Verify full map label updates to current track name
- [ ] Verify no layout regression in map panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)