### PR TITLE
Fix starting lights never showing in iRacing

### DIFF
--- a/dashboard-overlay/modules/js/formation.js
+++ b/dashboard-overlay/modules/js/formation.js
@@ -36,7 +36,7 @@
     // Detect transition from ParadeLaps (3) to Racing (4): this is when lights should show.
     // If plugin doesn't send LightsPhase, we generate a synthetic green sequence
     // and hold it for 3 seconds so it's actually visible.
-    const transitioningToRace = _gridPrevSessionState === 3 && sessionState === 4;
+    const transitioningToRace = _gridPrevSessionState >= 1 && _gridPrevSessionState <= 3 && sessionState === 4;
     if (transitioningToRace && lightsPhase === 0 && _simLightsPhase === 0) {
       _simLightsPhase = 7;
       clearTimeout(_simLightsTimer);

--- a/simhub-plugin/plugin/K10Motorsports.Plugin/Plugin.cs
+++ b/simhub-plugin/plugin/K10Motorsports.Plugin/Plugin.cs
@@ -600,6 +600,18 @@ namespace K10Motorsports.Plugin
                 {
                     _lightsPhase = 6; // jump to all red
                 }
+                // Final fallback: in formation with pace mode >= 3 but somehow never started
+                else if (ss == 3 && pm >= 3 && _lightsPrevPaceMode >= 3)
+                {
+                    _lightsPhase = 6;
+                }
+                // Catch-all: if session just went to Racing and we never fired lights,
+                // show a quick green flash so the driver sees something
+                else if (ss == 4 && _lightsPrevSessionState <= 3 && _lightsPrevSessionState >= 1 && _lightsPhase == 0)
+                {
+                    _lightsPhase = 7; // GREEN!
+                    _lightsHoldFrames = 15;
+                }
             }
 
             // If session goes back to non-formation unexpectedly, reset


### PR DESCRIPTION
## Summary
- Broadened C# plugin lights state machine to catch more PaceMode/SessionState transition patterns
- Added catch-all green flash when session transitions to Racing without any lights sequence having played
- Broadened dashboard synthetic fallback to trigger on any pre-race→Racing transition (not just state 3→4)
- Added fallback for PaceMode already at 3 when entering formation

## Test plan
- [ ] Join an iRacing rolling start race — lights should show during formation
- [ ] Verify green flash appears at race start
- [ ] Test in demo mode — existing demo lights sequence should still work
- [ ] Verify lights don't fire during practice/qualifying sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)