### PR TITLE
Tighten map player glow, brighten core, add pulse

### DIFF
--- a/dashboard-overlay/modules/js/webgl-helpers.js
+++ b/dashboard-overlay/modules/js/webgl-helpers.js
@@ -1028,16 +1028,17 @@
 
       grad = document.createElementNS('http://www.w3.org/2000/svg', 'radialGradient');
       grad.id = 'trackGlowGrad';
-      const stopInner = document.createElementNS('http://www.w3.org/2000/svg', 'stop');
-      stopInner.setAttribute('offset', '0%');
-      stopInner.setAttribute('stop-color', 'var(--map-player-color, hsl(185,70%,55%))');
-      stopInner.setAttribute('stop-opacity', '0.3');
-      grad.appendChild(stopInner);
+      // Bright white-ish core that fades to brand color at edges
+      const stopCore = document.createElementNS('http://www.w3.org/2000/svg', 'stop');
+      stopCore.setAttribute('offset', '0%');
+      stopCore.setAttribute('stop-color', 'hsl(0,0%,100%)');
+      stopCore.setAttribute('stop-opacity', '0.45');
+      grad.appendChild(stopCore);
 
       const stopMid = document.createElementNS('http://www.w3.org/2000/svg', 'stop');
-      stopMid.setAttribute('offset', '50%');
+      stopMid.setAttribute('offset', '35%');
       stopMid.setAttribute('stop-color', 'var(--map-player-color, hsl(185,70%,55%))');
-      stopMid.setAttribute('stop-opacity', '0.1');
+      stopMid.setAttribute('stop-opacity', '0.25');
       grad.appendChild(stopMid);
 
       const stopOuter = document.createElementNS('http://www.w3.org/2000/svg', 'stop');
@@ -1048,13 +1049,14 @@
 
       defs.appendChild(grad);
 
-      // Create glow circle overlay
+      // Create glow circle overlay — tight radius, pulsing via CSS
       glow = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
       glow.id = 'trackPlayerGlow';
-      glow.setAttribute('r', '25');
+      glow.setAttribute('r', '10');
       glow.setAttribute('fill', 'url(#trackGlowGrad)');
       glow.style.pointerEvents = 'none';
       glow.style.mixBlendMode = 'screen';
+      glow.style.animation = 'map-glow-pulse 2s ease-in-out infinite';
 
       // Insert before dots so it's behind them
       const dotsGroup = svgEl.querySelector('.map-opponent') || svgEl.lastChild;

--- a/dashboard-overlay/modules/styles/dashboard.css
+++ b/dashboard-overlay/modules/styles/dashboard.css
@@ -1295,8 +1295,20 @@
   .map-player {
     fill: var(--map-player-color, var(--cyan));
     transition: fill 0.4s ease;
-    filter: drop-shadow(0 0 4px var(--map-player-color, var(--cyan)))
-            drop-shadow(0 0 8px var(--map-player-color, var(--cyan)));
+    filter: drop-shadow(0 0 2px hsla(0,0%,100%,0.7))
+            drop-shadow(0 0 4px var(--map-player-color, var(--cyan)));
+    animation: map-player-pulse 2s ease-in-out infinite;
+  }
+  @keyframes map-player-pulse {
+    0%, 100% {
+      filter: drop-shadow(0 0 2px hsla(0,0%,100%,0.7))
+              drop-shadow(0 0 4px var(--map-player-color, var(--cyan)));
+    }
+    50% {
+      filter: drop-shadow(0 0 3px hsla(0,0%,100%,0.9))
+              drop-shadow(0 0 6px var(--map-player-color, var(--cyan)))
+              drop-shadow(0 0 10px var(--map-player-color, var(--cyan)));
+    }
   }
   .map-gforce-trail {
     pointer-events: none;
@@ -1319,6 +1331,12 @@
   }
   .map-opponent.map-opponent-near {
     animation: map-opponent-pulse 1.5s ease-in-out infinite;
+  }
+
+  /* SVG radial glow pulse behind player dot */
+  @keyframes map-glow-pulse {
+    0%, 100% { r: 10; opacity: 0.8; }
+    50% { r: 14; opacity: 1; }
   }
 
   .map-zoom-panel {


### PR DESCRIPTION
## Summary
- Tightened SVG radial glow from r=25 to r=10 for a sharper halo around the driver dot
- Shifted gradient core from brand color to white (0.45 opacity) that fades to brand at edges — reads as a bright highlight rather than a flat color wash
- Added 2s pulse animation on both the CSS drop-shadow and the SVG radial glow
- Inner drop-shadow is now white to separate the dot from the brand-colored outer glow

## Test plan
- [ ] Verify glow is tighter and brighter around player dot
- [ ] Confirm pulse is visible but not distracting
- [ ] Check that brand color still tints the outer edge of the glow

🤖 Generated with [Claude Code](https://claude.com/claude-code)