### PR TITLE
feat: car research system with photos in commentary

### DIFF
--- a/.skills/car-research/SKILL.md
+++ b/.skills/car-research/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: car-research
+description: >
+  Research, document, and maintain car data for the K10 Media Broadcaster.
+  Use this skill whenever someone asks about car facts, manufacturer history,
+  engine specs, driving characteristics, or commentary material for any racing
+  car — especially iRacing cars. Also use when adding a new car to the system,
+  finding car photos for commentary, or enriching the commentary database with
+  car-specific talking points. Trigger on mentions of specific car names,
+  "car data", "car research", "manufacturer facts", "car photos", "car images",
+  or "add a car".
+---
+
+# Car Research Skill
+
+This skill manages the authoritative car and manufacturer database for the K10
+Media Broadcaster project. The database powers two things:
+
+1. **The commentary engine** — rich facts, driving character descriptions,
+   engine specs, and broadcast-ready talking points that make the AI commentator
+   sound knowledgeable and engaging about every car on the grid.
+2. **Commentary images** — Wikimedia Commons photos of cars displayed alongside
+   car-related commentary topics (car spotlight, manufacturer heritage, etc.).
+
+## Data sources
+
+Car data comes from several places, in priority order:
+
+1. **The existing `commentary_cars.json`** — contains curated info for
+   GT3, GTP, LMP2, TCR, and historic cars. Already referenced by the plugin.
+2. **Web research** — for history, notable drivers, design philosophy, and
+   commentary-grade facts. Wikipedia, manufacturer press kits, official
+   series sites, Wikimedia Commons for images.
+3. **iRacing session data** — CarModel string from the sim identifies which
+   car the player is driving. The plugin fuzzy-matches this against our database.
+
+## Database location
+
+`simhub-plugin/k10-motorsports-data/commentary_cars.json` — the master
+reference file. Contains both `cars` (individual car entries) and
+`manufacturers` (brand-level commentary data).
+
+## Car entry schema
+
+Each car entry follows this structure:
+
+```json
+{
+  "displayName": "BMW M4 GT3 EVO",
+  "manufacturer": "BMW",
+  "class": "GT3",
+  "engineLayout": "front-engine",
+  "engineSpec": "3.0L twin-turbo straight-six",
+  "talkingPoints": [
+    "Evolved from the dominant M6 GT3",
+    "Most forgiving GT3 on the grid"
+  ],
+  "drivingCharacter": [
+    "accessible to master but fast in the right hands",
+    "forgiving mid-corner stability"
+  ],
+  "nickname": "The Bavarian Workhorse",
+  "designer": "BMW M GmbH",
+  "notableDrivers": ["Augusto Farfus", "Sheldon van der Linde"],
+  "images": [
+    "https://upload.wikimedia.org/wikipedia/commons/..."
+  ]
+}
+```
+
+## Manufacturer entry schema
+
+```json
+{
+  "displayName": "BMW M Motorsport",
+  "countryCode": "DE",
+  "founder": "Karl Rapp",
+  "racingPhilosophy": "engineering precision meets touring car heritage",
+  "talkingPoints": [
+    "BMW's motorsport DNA goes back to the 1972 formation of BMW Motorsport GmbH",
+    "The M division was born from racing and that ethos flows into every M car"
+  ]
+}
+```
+
+## Finding car images
+
+Images should come from **Wikimedia Commons** (Creative Commons licensed):
+
+1. Search `https://commons.wikimedia.org/` for the car name
+2. Look for **action/racing shots** over static/showroom photos
+3. Use the **direct file URL** (starts with `https://upload.wikimedia.org/`)
+4. For thumbnails, use the `/thumb/` path with a width suffix like `/1280px-...`
+5. Aim for 1-3 images per car
+6. Add to the car's `"images"` array
+
+The dashboard displays these in the commentary panel when car/manufacturer
+topics fire, with a "Wikimedia Commons · CC" attribution overlay.
+
+## When researching a car
+
+1. **Check the database first** — read `commentary_cars.json`
+2. **If the car exists**, present what we have and note any gaps
+3. **If the car is missing**, research it:
+   - Search for the car's official spec sheet
+   - Check Wikipedia for history, engine, designer
+   - Look for notable real-world racing results
+   - Find 1-3 Wikimedia Commons images
+   - Identify the driving character (what makes it unique to drive)
+4. **Always gather commentary-grade facts** — the kind of thing a broadcast
+   commentator would say: "The flat-six in this Porsche is naturally aspirated
+   in a field of turbos" type nuggets.
+5. **Update the database** with findings
+
+## Commentary integration
+
+When adding facts, think about what makes good broadcast material:
+
+- **Talking points** should be surprising, specific, and conversational — not
+  generic spec sheets. "Turbos sit inside the V-angle" beats "Has turbocharging."
+- **Driving character** descriptions should evoke what the car feels like to
+  drive: "explosive turbo delivery demanding smooth inputs"
+- **Engine specs** as a single punchy string: "4.2L naturally aspirated flat-six"
+- **Nicknames** add broadcast color: "The Purist's Choice", "The Turbo Revolution"
+- **Notable drivers** give context for "a car that carried [driver] to victory"
+
+## Car classes in iRacing
+
+- `"GT3"` — GT World Challenge spec (most popular)
+- `"GTP"` — IMSA/WEC Hypercar class
+- `"LMP2"` — Le Mans Prototype 2
+- `"GT4"` — entry-level GT
+- `"TCR"` — touring car
+- `"F1"` — open-wheel (historic or modern)
+- `"NASCAR"` — stock car
+- `"Prototype"` — older LMP categories

