### PR TITLE
fix: align game logo horizontally with main modules

### DIFF
--- a/dashboard-overlay/modules/js/game-logo.js
+++ b/dashboard-overlay/modules/js/game-logo.js
@@ -18,14 +18,14 @@
     'lmu':     'le-mans-ultimate.svg'
   };
 
-  // Opposite-corner mapping: dashboard position → logo position
-  // Logo goes on the opposite vertical edge from the dashboard,
-  // same horizontal side — visually balanced without crowding.
+  // Logo-corner mapping: dashboard position → logo position
+  // Logo goes on the same vertical edge as the dashboard but on the
+  // opposite horizontal side — keeps it aligned with main modules.
   var OPPOSITE_CORNER = {
-    'top-right':       'bottom-right',
-    'top-left':        'bottom-left',
-    'bottom-right':    'top-right',
-    'bottom-left':     'top-left',
+    'top-right':       'top-left',
+    'top-left':        'top-right',
+    'bottom-right':    'bottom-left',
+    'bottom-left':     'bottom-right',
     'absolute-center': 'bottom-left'
   };
 


### PR DESCRIPTION
## Summary
- Game logo now stays on the same vertical edge as the main dashboard modules (e.g. top-left when dashboard is top-right) instead of always going to the opposite vertical edge

## Test plan
- [ ] Set dashboard to top-right, verify logo appears top-left
- [ ] Set dashboard to bottom-left, verify logo appears bottom-right
- [ ] Verify logo still fades in/out correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)