### PR TITLE
fix: reset race timeline when session changes

### DIFF
--- a/dashboard-overlay/modules/js/config.js
+++ b/dashboard-overlay/modules/js/config.js
@@ -349,6 +349,9 @@ let _prevBB = -1, _prevTC = -1, _prevABS = -1;
 let _clutchSeenActive = false;
 let _clutchHidden = false;
 
+// Session change detection (resets event history, timeline, etc.)
+let _prevSessionTypeName = '';
+
 // Manufacturer country flag trigger state
 let _mfrFlagShownThisSession = false;  // prevent re-trigger within same session
 let _mfrFlagPrevSessState = 0;         // previous grid SessionState

--- a/dashboard-overlay/modules/js/poll-engine.js
+++ b/dashboard-overlay/modules/js/poll-engine.js
@@ -87,6 +87,16 @@
     const sessNum = parseInt(vs(sessionPre + 'SessionState')) || 0;
     const _inPitLane = +(p[dsPre + 'IsInPitLane']) > 0;
 
+    // ─── Session change detection — reset per-session state ───
+    const _currSessionTypeName = _demo
+      ? vs('K10Motorsports.Plugin.Demo.SessionTypeName')
+      : vs('K10Motorsports.Plugin.SessionTypeName');
+    if (_currSessionTypeName && _currSessionTypeName !== _prevSessionTypeName && _prevSessionTypeName) {
+      console.log('[K10] Session changed:', _prevSessionTypeName, '→', _currSessionTypeName);
+      if (typeof resetTimeline === 'function') resetTimeline();
+    }
+    if (_currSessionTypeName) _prevSessionTypeName = _currSessionTypeName;
+
     // Detect game and apply feature gating
     const rawGameId = v('K10Motorsports.Plugin.GameId') || '';
     const newGameId = detectGameId(rawGameId);


### PR DESCRIPTION
## Summary
- Detects session type name changes (practice → quali → race) and calls resetTimeline()
- Event history strip now clears at the start of each new session

## Test plan
- [ ] Run practice then switch to qualifying, verify timeline strip is cleared
- [ ] Switch to race, verify timeline starts fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)