### PR TITLE
Add tire/track condition mismatch spotter alert

### DIFF
--- a/dashboard-overlay/modules/js/poll-engine.js
+++ b/dashboard-overlay/modules/js/poll-engine.js
@@ -1058,6 +1058,9 @@
     // ─── Spotter (disabled in pit lane — no close racing alerts) ───
     try { if (!_inPitLane) updateSpotter(p, _demo); } catch(e) { console.error('[K10] Spotter error:', e); }
 
+    // ─── Tire / Track Condition Mismatch ───
+    try { if (typeof checkTyreMismatch === 'function' && !_inPitLane) checkTyreMismatch(p, _demo); } catch(e) { console.error('[K10] Tire mismatch check error:', e); }
+
     // ─── Race Timeline ───
     try {
       const rtIncidents = +(v('K10Motorsports.Plugin.DS.IncidentCount')) || 0;

--- a/dashboard-overlay/modules/js/spotter.js
+++ b/dashboard-overlay/modules/js/spotter.js
@@ -280,3 +280,51 @@
   };
 
   // ═══════════════════════════════════════════════════════════════
+
+  // ═══════════════════════════════════════════════════════════════
+  //  TIRE / TRACK CONDITION MISMATCH DETECTION
+  // ═══════════════════════════════════════════════════════════════
+  let _tyreMismatchLastAlert = 0;
+  const _tyreMismatchCooldown = 60000; // Only alert once per minute
+
+  window.checkTyreMismatch = function(p, isDemo) {
+    const pre = isDemo ? 'K10Motorsports.Plugin.Demo.DS.' : 'K10Motorsports.Plugin.DS.';
+    const isWet = +(p[pre + 'WeatherWet']) === 1;
+    const trackWetness = +(p[pre + 'TrackWetness']) || 0;
+
+    // Tire compound: try multiple possible property paths
+    // Some SimHub plugins expose TireCompound directly; others use raw telemetry indices
+    let onWetTires = false;
+
+    // Try K10 plugin custom property first
+    const compound = +(p[pre + 'TireCompound']);
+    if (!isNaN(compound)) {
+      // 1 = wet tires, 0 = dry tires
+      onWetTires = compound === 1;
+    } else {
+      // Fallback: we don't have reliable tire compound data
+      return;
+    }
+
+    const now = Date.now();
+    if (now - _tyreMismatchLastAlert < _tyreMismatchCooldown) return;
+
+    let msg = '';
+    let severity = '';
+
+    // Wet weather but on dry tires — critical alert
+    if (isWet && !onWetTires && trackWetness > 0.3) {
+      msg = 'Dry tires on wet track — consider pitting for wets';
+      severity = 'sp-warn';
+    }
+    // Dry weather but on wet tires — performance warning
+    else if (!isWet && onWetTires && trackWetness < 0.1) {
+      msg = 'Wet tires on dry track — losing grip to compound';
+      severity = 'sp-warn';
+    }
+
+    if (msg) {
+      _tyreMismatchLastAlert = now;
+      _showSpotterMsg(msg, severity, 'Conditions');
+    }
+  };


### PR DESCRIPTION
## Summary
- Adds spotter alert when tire compound doesn't match track conditions
- Warns about dry tires on wet track and wet tires on dry track
- Uses WeatherWet and TrackWetness telemetry data
- 60-second cooldown between mismatch alerts to avoid spamming

## Test plan
- [ ] Test in wet conditions with dry tires — should see warning
- [ ] Test in dry conditions with wet tires — should see warning
- [ ] Verify alert doesn't repeat within 60 seconds
- [ ] Verify no false positives in normal dry conditions

Generated with Claude Code