### PR TITLE
feat: flat sparkline during rolling/formation starts

### DIFF
--- a/dashboard-overlay/modules/js/leaderboard.js
+++ b/dashboard-overlay/modules/js/leaderboard.js
@@ -154,7 +154,15 @@
       let sparkSvg = '';
       // Filter out any stale 0s that may have entered the history
       const hist = _sparkHistory[name] ? _sparkHistory[name].filter(v => v > 0) : null;
-      if (hist && hist.length >= 2) {
+      // During rolling/formation starts, draw a flat baseline when no lap data exists
+      if ((!hist || hist.length < 2) && window._isRollingStart) {
+        const w = 44, h2 = 14;
+        const midY = (h2 / 2).toFixed(1);
+        const col = isPlayer ? 'hsla(210,75%,55%,0.5)' : 'hsla(0,0%,100%,0.15)';
+        sparkSvg = '<svg class="lb-spark" viewBox="0 0 ' + w + ' ' + h2 + '" preserveAspectRatio="none">'
+          + '<line x1="0" y1="' + midY + '" x2="' + w + '" y2="' + midY + '" stroke="' + col + '" stroke-width="1" stroke-dasharray="3,2"/>'
+          + '</svg>';
+      } else if (hist && hist.length >= 2) {
         const mn = Math.min(...hist), mx = Math.max(...hist);
         const range = mx - mn || 1;
         const w = 44, h2 = 14;

--- a/dashboard-overlay/modules/js/poll-engine.js
+++ b/dashboard-overlay/modules/js/poll-engine.js
@@ -106,6 +106,9 @@
       return;
     }
 
+    // Expose rolling/formation start state for leaderboard sparklines
+    window._isRollingStart = (sessNum === 2 || sessNum === 3); // Warmup or ParadeLaps
+
     // Idle detection: only idle when no session (sessNum === 0) or game not running
     // Pre-race states (sessNum 1=GetInCar, 2=Warmup, 3=ParadeLaps) should stay active
     const nowIdle = !_demo && (!gameRunning || sessNum === 0);


### PR DESCRIPTION
## Summary
- During warmup or parade laps, leaderboard sparklines show a dashed horizontal baseline
- Player line uses brighter blue, opponents get subtle white dashed line
- Once real lap times are recorded, sparklines transition to normal stepped chart

## Test plan
- [ ] During rolling start, verify all sparklines show dashed baseline
- [ ] After first completed lap, verify sparklines switch to lap time data

🤖 Generated with [Claude Code](https://claude.com/claude-code)