### PR TITLE
Add visual effects to track map near driver and opponents

### DIFF
--- a/dashboard-overlay/modules/js/webgl-helpers.js
+++ b/dashboard-overlay/modules/js/webgl-helpers.js
@@ -871,6 +871,12 @@
       zoomPlayer.setAttribute('cy', sy.toFixed(1));
     }
 
+    // Update track glow effect following player position
+    const fullSvg = document.getElementById('fullMapSvg');
+    const zoomSvg = document.getElementById('zoomMapSvg');
+    if (fullSvg) _updateTrackGlow(fullSvg, sx, sy);
+    if (zoomSvg) _updateTrackGlow(zoomSvg, sx, sy);
+
     // G-force trail — read current G from datastream globals
     const latG  = window._ambientLatG  || 0;
     const longG = window._ambientLongG || 0;
@@ -959,11 +965,15 @@
       fullDots[i].setAttribute('cy', oy);
       fullDots[i].style.display = inPit ? 'none' : '';
       fullDots[i].classList.toggle('close', _isClose(sx, sy, ox, oy));
+      // Add pulse animation for nearby opponents (~20% track proximity)
+      fullDots[i].classList.toggle('map-opponent-near', _isNear(sx, sy, ox, oy));
 
       zoomDots[i].setAttribute('cx', ox);
       zoomDots[i].setAttribute('cy', oy);
       zoomDots[i].style.display = inPit ? 'none' : '';
       zoomDots[i].classList.toggle('close', _isClose(sx, sy, ox, oy));
+      // Add pulse animation for nearby opponents (~20% track proximity)
+      zoomDots[i].classList.toggle('map-opponent-near', _isNear(sx, sy, ox, oy));
     }
   }
 
@@ -982,6 +992,69 @@
   function _isClose(px, py, ox, oy) {
     const dx = px - ox, dy = py - oy;
     return (dx * dx + dy * dy) < 64; // ~8 SVG units
+  }
+
+  function _isNear(px, py, ox, oy) {
+    // Proximity pulse: ~20% of track (distance ~20 SVG units = ~400 units squared)
+    const dx = px - ox, dy = py - oy;
+    return (dx * dx + dy * dy) < 400; // ~20 SVG units
+  }
+
+  function _updateTrackGlow(svgEl, px, py) {
+    // Create or update a radial gradient glow that follows player position
+    let glow = svgEl.getElementById('trackPlayerGlow');
+    let grad = svgEl.getElementById('trackGlowGrad');
+
+    if (!glow) {
+      // Create radial gradient definition once
+      const defs = svgEl.querySelector('defs') || (() => {
+        const d = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
+        svgEl.insertBefore(d, svgEl.firstChild);
+        return d;
+      })();
+
+      grad = document.createElementNS('http://www.w3.org/2000/svg', 'radialGradient');
+      grad.id = 'trackGlowGrad';
+      const stopInner = document.createElementNS('http://www.w3.org/2000/svg', 'stop');
+      stopInner.setAttribute('offset', '0%');
+      stopInner.setAttribute('stop-color', 'var(--map-player-color, hsl(185,70%,55%))');
+      stopInner.setAttribute('stop-opacity', '0.3');
+      grad.appendChild(stopInner);
+
+      const stopMid = document.createElementNS('http://www.w3.org/2000/svg', 'stop');
+      stopMid.setAttribute('offset', '50%');
+      stopMid.setAttribute('stop-color', 'var(--map-player-color, hsl(185,70%,55%))');
+      stopMid.setAttribute('stop-opacity', '0.1');
+      grad.appendChild(stopMid);
+
+      const stopOuter = document.createElementNS('http://www.w3.org/2000/svg', 'stop');
+      stopOuter.setAttribute('offset', '100%');
+      stopOuter.setAttribute('stop-color', 'var(--map-player-color, hsl(185,70%,55%))');
+      stopOuter.setAttribute('stop-opacity', '0');
+      grad.appendChild(stopOuter);
+
+      defs.appendChild(grad);
+
+      // Create glow circle overlay
+      glow = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+      glow.id = 'trackPlayerGlow';
+      glow.setAttribute('r', '25');
+      glow.setAttribute('fill', 'url(#trackGlowGrad)');
+      glow.style.pointerEvents = 'none';
+      glow.style.mixBlendMode = 'screen';
+
+      // Insert before dots so it's behind them
+      const dotsGroup = svgEl.querySelector('.map-opponent') || svgEl.lastChild;
+      if (dotsGroup && dotsGroup.parentNode) {
+        dotsGroup.parentNode.insertBefore(glow, dotsGroup);
+      } else {
+        svgEl.appendChild(glow);
+      }
+    }
+
+    // Update glow position to follow player
+    glow.setAttribute('cx', px.toFixed(1));
+    glow.setAttribute('cy', py.toFixed(1));
   }
 
   // ═══ EXPOSE ALL FUNCTIONS TO WINDOW ═══

--- a/dashboard-overlay/modules/styles/dashboard.css
+++ b/dashboard-overlay/modules/styles/dashboard.css
@@ -1295,6 +1295,8 @@
   .map-player {
     fill: var(--map-player-color, var(--cyan));
     transition: fill 0.4s ease;
+    filter: drop-shadow(0 0 4px var(--map-player-color, var(--cyan)))
+            drop-shadow(0 0 8px var(--map-player-color, var(--cyan)));
   }
   .map-gforce-trail {
     pointer-events: none;
@@ -1303,6 +1305,21 @@
   }
   .map-opponent { fill: hsla(0,0%,100%,0.35); }
   .map-opponent.close { fill: var(--orange); }
+
+  /* Pulse animation for nearby opponents */
+  @keyframes map-opponent-pulse {
+    0%, 100% {
+      opacity: 0.7;
+      filter: none;
+    }
+    50% {
+      opacity: 1;
+      filter: drop-shadow(0 0 3px hsla(0,70%,60%,0.6));
+    }
+  }
+  .map-opponent.map-opponent-near {
+    animation: map-opponent-pulse 1.5s ease-in-out infinite;
+  }
 
   .map-zoom-panel {
     flex: 1;


### PR DESCRIPTION
## Summary
- Adds radial glow around player dot on track map, colored by manufacturer brand
- Nearby opponent dots (within ~20% of track proximity) get a subtle pulse animation
- SVG radial gradient follows the player position, creating a soft illumination on the track artwork
- All effects use CSS variables for consistent theming

## Test plan
- [ ] Verify player dot has colored glow on track map
- [ ] Check nearby opponents pulse when within 20% proximity
- [ ] Confirm glow follows player position as they drive
- [ ] Verify no performance regression on track map rendering

Generated with Claude Code