### PR TITLE
Fix duplicate const zoomSvg breaking dashboard-embed

### DIFF
--- a/dashboard-overlay/modules/js/webgl-helpers.js
+++ b/dashboard-overlay/modules/js/webgl-helpers.js
@@ -885,10 +885,10 @@
     }
 
     // Update track glow effect following player position
-    const fullSvg = document.getElementById('fullMapSvg');
-    const zoomSvg = document.getElementById('zoomMapSvg');
-    if (fullSvg) _updateTrackGlow(fullSvg, sx, sy);
-    if (zoomSvg) _updateTrackGlow(zoomSvg, sx, sy);
+    const glowFullSvg = document.getElementById('fullMapSvg');
+    const glowZoomSvg = document.getElementById('zoomMapSvg');
+    if (glowFullSvg) _updateTrackGlow(glowFullSvg, sx, sy);
+    if (glowZoomSvg) _updateTrackGlow(glowZoomSvg, sx, sy);
 
     // G-force trail — read current G from datastream globals
     const latG  = window._ambientLatG  || 0;


### PR DESCRIPTION
## Summary
- The track glow feature (PR #62) introduced a second `const zoomSvg` declaration in `updateTrackMap` at the same function scope as the existing one
- When JS gets inlined into `dashboard-embed.html`, this caused `SyntaxError: Cannot declare a const variable twice: 'zoomSvg'` — breaking all live data
- Renamed the glow-related variables to `glowFullSvg` / `glowZoomSvg` to avoid the conflict

## Test plan
- [ ] Verify dashboard-embed.html loads without SyntaxError
- [ ] Confirm live data resumes
- [ ] Track glow effect still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)