### PR TITLE
feat: color map player dot with manufacturer brand color

### DIFF
--- a/dashboard-overlay/modules/js/car-logos.js
+++ b/dashboard-overlay/modules/js/car-logos.js
@@ -64,6 +64,15 @@
     // Apply brand-colored background for white/mono logos, default dark bg otherwise
     const sq = document.getElementById('carLogoSquare');
     sq.style.background = _mfrBrandColors[key] || _defaultLogoBg;
+    // Expose full-opacity brand color for map player dot
+    const brandHsl = _mfrBrandColors[key];
+    if (brandHsl) {
+      // Convert 0.6x alpha HSLA to full-opacity for the map dot fill
+      const solidColor = brandHsl.replace(/[\d.]+\)$/, '1)');
+      document.documentElement.style.setProperty('--map-player-color', solidColor);
+    } else {
+      document.documentElement.style.setProperty('--map-player-color', 'var(--cyan)');
+    }
   }
 
   // ═══ TACHOMETER ═══

--- a/dashboard-overlay/modules/styles/dashboard.css
+++ b/dashboard-overlay/modules/styles/dashboard.css
@@ -1291,7 +1291,8 @@
     transition: stroke 0.3s;
   }
   .map-player {
-    fill: var(--cyan);
+    fill: var(--map-player-color, var(--cyan));
+    transition: fill 0.4s ease;
   }
   .map-opponent { fill: hsla(0,0%,100%,0.35); }
   .map-opponent.close { fill: var(--orange); }


### PR DESCRIPTION
## Summary
- Player dot on track maps now fills with the manufacturer's brand color (BMW blue, Ferrari red, etc.)
- Uses CSS custom property --map-player-color with 0.4s transition
- Falls back to cyan when no brand color available

## Test plan
- [ ] Verify dot color matches car logo background color
- [ ] Verify smooth color transition when switching cars

🤖 Generated with [Claude Code](https://claude.com/claude-code)