### PR TITLE
fix: prevent gap/lap times from clipping in position module

### DIFF
--- a/dashboard-overlay/modules/styles/dashboard.css
+++ b/dashboard-overlay/modules/styles/dashboard.css
@@ -706,7 +706,8 @@
     flex-direction: column;
     gap: var(--gap);
     flex-shrink: 0;
-    width: 150px;
+    min-width: 150px;
+    width: max-content;
   }
   .rating-pos-block {
     width: 100%;
@@ -1004,6 +1005,7 @@
     font-variant-numeric: tabular-nums;
     line-height: 1.1;
     letter-spacing: -0.02em;
+    white-space: nowrap;
   }
   .gap-time.ahead { color: var(--green); }
   .gap-time.behind { color: var(--red); }


### PR DESCRIPTION
## Summary
- Changed pos-gaps-col from fixed 150px to min-width:150px with width:max-content
- Added white-space:nowrap on gap-time to prevent line-breaking

## Test plan
- [ ] On laps > 9, verify gap times like +1:02.345 are fully visible
- [ ] Verify position module still looks correct at normal widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)