--- a/dashboard-overlay/modules/js/poll-engine.js
+++ b/dashboard-overlay/modules/js/poll-engine.js
@@ -924,7 +924,9 @@
         const hue = colorToHue(vs('K10Motorsports.Plugin.CommentarySentimentColor'));
         const severity = +v('K10Motorsports.Plugin.CommentarySeverity') || 0;
         const trackImg = vs('K10Motorsports.Plugin.CommentaryTrackImage') || '';
-        showCommentary(hue, vs('K10Motorsports.Plugin.CommentaryTopicTitle'), vs('K10Motorsports.Plugin.CommentaryText'), vs('K10Motorsports.Plugin.CommentaryCategory'), cmTopicId, severity, trackImg);
+        const carImg = vs('K10Motorsports.Plugin.CommentaryCarImage') || '';
+        const commentaryImg = trackImg || carImg;  // track image takes priority, car image as fallback
+        showCommentary(hue, vs('K10Motorsports.Plugin.CommentaryTopicTitle'), vs('K10Motorsports.Plugin.CommentaryText'), vs('K10Motorsports.Plugin.CommentaryCategory'), cmTopicId, severity, commentaryImg);
       }
     } else if (!cmVis && _commentaryWasVisible) {
       hideCommentary();

--- a/simhub-plugin/k10-motorsports-data/commentary_cars.json
+++ b/simhub-plugin/k10-motorsports-data/commentary_cars.json
@@ -21,7 +21,11 @@
         "forgiving mid-corner stability",
         "turbo lag manageable with precise throttle control"
       ],
-      "nickname": "The Bavarian Workhorse"
+      "nickname": "The Bavarian Workhorse",
+      "images": [
+        "https://upload.wikimedia.org/wikipedia/commons/e/e1/Nick_Yelloly_BMW_M4_GT3_GT_World_Challenge_Hockenheim_2022.jpg",
+        "https://upload.wikimedia.org/wikipedia/commons/0/0c/2022_BMW_M4_GT3_%2819047%29.jpg"
+      ]
     },
     "ferrari 296 gt3": {
       "displayName": "Ferrari 296 GT3",
@@ -41,7 +45,11 @@
         "explosive turbo delivery demanding smooth inputs",
         "playful rear-end requiring confidence to extract full potential"
       ],
-      "nickname": "The Turbo Revolution"
+      "nickname": "The Turbo Revolution",
+      "images": [
+        "https://upload.wikimedia.org/wikipedia/commons/c/cb/2024_4_Hours_of_Le_Castellet_7.jpg",
+        "https://upload.wikimedia.org/wikipedia/commons/5/5e/Ferrari_296_GT3%2C_DTM_%2855052860867%29.jpg"
+      ]
     },
     "porsche 911 gt3 r": {
       "displayName": "Porsche 911 GT3 R (992)",
@@ -62,7 +70,11 @@
         "requires commitment to brake late and turn-in hard",
         "rewarding for drivers who embrace its naturally aspirated soul"
       ],
-      "nickname": "The Purist's Choice"
+      "nickname": "The Purist's Choice",
+      "images": [
+        "https://upload.wikimedia.org/wikipedia/commons/3/3c/22_le_fant%C3%B4me.jpg",
+        "https://upload.wikimedia.org/wikipedia/commons/e/e1/24h_Le_Mans_2025_-_WGI_%2834%29.jpg"
+      ]
     },
     "mercedes-amg gt3": {
       "displayName": "Mercedes-AMG GT3 2020",
@@ -83,7 +95,10 @@
         "confidence-inspiring front-end grip",
         "rewards smooth, flowing inputs over aggressive inputs"
       ],
-      "nickname": "The German Precision Machine"
+      "nickname": "The German Precision Machine",
+      "images": [
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a5/2017_IMSA_WeatherTech_SportsCar_Championship_Petit_Le_Mans_%2834392983821%29.jpg/1280px-2017_IMSA_WeatherTech_SportsCar_Championship_Petit_Le_Mans_%2834392983821%29.jpg"
+      ]
     },
     "mclaren 720s gt3": {
       "displayName": "McLaren 720S GT3 EVO",
@@ -121,6 +136,9 @@
         "Rob Bell (McLaren Factory Driver since 2012, 720S GT3 debut winner at Donington 2019)",
         "Tom Blomqvist (Bathurst 12H podium, Daytona 24H champion)",
         "Alvaro Parente (McLaren endurance ace, Bathurst 12H champion in the 650S GT3)"
+      ],
+      "images": [
+        "https://upload.wikimedia.org/wikipedia/commons/7/76/2019_McLaren_720S_GT3_FOS19.jpg"
       ]
     },
     "lamborghini huracán gt3": {
@@ -141,7 +159,10 @@
         "mid-engine agility with supercar attitude",
         "demands respect and rewards aggression"
       ],
-      "nickname": "The Raging Bull"
+      "nickname": "The Raging Bull",
+      "images": [
+        "https://upload.wikimedia.org/wikipedia/commons/5/59/2018_Rolex_24_%2827393482358%29.jpg"
+      ]
     },
     "audi r8 lms": {
       "displayName": "Audi R8 LMS EVO II GT3",
@@ -162,7 +183,10 @@
         "trusting V10 power delivery",
         "methodical pace that accumulates over race distance"
       ],
-      "nickname": "The German Engineer's Answer"
+      "nickname": "The German Engineer's Answer",
+      "images": [
+        "https://upload.wikimedia.org/wikipedia/commons/7/7f/Audi_R8_LMS_Evo_of_Garry_Higgon_%26_Paul_Stokell_%28Adelaide_2022%29.jpg"
+      ]
     },
     "aston martin vantage gt3": {
       "displayName": "Aston Martin Vantage GT3 EVO",
@@ -183,7 +207,10 @@
         "front-engine balance with AMG reliability",
         "still being discovered by the community"
       ],
-      "nickname": "The British Newcomer"
+      "nickname": "The British Newcomer",
+      "images": [
+        "https://upload.wikimedia.org/wikipedia/commons/1/15/2018_Aston_Martin_Vantage_GT3_FOS19.jpg"
+      ]
     },
     "chevrolet corvette z06 gt3": {
       "displayName": "Chevrolet Corvette Z06 GT3.R",
@@ -450,7 +477,11 @@
         "brute-force approach to hybrid competition",
         "legacy of proven reliability"
       ],
-      "nickname": "The American Muscle Hypercar"
+      "nickname": "The American Muscle Hypercar",
+      "images": [
+        "https://upload.wikimedia.org/wikipedia/commons/e/e5/2023_24_Hours_of_Le_Mans_%2852974790571%29.jpg",
+        "https://upload.wikimedia.org/wikipedia/commons/4/4f/2024_24_Hours_of_Le_Mans_%2854094637094%29.jpg"
+      ]
     },
     "acura arx-06 gtp": {
       "displayName": "Acura ARX-06 GTP",
@@ -663,6 +694,9 @@
         "Jan Lammers (1988 Le Mans winner, Racing Team Nederland founder, campaigned P217 at age 56)",
         "Giedo van der Garde (ex-F1 Caterham, 2016 ELMS champion, RTN P217 driver)",
         "Frits van Eerd (RTN co-founder and driver, consistent LMP2 podium threat)"
+      ],
+      "images": [
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3c/2019_4_Hours_of_Silverstone_%2848664669456%29.jpg/1280px-2019_4_Hours_of_Silverstone_%2848664669456%29.jpg"
       ]
     },
     "mercedes-amg f1 w12": {

--- a/simhub-plugin/plugin/K10Motorsports.Plugin/Engine/CommentaryEngine.cs
+++ b/simhub-plugin/plugin/K10Motorsports.Plugin/Engine/CommentaryEngine.cs
@@ -116,6 +116,7 @@ namespace K10Motorsports.Plugin.Engine
         private volatile string _currentTextColor      = "#FFFFFFFF";
         private volatile string _currentEventExposition = "";
         private volatile string _currentTrackImage      = "";
+        private volatile string _currentCarImage        = "";
         private DateTime _promptDisplayedAt             = DateTime.MinValue;
         private int _currentSeverity                    = 0;
 
@@ -163,6 +164,7 @@ namespace K10Motorsports.Plugin.Engine
         public string CurrentTextColor      => _currentTextColor;
         public string CurrentEventExposition => _currentEventExposition;
         public string CurrentTrackImage     => _currentTrackImage;
+        public string CurrentCarImage       => _currentCarImage;
         public int    CurrentSeverity       => _currentSeverity;
         public bool   IsVisible       => _currentText.Length > 0
                                          && (DateTime.UtcNow - _promptDisplayedAt).TotalSeconds < DisplaySeconds;
@@ -535,6 +537,7 @@ namespace K10Motorsports.Plugin.Engine
             _currentTextColor       = "#FFFFFFFF";
             _currentEventExposition = "";
             _currentTrackImage      = "";
+            _currentCarImage        = "";
             _currentSeverity        = 0;
         }
 
@@ -675,6 +678,15 @@ namespace K10Motorsports.Plugin.Engine
                 trackImage = _currentTrackData.Images[_rng.Next(_currentTrackData.Images.Count)];
             }
 
+            // Pick a random car image if this is a car/manufacturer-related topic
+            string carImage = "";
+            if (_currentCarData?.Images != null && _currentCarData.Images.Count > 0
+                && (topic.Id.Contains("car") || topic.Id.Contains("manufacturer")
+                    || topic.Id.Contains("prerace_car") || topic.Id.Contains("race_car")))
+            {
+                carImage = _currentCarData.Images[_rng.Next(_currentCarData.Images.Count)];
+            }
+
             _currentText            = prompt;
             _currentCategory        = topic.Category;
             _currentTitle           = topic.Title;
@@ -684,6 +696,7 @@ namespace K10Motorsports.Plugin.Engine
             _currentTextColor       = textColor;
             _currentEventExposition = exposition;
             _currentTrackImage      = trackImage;
+            _currentCarImage        = carImage;
             _currentSeverity        = topic.Severity;
             _promptDisplayedAt      = DateTime.UtcNow;
 

--- a/simhub-plugin/plugin/K10Motorsports.Plugin/Models/CommentaryTopic.cs
+++ b/simhub-plugin/plugin/K10Motorsports.Plugin/Models/CommentaryTopic.cs
@@ -117,6 +117,9 @@ namespace K10Motorsports.Plugin.Models
 
         /// <summary>Notable drivers associated with this car (real-world, not sim).</summary>
         public List<string> NotableDrivers { get; set; } = new List<string>();
+
+        /// <summary>Image URLs for this car (Wikimedia Commons, etc.).</summary>
+        public List<string> Images { get; set; } = new List<string>();
     }
 
     /// <summary>

--- a/simhub-plugin/plugin/K10Motorsports.Plugin/Plugin.cs
+++ b/simhub-plugin/plugin/K10Motorsports.Plugin/Plugin.cs
@@ -213,6 +213,9 @@ namespace K10Motorsports.Plugin
             // Track image URL (Creative Commons) — set when track-related commentary fires
             this.AttachDelegate("CommentaryTrackImage", () => _engine.CurrentTrackImage);
 
+            // Car image URL (Creative Commons) — set when car/manufacturer-related commentary fires
+            this.AttachDelegate("CommentaryCarImage", () => _engine.CurrentCarImage);
+
             // Flag state for Homebridge and dashboard — priority order, most urgent first.
             // All iRacing flags are now exposed so lights respond correctly.
             // "meatball" = repair required (iRacing 0x100000)
@@ -1244,6 +1247,7 @@ namespace K10Motorsports.Plugin
                     Jp(sb, "K10Motorsports.Plugin.CommentarySentimentColor", Escape(_engine.CurrentSentimentColor ?? "#FF000000"));
                     Jp(sb, "K10Motorsports.Plugin.CommentarySeverity", _engine.IsVisible ? _engine.CurrentSeverity : 0);
                     Jp(sb, "K10Motorsports.Plugin.CommentaryTrackImage", Escape(_engine.CurrentTrackImage ?? ""));
+                    Jp(sb, "K10Motorsports.Plugin.CommentaryCarImage", Escape(_engine.CurrentCarImage ?? ""));
 
                     // ── Strategy ──
                     Jp(sb, "K10Motorsports.Plugin.Strategy.Visible", _strategy.IsVisible ? 1 : 0);


### PR DESCRIPTION
## Summary
- Added Images field to CarCommentaryData model
- CommentaryEngine picks random car image for car/manufacturer commentary topics
- New CommentaryCarImage property exposed via plugin + HTTP API
- Dashboard uses car image when no track image is available
- Populated Wikimedia Commons photos for 10 cars
- Created .skills/car-research/ skill with schema docs

## Test plan
- [ ] Trigger a car-related commentary topic, verify image appears
- [ ] Verify track images still take priority over car images
- [ ] Verify attribution overlay shows on car images

🤖 Generated with [Claude Code](https://claude.com/claude-code)