### PR TITLE
Fix flag overlay showing 0 on marketing site

### DIFF
--- a/dashboard-overlay/modules/js/poll-engine.js
+++ b/dashboard-overlay/modules/js/poll-engine.js
@@ -829,7 +829,8 @@
     }
 
     // ─── Flag Status → Gaps Block ───
-    const flagState = (_forceFlagState && _demo) ? _forceFlagState : (vs('currentFlagState') || 'none');
+    const rawFlag = (_forceFlagState && _demo) ? _forceFlagState : (vs('currentFlagState') || 'none');
+    const flagState = (!rawFlag || rawFlag === '0' || rawFlag === 0) ? 'none' : rawFlag;
     const gapsBlock = document.getElementById('gapsBlock');
     if (gapsBlock) {
       const flagLabels = { yellow: 'CAUTION', red: 'RED FLAG', blue: 'BLUE FLAG', white: 'LAST LAP', debris: 'DEBRIS', checkered: 'FINISH', black: 'BLACK FLAG', green: 'GREEN', meatball: 'MEATBALL', orange: 'LAPPED CAR' };

--- a/web/public/_demo/dashboard-embed.html
+++ b/web/public/_demo/dashboard-embed.html
@@ -1,0 +1,18102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>K10 Motorsports — Dashboard Demo</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:ital,wght@0,400;0,500;0,600;0,700;0,800;0,900;1,400;1,500&family=Barlow+Semi+Condensed:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<style>
+/* ── modules/styles/base.css ── */
+  *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+  :root {
+    --corner-r: 8px;
+    --corner-r-sm: 5px;
+    --gap: 4px;
+    --panel-gap: 6px;           /* gap between adjacent secondary panels */
+    --edge: 10px;               /* universal inset from screen edges */
+    --pad: 6px;
+
+    --dash-h: 200px;
+    --row-h: calc((var(--dash-h) - var(--gap)) / 2);
+
+    --bg: hsla(0, 0%, 8%, 0.90);
+    --bg-panel: hsla(0, 0%, 6%, 0.90);
+    --bg-logo: hsla(0, 0%, 12%, 0.90);
+    --border: hsla(0, 0%, 100%, 0.14);
+    --text-primary: hsla(0, 0%, 100%, 1.0);
+    --text-secondary: hsla(0, 0%, 100%, 0.69);
+    --text-dim: hsla(0, 0%, 100%, 0.55);
+
+    --red: #e53935;
+    --green: #43a047;
+    --blue: #1e88e5;
+    --amber: #ffb300;
+    --orange: #fb8c00;
+    --cyan: #00acc1;
+    --purple: hsl(280,80%,70%);
+
+    --ff: 'Barlow Condensed', 'Corbel', 'Segoe UI', system-ui, sans-serif;
+    --ff-mono: 'JetBrains Mono', 'Consolas', 'SF Mono', monospace;
+    --fs-xl: 20px;
+    --fs-lg: 13px;
+    --fs-md: 11px;
+    --fs-sm: 11px;
+    --fs-xs: 10px;
+    --fw-black: 800;
+    --fw-bold: 700;
+    --fw-semi: 600;
+    --fw-medium: 500;
+    --fw-regular: 400;
+
+    --t-fast: 180ms ease;
+    --t-med: 350ms ease;
+    --t-slow: 600ms ease-out;
+
+    --sentiment-h: 0;
+    --sentiment-s: 0%;
+    --sentiment-l: 0%;
+    --sentiment-alpha: 0;
+  }
+
+  body {
+    font-family: var(--ff);
+    color: var(--text-primary);
+    background: transparent;
+    overflow: hidden;
+    -webkit-font-smoothing: antialiased;
+    letter-spacing: 0.03em;
+    position: relative;
+    margin: 0;
+    padding: 0;
+  }
+
+  /* ── Chroma-key / green-screen mode ───────────────────────
+     Solid green background for OBS chroma-key compositing.
+     Panels get opaque backgrounds, drop shadows and blur are
+     disabled so edges key cleanly. */
+  body.opaque-mode {
+    background: #00FF00;
+  }
+  body.opaque-mode .panel {
+    background: hsl(0, 0%, 8%) !important;
+  }
+  body.opaque-mode .commentary-inner {
+    background: hsla(var(--commentary-h, 0), 50%, 8%, 1) !important;
+  }
+  body.opaque-mode .dashboard {
+    filter: none !important;
+  }
+  body.opaque-mode .dashboard::before {
+    background: hsla(var(--sentiment-h), var(--sentiment-s), 6%, var(--sentiment-alpha)) !important;
+  }
+
+  /* Settings hint text */
+  .settings-hint {
+    font-size: 9px;
+    color: hsla(0,0%,100%,0.35);
+    padding: 2px 0 6px;
+    line-height: 1.4;
+  }
+
+  /* ── Settings / drag mode ──────────────────────────────────
+     Ctrl+Shift+S toggles settings mode. In green-screen mode
+     the window is draggable + resizable. Banner shows current state. */
+  body.settings-drag {
+    -webkit-app-region: drag;
+    cursor: move;
+  }
+  body.settings-drag::after {
+    content: 'SETTINGS MODE \2022 Ctrl+Shift+S TO LOCK';
+    position: fixed;
+    top: 0; left: 0; right: 0;
+    background: rgba(255, 165, 0, 0.9);
+    color: #000;
+    text-align: center;
+    font: bold 12px/28px system-ui, sans-serif;
+    letter-spacing: 1px;
+    z-index: 99999;
+    -webkit-app-region: drag;
+  }
+  body.green-screen-mode.settings-drag::after {
+    content: 'DRAG TO MOVE \2022 RESIZE EDGES \2022 Ctrl+Shift+S TO LOCK';
+  }
+  /* Keep buttons/inputs clickable inside settings mode */
+  body.settings-drag button,
+  body.settings-drag input,
+  body.settings-drag select,
+  body.settings-drag .settings-toggle,
+  body.settings-drag .settings-close,
+  body.settings-drag .settings-overlay,
+  body.settings-drag .settings-panel,
+  body.settings-drag .conn-banner {
+    -webkit-app-region: no-drag;
+  }
+
+  /* ═══════════════════════════════════════════════
+     DRIVE MODE — full-screen driver-focused HUD
+     Activated by Ctrl+Shift+F or auto on remote server.
+     ═══════════════════════════════════════════════ */
+  body.drive-mode-active {
+    background: #000 !important;
+    overflow: hidden;
+  }
+  body.drive-mode-active #dashboard,
+  body.drive-mode-active .leaderboard-panel,
+  body.drive-mode-active .datastream-panel,
+  body.drive-mode-active .pitbox-panel,
+  body.drive-mode-active .incidents-panel,
+  body.drive-mode-active .spotter-panel,
+  body.drive-mode-active .commentary-col,
+  body.drive-mode-active .timer-row,
+  body.drive-mode-active #connBanner,
+  body.drive-mode-active #idleLogo,
+  body.drive-mode-active .rc-banner,
+  body.drive-mode-active #secContainer {
+    display: none !important;
+  }
+  body.drive-mode-active #driveHud { display: grid !important; }
+
+  .drive-hud {
+    display: none;
+    position: fixed;
+    inset: 0;
+    grid-template-columns: 1fr 1.2fr auto;
+    gap: 0;
+    padding: 0;
+    background: #000;
+    color: var(--text-primary);
+    font-family: var(--ff);
+    z-index: 100;
+  }
+
+  /* ── Left: track map fills entire column ── */
+  .dh-left {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+  }
+  .dh-map {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background: hsla(0,0%,100%,0.02);
+    position: relative;
+    /* overflow:visible allows the SVG to extend slightly during rotation
+       without rectangular clipping. A circular clip-path gives a clean
+       edge while accommodating the rotated content. */
+    overflow: visible;
+    clip-path: inset(0 round var(--corner-r));
+    border-radius: var(--corner-r);
+  }
+  .dh-map-name {
+    position: absolute;
+    top: 16px;
+    left: 16px;
+    font-size: 14px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: hsla(0,0%,100%,0.3);
+    z-index: 1;
+  }
+  .dh-map-svg {
+    width: 100%;
+    height: 100%;
+    /* Rotation is now applied to the inner <g> via SVG attribute transforms,
+       so no CSS transition on the element itself is needed. */
+  }
+  .dh-map-svg .map-track { stroke-width: 2; }
+  .dh-map-svg .map-player {
+    fill: var(--purple);
+    filter: drop-shadow(0 0 8px var(--purple));
+  }
+  .dh-map-svg .map-opponent {
+    fill: hsla(0,0%,100%,0.35);
+    transition: fill 0.2s;
+  }
+  .dh-map-svg .map-opponent.close {
+    fill: hsla(0,70%,55%,0.9);
+    filter: drop-shadow(0 0 4px hsla(0,70%,55%,0.6));
+  }
+  .dh-map-svg .map-sector { stroke-width: 2.5; }
+  .dh-spotter {
+    position: absolute;
+    bottom: 16px;
+    left: 16px;
+    right: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    z-index: 1;
+  }
+
+  /* ── Center: timing — vertically stacked, full height ── */
+  .dh-center {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 3vh;
+    padding: 24px;
+  }
+  .dh-position { text-align: center; }
+  .dh-pos-num {
+    font-size: 14vh;
+    font-weight: 900;
+    font-style: italic;
+    letter-spacing: -0.03em;
+    line-height: 1;
+  }
+  .dh-lap-delta {
+    font-family: var(--ff-mono);
+    font-size: 8vh;
+    font-weight: 700;
+    text-align: center;
+    transition: color 0.2s;
+  }
+  .dh-lap-delta.dh-faster { color: var(--green); }
+  .dh-lap-delta.dh-slower { color: var(--red); }
+  .dh-lap-delta.dh-neutral { color: var(--text-dim); }
+
+  .dh-sectors {
+    display: flex;
+    gap: 10px;
+    width: 100%;
+  }
+  .dh-sector {
+    flex: 1;
+    text-align: center;
+    padding: 16px 10px;
+    border-radius: 10px;
+    background: hsla(0,0%,100%,0.04);
+    transition: background 0.3s;
+  }
+  .dh-sec-label {
+    font-size: 14px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: hsla(0,0%,100%,0.35);
+    margin-bottom: 6px;
+  }
+  .dh-sec-time {
+    font-family: var(--ff-mono);
+    font-size: 3.5vh;
+    font-weight: 600;
+  }
+  .dh-sec-delta {
+    font-family: var(--ff-mono);
+    font-size: 2vh;
+    font-weight: 600;
+    color: hsla(0,0%,100%,0.35);
+    margin-top: 4px;
+  }
+  .dh-sector.dh-s-pb { background: hsla(280,60%,45%,0.45); }
+  .dh-sector.dh-s-pb .dh-sec-time, .dh-sector.dh-s-pb .dh-sec-delta { color: hsl(280,80%,78%); }
+  .dh-sector.dh-s-faster { background: hsla(130,55%,40%,0.45); }
+  .dh-sector.dh-s-faster .dh-sec-time, .dh-sector.dh-s-faster .dh-sec-delta { color: hsl(130,75%,72%); }
+  .dh-sector.dh-s-slower { background: hsla(45,80%,40%,0.4); }
+  .dh-sector.dh-s-slower .dh-sec-time, .dh-sector.dh-s-slower .dh-sec-delta { color: hsl(45,95%,68%); }
+  .dh-sector.dh-s-invalid { background: hsla(0,65%,45%,0.45); }
+  .dh-sector.dh-s-invalid .dh-sec-time, .dh-sector.dh-s-invalid .dh-sec-delta { color: hsl(0,80%,72%); }
+  .dh-sector.dh-s-active { border: 2px solid hsla(0,0%,100%,0.3); }
+
+  .dh-lap-times {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    width: 100%;
+    position: relative;
+  }
+  .dh-lap-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: 6px 12px;
+    background: hsla(0,0%,100%,0.02);
+    border-radius: 6px;
+  }
+  .dh-lap-label {
+    font-size: 2.2vh;
+    font-weight: 600;
+    color: hsla(0,0%,100%,0.4);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+  .dh-lap-val {
+    font-family: var(--ff-mono);
+    font-size: 3.5vh;
+    font-weight: 600;
+  }
+  .dh-purple { color: var(--purple); }
+  /* Live lap time + delta — absolutely positioned, never affects lap number layout */
+  .dh-live-lap {
+    position: absolute;
+    bottom: -4.5vh;
+    left: 0;
+    right: 0;
+    text-align: center;
+    pointer-events: none;
+  }
+  .dh-live-time {
+    font-family: var(--ff-mono);
+    font-size: 2.8vh;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+  .dh-live-delta {
+    font-family: var(--ff-mono);
+    font-size: 2.2vh;
+    font-weight: 700;
+    margin-left: 8px;
+    transition: color 0.2s;
+  }
+  .dh-live-delta.dh-delta-pb     { color: var(--purple); }
+  .dh-live-delta.dh-delta-faster { color: var(--green); }
+  .dh-live-delta.dh-delta-slower { color: var(--amber); }
+  .dh-live-delta.dh-delta-much-slower { color: var(--red); }
+
+  /* ── Right: incidents — fills column vertically ── */
+  .dh-right {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: hsla(0,0%,100%,0.02);
+  }
+  .dh-incidents { text-align: center; }
+  .dh-inc-label {
+    font-size: 16px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: hsla(0,0%,100%,0.35);
+    margin-bottom: 10px;
+  }
+  .dh-inc-count {
+    font-family: var(--ff-mono);
+    font-size: 12vh;
+    font-weight: 800;
+    line-height: 1;
+  }
+  .dh-inc-x {
+    font-size: 5vh;
+    font-weight: 600;
+    color: hsla(0,0%,100%,0.35);
+    margin-left: 2px;
+  }
+  .dh-inc-thresholds {
+    font-size: 2.2vh;
+    color: hsla(0,0%,100%,0.4);
+    margin-top: 16px;
+    line-height: 1.8;
+  }
+  .dh-inc-thresholds span {
+    font-family: var(--ff-mono);
+    font-weight: 700;
+    color: hsla(0,0%,100%,0.7);
+  }
+
+  .dashboard {
+    position: fixed;
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap);
+    transition: all var(--t-slow);
+    z-index: 55;
+    pointer-events: none;
+  }
+  /* Bottom layouts: timer on top, main HUD hugs bottom screen edge */
+  .dashboard.layout-br,
+  .dashboard.layout-bl {
+    flex-direction: column-reverse;
+  }
+  .main-row {
+    display: flex;
+    gap: var(--gap);
+    height: var(--dash-h);
+    align-items: stretch;
+    flex-shrink: 0;
+  }
+  .timer-row {
+    flex-shrink: 0;
+  }
+
+  /* ── COMMENTARY — independent fixed overlay ──
+     Diagonally opposite the main HUD.
+     Variable height content, so no max-height transition (that clips).
+     Fade + slide in from BOTH of its nearest edges. */
+  .commentary-col {
+    position: fixed;
+    z-index: 56;
+    pointer-events: none;
+    width: 280px;
+    opacity: 0;
+    transition: opacity 0.4s ease, transform 0.4s ease;
+  }
+  .commentary-col.visible {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translate(0, 0);
+  }
+  /* Bottom-left: slides in from left and below */
+  .commentary-col.cmt-bl {
+    bottom: calc(var(--edge-z, var(--edge)) + 100px); left: calc(var(--edge-z, var(--edge)) + 50px);
+    transform: translate(-20px, 12px);
+  }
+  /* Bottom-right: slides in from right and below */
+  .commentary-col.cmt-br {
+    bottom: calc(var(--edge-z, var(--edge)) + 100px); right: calc(var(--edge-z, var(--edge)) + 50px);
+    transform: translate(20px, 12px);
+  }
+  /* Top-left: slides in from left and above */
+  .commentary-col.cmt-tl {
+    top: calc(var(--edge-z, var(--edge)) + 100px); left: calc(var(--edge-z, var(--edge)) + 50px);
+    transform: translate(-20px, -12px);
+  }
+  /* Top-right: slides in from right and above */
+  .commentary-col.cmt-tr {
+    top: calc(var(--edge-z, var(--edge)) + 100px); right: calc(var(--edge-z, var(--edge)) + 50px);
+    transform: translate(20px, -12px);
+  }
+
+
+
+/* ── modules/styles/dashboard.css ── */
+  /* ═══════════════════════════════════════════════
+     LAYOUT POSITION SYSTEM — 5 positions
+     4 corners (user-selectable) + absolute-center (programmatic).
+     All behavior is deterministic from the corner choice:
+       Right corners → RTL flow (logo at right edge)
+       Left corners  → LTR flow (logo at left edge)
+       Bottom corners → column-reverse + vswap
+       Top corners    → column normal
+     ═══════════════════════════════════════════════ */
+
+  /* ── Position anchoring ──
+     Zoomed fixed elements use --edge-z (zoom-compensated) so the visual
+     gap from screen edges stays consistent regardless of zoom level.
+     --edge-z is set by applyZoom() in JS. Falls back to --edge. */
+  .dashboard.layout-tr { top: var(--edge-z, var(--edge)); right: var(--edge-z, var(--edge)); }
+  .dashboard.layout-tl { top: var(--edge-z, var(--edge)); left: var(--edge-z, var(--edge)); }
+  .dashboard.layout-br { bottom: var(--edge-z, var(--edge)); right: var(--edge-z, var(--edge)); }
+  .dashboard.layout-bl { bottom: var(--edge-z, var(--edge)); left: var(--edge-z, var(--edge)); }
+  .dashboard.layout-ac { top: 500px; left: 50%; transform: translateX(-50%); }
+
+  /* ── Horizontal flow ── */
+  /* Right corners: RTL — logo+tacho at right edge, data panels extend left */
+  .dashboard.layout-tr .main-row,
+  .dashboard.layout-br .main-row { flex-direction: row-reverse; }
+  .dashboard.layout-tr .main-area,
+  .dashboard.layout-br .main-area { flex-direction: row; }
+
+  /* Left corners: LTR — logo+tacho at left edge, data panels extend right */
+  .dashboard.layout-tl .main-row,
+  .dashboard.layout-bl .main-row { flex-direction: row; }
+  .dashboard.layout-tl .main-area,
+  .dashboard.layout-bl .main-area { flex-direction: row-reverse; }
+
+  /* Absolute center: LTR default */
+  .dashboard.layout-ac .main-row { flex-direction: row; }
+  .dashboard.layout-ac .main-area { flex-direction: row-reverse; }
+
+  /* ── Corner rounding for LTR flow (left corners) ── */
+  .dashboard.layout-tl .fuel-block,
+  .dashboard.layout-bl .fuel-block,
+  .dashboard.layout-ac .fuel-block {
+    border-top-left-radius: 0; border-top-right-radius: var(--corner-r);
+  }
+  .dashboard.layout-tl .tyres-block,
+  .dashboard.layout-bl .tyres-block,
+  .dashboard.layout-ac .tyres-block {
+    border-bottom-left-radius: 0; border-bottom-right-radius: var(--corner-r);
+  }
+  .dashboard.layout-tl .tacho-block,
+  .dashboard.layout-bl .tacho-block,
+  .dashboard.layout-ac .tacho-block {
+    border-top-right-radius: 0; border-bottom-right-radius: 0;
+    border-top-left-radius: var(--corner-r); border-bottom-left-radius: var(--corner-r);
+  }
+
+  /* ── Vertical swap for bottom corners ──
+     Reverses internal column order so panels read correctly
+     when the HUD is anchored to the bottom edge. */
+  .dashboard.layout-br .fuel-tyres-col,
+  .dashboard.layout-bl .fuel-tyres-col,
+  .dashboard.layout-br .controls-pedals-block,
+  .dashboard.layout-bl .controls-pedals-block,
+  .dashboard.layout-br .maps-col,
+  .dashboard.layout-bl .maps-col,
+  .dashboard.layout-br .pos-gaps-col,
+  .dashboard.layout-bl .pos-gaps-col,
+  .dashboard.layout-br .logo-col,
+  .dashboard.layout-bl .logo-col {
+    flex-direction: column-reverse;
+  }
+
+  /* Vswap corner rounding — bottom-right (RTL): fuel→bottom-left, tyres→top-left */
+  .dashboard.layout-br .fuel-block  { border-top-left-radius: 0; border-bottom-left-radius: var(--corner-r); }
+  .dashboard.layout-br .tyres-block { border-bottom-left-radius: 0; border-top-left-radius: var(--corner-r); }
+
+  /* Vswap corner rounding — bottom-left (LTR): fuel→bottom-right, tyres→top-right */
+  .dashboard.layout-bl .fuel-block  {
+    border-top-right-radius: 0; border-bottom-right-radius: var(--corner-r);
+    border-top-left-radius: 0; border-bottom-left-radius: 0;
+  }
+  .dashboard.layout-bl .tyres-block {
+    border-bottom-right-radius: 0; border-top-right-radius: var(--corner-r);
+    border-bottom-left-radius: 0; border-top-left-radius: 0;
+  }
+
+  /* Vswap logo column — bottom corners flip logo squares */
+  .dashboard.layout-br .logo-col .logo-square:first-child,
+  .dashboard.layout-bl .logo-col .logo-square:first-child {
+    border-top-left-radius: 0; border-top-right-radius: 0;
+    border-bottom-left-radius: var(--corner-r); border-bottom-right-radius: var(--corner-r);
+  }
+  .dashboard.layout-br .logo-col .logo-square:last-child,
+  .dashboard.layout-bl .logo-col .logo-square:last-child {
+    border-bottom-left-radius: 0; border-bottom-right-radius: 0;
+    border-top-left-radius: var(--corner-r); border-top-right-radius: var(--corner-r);
+  }
+  .dashboard::before {
+    content: '';
+    position: absolute;
+    inset: -2px;
+    border-radius: calc(var(--corner-r) + 2px);
+    background: hsla(var(--sentiment-h), var(--sentiment-s), var(--sentiment-l), var(--sentiment-alpha));
+    pointer-events: none;
+    z-index: 0;
+    transition: background 1s ease;
+  }
+  .dashboard > * { position: relative; z-index: 1; pointer-events: auto; }
+
+  .panel {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 0;
+    padding: var(--pad);
+    transition: background var(--t-slow), border-color var(--t-med);
+    overflow: hidden;
+  }
+
+  /* ── UNIFIED GRID ROUNDING ──
+     Only outer corners of the non-logo block grid get radius.
+     Inner corners where panels meet through gaps stay square. */
+  .fuel-block  { border-top-left-radius: var(--corner-r); }
+  .tyres-block { border-bottom-left-radius: var(--corner-r); }
+  .tacho-block {
+    border-top-right-radius: var(--corner-r);
+    border-bottom-right-radius: var(--corner-r);
+  }
+  .panel-label {
+    font-size: var(--fs-xs);
+    font-weight: var(--fw-semi);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-dim);
+    margin-bottom: 2px;
+    white-space: nowrap;
+  }
+
+  /* ── COMMENTARY (positioning now handled in base.css as position:fixed) ── */
+  .commentary-inner {
+    position: relative;
+    width: 280px;
+    flex: 1;
+    background: hsla(var(--commentary-h, 0), 50%, 13%, 0.96);
+    border: 1px solid hsla(var(--commentary-h, 0), 50%, 27%, 0.50);
+    border-radius: var(--corner-r);
+    padding: 14px;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    transition: background 0.8s ease, border-color 0.8s ease;
+    overflow: visible;
+    min-height: 0;
+  }
+  .commentary-gl-canvas {
+    position: absolute;
+    inset: -8px;
+    width: calc(100% + 16px);
+    height: calc(100% + 16px);
+    pointer-events: none;
+    z-index: 0;
+    border-radius: calc(var(--corner-r) + 4px);
+    opacity: 0;
+    transition: opacity 0.5s ease;
+  }
+  .commentary-col.visible .commentary-gl-canvas {
+    opacity: 1;
+  }
+  /* ── Track Image (shown during track-related commentary) ── */
+  .commentary-track-img {
+    width: calc(100% + 28px);   /* bleed into padding */
+    margin: -14px -14px 10px;   /* pull into parent padding, gap below */
+    height: 0;
+    overflow: hidden;
+    border-radius: var(--corner-r) var(--corner-r) 0 0;
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    position: relative;
+    opacity: 0;
+    transition: height 0.5s cubic-bezier(.4,0,.2,1),
+                opacity 0.6s ease 0.15s;
+  }
+  .commentary-track-img.active {
+    height: 120px;
+    opacity: 1;
+  }
+  /* dark gradient overlay for text below */
+  .commentary-track-img::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      to bottom,
+      transparent 30%,
+      hsla(var(--commentary-h, 0), 50%, 13%, 0.85) 100%
+    );
+    pointer-events: none;
+  }
+  /* attribution badge */
+  .commentary-track-img .img-attr {
+    position: absolute;
+    bottom: 4px;
+    right: 6px;
+    font-size: 8px;
+    font-weight: var(--fw-medium);
+    color: rgba(255,255,255,0.45);
+    z-index: 1;
+    letter-spacing: 0.3px;
+  }
+
+  .commentary-title {
+    font-size: 20px;
+    font-weight: var(--fw-black);
+    line-height: 1.0;
+    margin-bottom: 6px;
+    padding-right: 38px;  /* room for icon */
+  }
+  .commentary-icon {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    width: 28px;
+    height: 28px;
+    opacity: 0.85;
+    transition: opacity 0.4s ease;
+  }
+  .commentary-icon svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+  .commentary-text-scroll {
+    overflow: hidden;
+    flex: 1;
+    min-height: 0;
+    position: relative;
+    /* Fade mask at bottom to hint more text below */
+    -webkit-mask-image: linear-gradient(to bottom, black 85%, transparent 100%);
+    mask-image: linear-gradient(to bottom, black 85%, transparent 100%);
+  }
+  .commentary-text-scroll.no-overflow {
+    -webkit-mask-image: none;
+    mask-image: none;
+  }
+  .commentary-text {
+    font-family: 'Barlow Semi Condensed', var(--ff);
+    font-size: 15px;
+    font-weight: var(--fw-medium);
+    line-height: 1.2;
+    color: var(--text-primary);
+  }
+  .commentary-text.scrolling {
+    animation: commentaryScroll var(--scroll-duration, 8s) linear 2s infinite;
+  }
+  @keyframes commentaryScroll {
+    0%   { transform: translateY(0); }
+    20%  { transform: translateY(0); }          /* hold at top for first 20% */
+    80%  { transform: translateY(var(--scroll-distance, 0px)); }  /* scroll to bottom */
+    95%  { transform: translateY(var(--scroll-distance, 0px)); }  /* hold at bottom */
+    100% { transform: translateY(0); }          /* snap back to top */
+  }
+  .commentary-meta {
+    display: none;
+  }
+
+  /* ── Commentary Data Visualization ── */
+  .commentary-viz {
+    position: relative;
+    width: 100%;
+    height: 0;
+    overflow: hidden;
+    opacity: 0;
+    margin-top: 0;
+    transition: height 0.4s cubic-bezier(0.22, 1, 0.36, 1),
+                opacity 0.35s ease 0.05s,
+                margin-top 0.4s ease;
+  }
+  .commentary-viz.viz-active {
+    height: 86px;
+    opacity: 1;
+    margin-top: 10px;
+    overflow: visible;
+  }
+  .commentary-viz[data-viz-type="quad"].viz-active {
+    height: 78px;
+  }
+  .commentary-viz[data-viz-type="counter"].viz-active {
+    height: 46px;
+  }
+  .commentary-viz[data-viz-type="gforce"].viz-active {
+    height: 96px;
+  }
+  .commentary-viz[data-viz-type="bar"].viz-active {
+    height: 52px;
+  }
+  .commentary-viz[data-viz-type="delta"].viz-active {
+    height: 52px;
+  }
+  .commentary-viz[data-viz-type="grid"].viz-active {
+    height: 78px;
+  }
+  .commentary-viz[data-viz-type="incident"].viz-active {
+    height: 78px;
+  }
+  #commentaryVizCanvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+  .commentary-viz-value {
+    position: absolute;
+    bottom: 4px;
+    right: 0;
+    font-family: var(--ff-mono);
+    font-size: 11px;
+    font-weight: var(--fw-bold);
+    color: var(--text-primary);
+    opacity: 0.85;
+    text-shadow: 0 1px 3px hsla(0, 0%, 0%, 0.6);
+    pointer-events: none;
+  }
+  .commentary-viz[data-viz-type="counter"] .commentary-viz-value {
+    position: relative;
+    bottom: auto;
+    right: auto;
+    text-align: center;
+    font-size: 22px;
+    font-weight: var(--fw-black);
+    line-height: 1;
+    opacity: 1;
+    width: 100%;
+    padding-top: 4px;
+  }
+  .commentary-viz-label {
+    position: absolute;
+    top: 0;
+    left: 0;
+    font-size: 7px;
+    font-weight: var(--fw-semi);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-dim);
+    pointer-events: none;
+  }
+  .commentary-viz[data-viz-type="counter"] .commentary-viz-label {
+    position: relative;
+    text-align: center;
+    width: 100%;
+  }
+
+  /* ── MAIN AREA ── */
+  .main-area {
+    display: flex;
+    flex-direction: row;
+    gap: var(--gap);
+    align-items: stretch;
+    height: 100%;
+  }
+
+  /* ── Stacked column blocks ── */
+  .fuel-tyres-col {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap);
+    flex-shrink: 0;
+  }
+  .controls-pedals-block {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap);
+    flex-shrink: 0;
+    /* 50% wider than fuel-tyres-col (160px) */
+    width: 240px;
+  }
+
+  /* ── CYCLING ── */
+  .cycle-container { position: relative; overflow: hidden; }
+  .cycle-page {
+    transition: opacity 1s ease;
+    position: absolute;
+    inset: 0;
+    padding: var(--pad);
+  }
+  .cycle-page.active { opacity: 1; z-index: 2; }
+  .cycle-page.inactive { opacity: 0; z-index: 1; }
+  .cycle-sizer { visibility: hidden; position: relative; padding: var(--pad); }
+  .cycle-dots {
+    position: absolute;
+    bottom: 3px;
+    left: 0; right: 0;
+    display: flex;
+    justify-content: center;
+    gap: 3px;
+    z-index: 5;
+  }
+  .cycle-dot {
+    width: 3px; height: 3px;
+    border-radius: 50%;
+    background: hsla(0,0%,100%,0.2);
+    transition: background 0.3s;
+  }
+  .cycle-dot.active { background: hsla(0,0%,100%,0.6); }
+
+  /* ═══════════════════════════════════════════════
+     COL: LOGO (two stacked squares)
+     ═══════════════════════════════════════════════ */
+  .logo-col {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap);
+    flex-shrink: 0;
+  }
+  .logo-square {
+    position: relative;
+    background: var(--bg-logo);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: var(--row-h);
+    height: var(--row-h);
+    border-radius: 0;
+    border: 1px solid var(--border);
+    flex-shrink: 0;
+    overflow: hidden;
+  }
+  /* Manufacturer country flag — WebGL cloth ripple behind logo */
+  .mfr-flag-canvas {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 0;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 1s ease-out;
+  }
+  .mfr-flag-canvas.flag-visible { opacity: 1; }
+  .car-logo-icon { position: relative; z-index: 1; }
+  .car-model-label { position: relative; z-index: 1; }
+  .logo-col .logo-square:first-child {
+    border-top-left-radius: var(--corner-r);
+    border-top-right-radius: var(--corner-r);
+  }
+  .logo-col .logo-square:last-child {
+    border-bottom-left-radius: var(--corner-r);
+    border-bottom-right-radius: var(--corner-r);
+  }
+  .logo-square img {
+    width: 56px;
+    height: auto;
+    opacity: 1;
+  }
+  .logo-square svg {
+    width: 60%;
+    height: 60%;
+    opacity: 0.96;
+  }
+  .car-logo-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    flex-shrink: 0;
+  }
+  .car-logo-icon svg {
+    width: 44px;
+    height: 44px;
+    opacity: 0.96;
+  }
+  .car-model-label {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-align: center;
+    white-space: normal;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    max-width: 90%;
+    padding: 0 4px 2px;
+    line-height: 1.15;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    margin-top: 2px;
+  }
+  .car-model-label:empty { display: none; }
+
+  /* ═══════════════════════════════════════════════
+     TACH — gear top-left, RPM top-right, speed+MPH beneath RPM
+     segments fill bottom
+     ═══════════════════════════════════════════════ */
+  .tacho-block {
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+    width: 140px;
+    position: relative;
+  }
+  .tacho-top-row {
+    display: flex;
+    align-items: flex-start;
+    height: var(--row-h);
+    overflow: hidden;
+  }
+  .tacho-gear {
+    font-size: 96px;
+    font-weight: var(--fw-black);
+    line-height: 0.85;
+    text-align: left;
+  }
+  .tacho-speed-cluster {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    margin-left: auto;
+  }
+  .tacho-rpm {
+    font-size: var(--fs-lg);
+    font-weight: var(--fw-bold);
+    font-variant-numeric: tabular-nums; /* TODO: extract to shared numeric-display class */
+    transition: color 0.2s ease, text-shadow 0.15s ease-out, transform 0.15s ease-out;
+    text-align: right;
+    line-height: 1;
+    margin-top: 2px;
+  }
+  .tacho-rpm.rpm-pulse-green  { text-shadow: 0 0 8px var(--green), 0 0 16px hsla(140, 70%, 50%, 0.3); transform: scale(1.04); }
+  .tacho-rpm.rpm-pulse-yellow { text-shadow: 0 0 8px var(--amber), 0 0 16px hsla(45, 90%, 55%, 0.3); transform: scale(1.04); }
+  .tacho-rpm.rpm-pulse-red    { text-shadow: 0 0 10px var(--red), 0 0 20px hsla(0, 80%, 50%, 0.4); transform: scale(1.06); }
+  .speed-value {
+    font-size: 28px;
+    font-weight: var(--fw-black);
+    line-height: 1;
+    font-variant-numeric: tabular-nums; /* TODO: extract to shared numeric-display class */
+    letter-spacing: -0.01em;
+    text-align: right;
+  }
+  .speed-unit {
+    font-size: var(--fs-xs);
+    font-weight: var(--fw-medium);
+    color: var(--text-dim);
+    text-align: right;
+    line-height: 1;
+  }
+  .tacho-bar-track {
+    display: flex;
+    gap: 2px;
+    flex: 1;
+    align-items: flex-end;
+    margin-top: 4px;
+  }
+  .tacho-seg {
+    flex: 1;
+    border-radius: 2px 2px 0 0;
+    background: hsla(0,0%,100%,0.06);
+    transition: background var(--t-fast), height 60ms linear, box-shadow var(--t-fast);
+    min-height: 2px;
+    height: 2px;
+    position: relative;
+    /* Unlit: subtle inset for depth */
+    border: 1px solid hsla(0,0%,100%,0.04);
+    border-bottom: none;
+  }
+
+  /* ── Lit segment base: convex LED surface via gradient + multi-layer glow ── */
+  .tacho-seg.lit-green {
+    background: linear-gradient(
+      to bottom,
+      hsla(140, 75%, 70%, 0.95) 0%,
+      var(--green) 35%,
+      hsla(140, 80%, 30%, 0.90) 100%
+    );
+    border-color: hsla(140, 60%, 50%, 0.30);
+    box-shadow:
+      inset 0  1px 0 hsla(140, 80%, 85%, 0.40),   /* top highlight */
+      inset 0 -1px 2px hsla(140, 80%, 20%, 0.50),  /* bottom shadow */
+      0 0 4px hsla(140, 70%, 50%, 0.35),            /* outer glow */
+      0 0 10px hsla(140, 70%, 50%, 0.12);           /* diffuse glow */
+    opacity: 1;
+  }
+  .tacho-seg.lit-yellow {
+    background: linear-gradient(
+      to bottom,
+      hsla(45, 95%, 75%, 0.95) 0%,
+      var(--amber) 35%,
+      hsla(40, 90%, 28%, 0.90) 100%
+    );
+    border-color: hsla(45, 80%, 50%, 0.30);
+    box-shadow:
+      inset 0  1px 0 hsla(45, 90%, 88%, 0.45),
+      inset 0 -1px 2px hsla(40, 80%, 20%, 0.50),
+      0 0 5px hsla(45, 85%, 55%, 0.40),
+      0 0 12px hsla(45, 85%, 55%, 0.15);
+    opacity: 1;
+  }
+  .tacho-seg.lit-red {
+    background: linear-gradient(
+      to bottom,
+      hsla(0, 85%, 65%, 0.95) 0%,
+      var(--red) 35%,
+      hsla(0, 80%, 25%, 0.90) 100%
+    );
+    border-color: hsla(0, 70%, 50%, 0.35);
+    box-shadow:
+      inset 0  1px 0 hsla(0, 80%, 80%, 0.45),
+      inset 0 -1px 2px hsla(0, 80%, 18%, 0.55),
+      0 0 6px hsla(0, 80%, 50%, 0.45),
+      0 0 14px hsla(0, 80%, 50%, 0.18);
+    opacity: 1;
+  }
+  .tacho-seg.lit-redline {
+    background: linear-gradient(
+      to bottom,
+      hsla(0, 90%, 72%, 1.0) 0%,
+      var(--red) 30%,
+      hsla(0, 85%, 28%, 0.95) 100%
+    );
+    border-color: hsla(0, 80%, 50%, 0.50);
+    box-shadow:
+      inset 0  1px 0 hsla(0, 85%, 85%, 0.55),
+      inset 0 -1px 2px hsla(0, 85%, 18%, 0.60),
+      0 0 8px hsla(0, 85%, 50%, 0.55),
+      0 0 18px hsla(0, 85%, 50%, 0.25);
+    animation: redline-pulse 0.3s ease-in-out infinite alternate;
+  }
+  @keyframes redline-pulse { 0%{opacity:.84} 100%{opacity:1} }
+
+  /* ── Pit limiter engaged — blue glow on entire tacho module ── */
+  .tacho-block.pit-limiter-engaged {
+    box-shadow:
+      inset 0 0 22px hsla(210, 90%, 55%, 0.25),
+      0 0 8px 2px hsla(210, 90%, 55%, 0.15);
+    animation: pit-limiter-pulse 1.2s ease-in-out infinite alternate;
+  }
+  @keyframes pit-limiter-pulse {
+    0%   {
+      border-color: hsla(210, 80%, 55%, 0.30);
+      box-shadow: inset 0 0 18px hsla(210, 90%, 55%, 0.18), 0 0 6px 1px hsla(210, 90%, 55%, 0.10);
+    }
+    100% {
+      border-color: hsla(210, 80%, 55%, 0.55);
+      box-shadow: inset 0 0 26px hsla(210, 90%, 55%, 0.30), 0 0 12px 3px hsla(210, 90%, 55%, 0.20);
+    }
+  }
+  /* Blue-tinted lit segments when pit limiter is engaged */
+  .tacho-block.pit-limiter-engaged .tacho-seg.lit-green,
+  .tacho-block.pit-limiter-engaged .tacho-seg.lit-yellow,
+  .tacho-block.pit-limiter-engaged .tacho-seg.lit-red,
+  .tacho-block.pit-limiter-engaged .tacho-seg.lit-redline {
+    background: linear-gradient(
+      to bottom,
+      hsla(210, 80%, 70%, 0.95) 0%,
+      hsla(210, 85%, 50%, 1.0) 35%,
+      hsla(210, 80%, 28%, 0.90) 100%
+    );
+    border-color: hsla(210, 70%, 55%, 0.35);
+    box-shadow:
+      inset 0  1px 0 hsla(210, 80%, 85%, 0.45),
+      inset 0 -1px 2px hsla(210, 80%, 20%, 0.50),
+      0 0 5px hsla(210, 85%, 55%, 0.40),
+      0 0 12px hsla(210, 85%, 55%, 0.15);
+    animation: none;
+  }
+  /* Gear + speed text goes blue */
+  .tacho-block.pit-limiter-engaged .tacho-gear,
+  .tacho-block.pit-limiter-engaged .speed-value {
+    color: hsl(210, 85%, 65%);
+    text-shadow: 0 0 10px hsla(210, 90%, 55%, 0.4);
+  }
+  .tacho-block.pit-limiter-engaged .tacho-rpm {
+    color: hsl(210, 80%, 60%) !important;
+    text-shadow: 0 0 8px hsla(210, 90%, 55%, 0.35) !important;
+  }
+
+  .tacho-block.tacho-redline {
+    box-shadow: inset 0 0 24px hsla(0, 85%, 50%, 0.30), 0 0 6px 1px hsla(0, 85%, 50%, 0.12);
+    animation: tacho-redline-flash 0.25s ease-in-out infinite alternate;
+  }
+  @keyframes tacho-redline-flash {
+    0%   {
+      border-color: hsla(0, 80%, 50%, 0.4);
+      box-shadow: inset 0 0 20px hsla(0, 85%, 50%, 0.22), 0 0 4px 0px hsla(0, 85%, 50%, 0.08);
+    }
+    100% {
+      border-color: hsla(0, 80%, 50%, 0.65);
+      box-shadow: inset 0 0 28px hsla(0, 85%, 50%, 0.35), 0 0 10px 2px hsla(0, 85%, 50%, 0.18);
+    }
+  }
+
+  /* WebGL FX overlay canvases */
+  .gl-overlay {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 10;
+    border-radius: inherit;
+  }
+
+  /* ═══════════════════════════════════════════════
+     POSITION/RATING + GAPS
+     ═══════════════════════════════════════════════ */
+  .pos-gaps-col {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap);
+    flex-shrink: 0;
+    min-width: 150px;
+    width: max-content;
+  }
+  .rating-pos-block {
+    width: 100%;
+    flex: 1;
+  }
+  .rating-value {
+    font-size: 22px;
+    font-weight: var(--fw-black);
+    line-height: 1;
+    letter-spacing: 0;
+  }
+  .rating-delta {
+    font-size: var(--fs-sm);
+    font-weight: var(--fw-semi);
+    margin-top: 2px;
+  }
+  .rating-delta.positive { color: var(--green); }
+  .rating-delta.negative { color: var(--red); }
+  .rating-row {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+  }
+  .rating-item { flex: 1; text-align: center; }
+
+  /* iRating horizontal bar */
+  .ir-bar-container {
+    margin-top: 4px;
+  }
+  .ir-bar-track {
+    position: relative;
+    height: 8px;
+    background: hsla(0,0%,100%,0.06);
+    border-radius: 2px;
+    overflow: visible;
+  }
+  .ir-bar-fill {
+    height: 100%;
+    border-radius: 2px;
+    background: linear-gradient(90deg, hsl(200,60%,40%), hsl(200,70%,55%));
+    transition: width var(--t-med);
+  }
+  .ir-bar-ticks {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+  .ir-bar-tick {
+    position: absolute;
+    top: -2px;
+    bottom: -2px;
+    width: 1px;
+    background: hsla(0,0%,100%,0.25);
+  }
+  .ir-bar-tick-label {
+    position: absolute;
+    top: 10px;
+    font-size: 6px;
+    font-weight: var(--fw-medium);
+    color: var(--text-dim);
+    transform: translateX(-50%);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Safety Rating pie chart */
+  .sr-pie-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: 2px;
+  }
+  .sr-pie-svg {
+    width: 36px;
+    height: 36px;
+  }
+  .sr-pie-bg {
+    fill: none;
+    stroke: hsla(0,0%,100%,0.06);
+    stroke-width: 5;
+  }
+  .sr-pie-fill {
+    fill: none;
+    stroke-width: 5;
+    stroke-linecap: round;
+    transition: stroke-dashoffset var(--t-med), stroke var(--t-med);
+    transform: rotate(-90deg);
+    transform-origin: center;
+  }
+  /* sr-pie-text removed */
+
+  .pos-layout {
+    display: flex;
+    align-items: baseline;
+    gap: 4px;
+    height: 100%;
+  }
+  .pos-number {
+    font-size: 44px;
+    font-weight: var(--fw-black);
+    line-height: 1;
+    letter-spacing: -0.01em;
+    text-align: left;
+    flex-shrink: 0;
+  }
+  .skew-accent { transform: skewX(-6deg); display: inline-block; }
+  .pos-delta {
+    font-size: 11px;
+    font-weight: var(--fw-bold);
+    letter-spacing: 0.02em;
+    text-align: left;
+    margin-top: 2px;
+    opacity: 0;
+    transition: opacity 0.4s ease, color 0.4s ease;
+  }
+  .pos-delta.visible { opacity: 1; }
+  .pos-delta.delta-up   { color: hsl(145, 50%, 55%); }
+  .pos-delta.delta-down { color: hsl(0, 50%, 60%); }
+  .pos-delta.delta-same { color: var(--text-secondary); opacity: 0; }
+  .pos-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    margin-left: auto;
+    padding-top: 2px;
+    min-width: 0;
+    overflow: hidden;
+  }
+  .pos-meta-row {
+    font-size: var(--fs-sm);
+    font-weight: var(--fw-medium);
+    color: var(--text-secondary);
+    text-align: right;
+  }
+  .pos-meta-row:first-child {
+    font-size: 14px;
+    font-weight: var(--fw-semi);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .pos-meta-row:first-child .val {
+    font-size: 22px;
+  }
+  .pos-meta-row .val {
+    font-weight: var(--fw-bold);
+    color: var(--text-primary);
+  }
+  .pos-meta-row .val.purple { color: var(--purple); }
+  .pos-meta-row .val.green  { color: var(--green); }
+  .pos-meta-row.current-row {
+    font-size: 16px;
+    font-weight: var(--fw-semi);
+    text-align: center;
+    width: 100%;
+  }
+  .pos-meta-row.current-row .val {
+    font-family: var(--ff-mono);
+    font-size: 18px;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    display: block;
+    text-align: center;
+  }
+  .pos-meta-row.delta-row {
+    text-align: center;
+    width: 100%;
+    min-height: 14px;
+  }
+  .pos-meta-row.delta-row .val {
+    font-family: var(--ff-mono);
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    display: block;
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    transition: color 0.2s ease;
+  }
+  .pos-meta-row.delta-row .val.delta-faster { color: var(--green); }
+  .pos-meta-row.delta-row .val.delta-slower { color: hsl(0, 60%, 55%); }
+  .pos-meta-row.delta-row .val.delta-pb     { color: var(--purple); }
+
+  /* Gaps — side-by-side */
+  .gaps-block {
+    display: flex;
+    flex-direction: row;
+    gap: 3px;
+    flex: 1;
+  }
+
+  /* F1-style sector indicator (shown during practice/qualifying/testing) */
+  .sector-indicator {
+    display: flex;
+    flex-direction: row;
+    gap: 3px;
+    flex: 1;
+    width: 100%;
+  }
+  .sector-cell {
+    flex: 1;
+    text-align: center;
+    padding: 6px 4px;
+    border-radius: var(--corner-r-sm);
+    background: hsla(0,0%,100%,0.03);
+    transition: background 0.3s, color 0.3s;
+  }
+  .sector-label {
+    font-size: 9px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: hsla(0,0%,100%,0.35);
+    margin-bottom: 2px;
+  }
+  .sector-time {
+    font-family: var(--ff-mono);
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+  .sector-delta {
+    font-family: var(--ff-mono);
+    font-size: 10px;
+    font-weight: 600;
+    color: hsla(0,0%,100%,0.35);
+    margin-top: 1px;
+  }
+  .sector-cell.sector-pb {
+    background: hsla(280,60%,45%,0.4);
+  }
+  .sector-cell.sector-pb .sector-time { color: hsl(280,80%,78%); }
+  .sector-cell.sector-pb .sector-delta { color: hsl(280,80%,78%); }
+  .sector-cell.sector-faster {
+    background: hsla(130,55%,40%,0.4);
+  }
+  .sector-cell.sector-faster .sector-time { color: hsl(130,75%,72%); }
+  .sector-cell.sector-faster .sector-delta { color: hsl(130,75%,72%); }
+  .sector-cell.sector-slower {
+    background: hsla(45,80%,40%,0.35);
+  }
+  .sector-cell.sector-slower .sector-time { color: hsl(45,95%,68%); }
+  .sector-cell.sector-slower .sector-delta { color: hsl(45,95%,68%); }
+  .sector-cell.sector-invalid {
+    background: hsla(0,65%,45%,0.4);
+  }
+  .sector-cell.sector-invalid .sector-time { color: hsl(0,80%,72%); }
+  .sector-cell.sector-invalid .sector-delta { color: hsl(0,80%,72%); }
+  .sector-cell.sector-active {
+    border: 1px solid hsla(0,0%,100%,0.15);
+  }
+  .gap-item {
+    flex: 1;
+    text-align: center;
+    padding: 4px;
+    border-radius: var(--corner-r-sm);
+    position: relative;
+    overflow: hidden;
+    transition: all var(--t-med);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 1px;
+  }
+  .gap-item::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    opacity: 0;
+    pointer-events: none;
+  }
+  .gap-item.ahead-changed::after { animation: value-flash 1.4s ease-out forwards; }
+  .gap-item.ahead-changed { --flash-color: hsla(123, 60%, 45%, 0.16); }
+  .gap-item.behind-changed::after { animation: value-flash 1.4s ease-out forwards; }
+  .gap-item.behind-changed { --flash-color: hsla(15, 80%, 50%, 0.16); }
+  .gap-item.gap-closing::after  { animation: value-flash 1.4s ease-out forwards; }
+  .gap-item.gap-closing  { --flash-color: hsla(0, 65%, 50%, 0.18); }
+  .gap-item.gap-growing::after  { animation: value-flash 1.4s ease-out forwards; }
+  .gap-item.gap-growing  { --flash-color: hsla(123, 55%, 45%, 0.14); }
+
+  .gap-driver {
+    font-size: var(--fs-xs);
+    font-weight: var(--fw-medium);
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .gap-time {
+    font-family: var(--ff-mono);
+    font-size: 17px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.1;
+    letter-spacing: -0.02em;
+    white-space: nowrap;
+  }
+  .gap-time.ahead { color: var(--green); }
+  .gap-time.behind { color: var(--red); }
+  .gap-ir {
+    font-size: var(--fs-xs);
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* ── Flag status overlay on gaps block ── */
+  .gaps-block.flag-active .gap-item {
+    transition: background 0.4s ease, border-color 0.4s ease;
+  }
+  .gap-normal {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1px;
+    width: 100%;
+    flex: 1;
+  }
+  .gaps-block { position: relative; }
+  .gaps-block.flag-active .gap-item { visibility: hidden; }
+  .gaps-block.flag-active .flag-overlay { display: flex; }
+  .flag-overlay {
+    display: none;
+    position: absolute;
+    inset: 0;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    z-index: 3;
+    border-radius: inherit;
+  }
+  .flag-label {
+    font-size: 17px;
+    font-weight: var(--fw-black);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    line-height: 1.1;
+  }
+  .flag-context {
+    font-size: var(--fs-xs);
+    opacity: 0.75;
+    text-align: center;
+    line-height: 1.2;
+  }
+  .flag-gl {
+    display: none;
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 1;
+    border-radius: inherit;
+  }
+  .gaps-block.flag-active .flag-gl { display: block; }
+
+  /* Flag color themes — redline-style inset glow with slow pulse on the block itself */
+  .gaps-block.flag-active {
+    transition: box-shadow 0.4s ease, border-color 0.4s ease;
+  }
+
+  /* ── Yellow / Caution — WebGL flag background ── */
+  .gaps-block.flag-yellow {
+    animation: flag-glow-yellow 3.5s ease-in-out infinite alternate;
+    border: 1px dashed;
+    border-image: repeating-linear-gradient(90deg, hsl(48, 95%, 55%) 0 8px, hsl(0, 0%, 92%) 8px 16px) 1;
+  }
+  .gaps-block.flag-yellow .flag-label { color: hsl(48, 95%, 65%); }
+  .gaps-block.flag-yellow .flag-context { color: hsl(48, 80%, 70%); }
+  @keyframes flag-glow-yellow {
+    0%   { box-shadow: inset 0 0 18px hsla(48, 95%, 50%, 0.60), 0 0 10px hsla(48, 95%, 50%, 0.30); }
+    100% { box-shadow: inset 0 0 30px hsla(48, 95%, 50%, 1.0), 0 0 20px hsla(48, 95%, 50%, 0.66); }
+  }
+
+  /* ── Red Flag — WebGL flag background ── */
+  .gaps-block.flag-red {
+    animation: flag-glow-red 3.5s ease-in-out infinite alternate;
+    border: 1px dashed;
+    border-image: repeating-linear-gradient(90deg, hsl(0, 85%, 55%) 0 8px, hsl(0, 75%, 30%) 8px 16px) 1;
+  }
+  .gaps-block.flag-red .flag-label { color: hsl(0, 90%, 65%); }
+  .gaps-block.flag-red .flag-context { color: hsl(0, 70%, 75%); }
+  @keyframes flag-glow-red {
+    0%   { box-shadow: inset 0 0 18px hsla(0, 85%, 50%, 0.66), 0 0 10px hsla(0, 85%, 50%, 0.36); }
+    100% { box-shadow: inset 0 0 30px hsla(0, 85%, 50%, 1.0), 0 0 20px hsla(0, 85%, 50%, 0.75); }
+  }
+
+  /* ── Blue Flag — WebGL flag background ── */
+  .gaps-block.flag-blue {
+    animation: flag-glow-blue 3.5s ease-in-out infinite alternate;
+    border: 1px dashed;
+    border-image: repeating-linear-gradient(90deg, hsl(220, 80%, 60%) 0 8px, hsl(220, 70%, 30%) 8px 16px) 1;
+  }
+  .gaps-block.flag-blue .flag-label { color: hsl(220, 85%, 68%); }
+  .gaps-block.flag-blue .flag-context { color: hsl(220, 65%, 75%); }
+  @keyframes flag-glow-blue {
+    0%   { box-shadow: inset 0 0 18px hsla(220, 80%, 55%, 0.60), 0 0 10px hsla(220, 80%, 55%, 0.30); }
+    100% { box-shadow: inset 0 0 30px hsla(220, 80%, 55%, 1.0), 0 0 20px hsla(220, 80%, 55%, 0.66); }
+  }
+
+  /* ── Green Flag — WebGL flag background ── */
+  .gaps-block.flag-green {
+    animation: flag-glow-green 3.5s ease-in-out infinite alternate;
+  }
+  .gaps-block.flag-green .flag-label { color: hsl(130, 75%, 58%); }
+  .gaps-block.flag-green .flag-context { color: hsl(130, 55%, 70%); }
+  @keyframes flag-glow-green {
+    0%   { box-shadow: inset 0 0 18px hsla(130, 70%, 45%, 0.60), 0 0 10px hsla(130, 70%, 45%, 0.30); border-color: hsla(130, 70%, 45%, 0.75); }
+    100% { box-shadow: inset 0 0 30px hsla(130, 70%, 45%, 1.0), 0 0 20px hsla(130, 70%, 45%, 0.66); border-color: hsla(130, 70%, 45%, 1.0); }
+  }
+
+  /* ── White Flag — WebGL flag background ── */
+  .gaps-block.flag-white {
+    animation: flag-glow-white 3.5s ease-in-out infinite alternate;
+  }
+  .gaps-block.flag-white .flag-label { color: hsl(0, 0%, 92%); }
+  .gaps-block.flag-white .flag-context { color: hsl(0, 0%, 75%); }
+  @keyframes flag-glow-white {
+    0%   { box-shadow: inset 0 0 14px hsla(0, 0%, 90%, 0.45), 0 0 8px hsla(0, 0%, 90%, 0.24); border-color: hsla(0, 0%, 90%, 0.54); }
+    100% { box-shadow: inset 0 0 26px hsla(0, 0%, 90%, 0.90), 0 0 16px hsla(0, 0%, 90%, 0.48); border-color: hsla(0, 0%, 90%, 1.0); }
+  }
+
+  /* ── Debris — WebGL flag background ── */
+  .gaps-block.flag-debris {
+    animation: flag-glow-debris 3.5s ease-in-out infinite alternate;
+    border: 1px dashed;
+    border-image: repeating-linear-gradient(90deg, hsl(48, 90%, 55%) 0 8px, hsl(0, 80%, 50%) 8px 16px) 1;
+  }
+  .gaps-block.flag-debris .flag-label { color: hsl(45, 90%, 65%); }
+  .gaps-block.flag-debris .flag-context { color: hsl(30, 70%, 70%); }
+  @keyframes flag-glow-debris {
+    0%   { box-shadow: inset 0 0 18px hsla(35, 80%, 50%, 0.45), 0 0 10px hsla(0, 80%, 50%, 0.24); }
+    100% { box-shadow: inset 0 0 30px hsla(35, 80%, 50%, 0.90), 0 0 20px hsla(0, 80%, 50%, 0.45); }
+  }
+
+  /* ── Checkered — WebGL flag background ── */
+  .gaps-block.flag-checkered {
+    animation: flag-glow-checkered 3.5s ease-in-out infinite alternate;
+    border: 1px dashed;
+    border-image: repeating-linear-gradient(90deg, hsl(0, 0%, 95%) 0 8px, hsl(0, 0%, 20%) 8px 16px) 1;
+  }
+  .gaps-block.flag-checkered .flag-label { color: #fff; }
+  .gaps-block.flag-checkered .flag-context { color: hsl(0, 0%, 80%); }
+  @keyframes flag-glow-checkered {
+    0%   { box-shadow: inset 0 0 14px hsla(0, 0%, 100%, 0.36), 0 0 8px hsla(0, 0%, 100%, 0.18); }
+    100% { box-shadow: inset 0 0 26px hsla(0, 0%, 100%, 0.84), 0 0 16px hsla(0, 0%, 100%, 0.42); }
+  }
+
+  /* ── Black Flag — WebGL flag background ── */
+  .gaps-block.flag-black {
+    animation: flag-glow-black 3.5s ease-in-out infinite alternate;
+    border: 1px dashed;
+    border-image: repeating-linear-gradient(90deg, hsl(0, 0%, 12%) 0 8px, hsl(0, 75%, 40%) 8px 16px) 1;
+  }
+  .gaps-block.flag-black .flag-label { color: hsl(0, 80%, 58%); }
+  .gaps-block.flag-black .flag-context { color: hsl(0, 50%, 65%); }
+  @keyframes flag-glow-black {
+    0%   { box-shadow: inset 0 0 18px hsla(0, 80%, 40%, 0.45), 0 0 8px hsla(0, 80%, 40%, 0.24); }
+    100% { box-shadow: inset 0 0 28px hsla(0, 80%, 40%, 1.0), 0 0 16px hsla(0, 80%, 40%, 0.54); }
+  }
+
+  /* ── Meatball Flag — red circles on black, repair required ── */
+  .gaps-block.flag-meatball {
+    animation: flag-glow-meatball 2.5s ease-in-out infinite alternate;
+    border: 1px dashed;
+    border-image: repeating-linear-gradient(90deg, hsl(0, 85%, 50%) 0 8px, hsl(0, 0%, 8%) 8px 16px) 1;
+  }
+  .gaps-block.flag-meatball .flag-label { color: hsl(0, 90%, 62%); }
+  .gaps-block.flag-meatball .flag-context { color: hsl(0, 70%, 72%); }
+  @keyframes flag-glow-meatball {
+    0%   { box-shadow: inset 0 0 18px hsla(0, 90%, 45%, 0.50), 0 0 8px hsla(0, 90%, 45%, 0.28); }
+    100% { box-shadow: inset 0 0 30px hsla(0, 90%, 45%, 1.0), 0 0 18px hsla(0, 90%, 45%, 0.60); }
+  }
+
+  /* ── Orange Flag — lapped car ahead must yield ── */
+  .gaps-block.flag-orange {
+    animation: flag-glow-orange 3.5s ease-in-out infinite alternate;
+  }
+  .gaps-block.flag-orange .flag-label { color: hsl(30, 95%, 58%); }
+  .gaps-block.flag-orange .flag-context { color: hsl(30, 80%, 68%); }
+  @keyframes flag-glow-orange {
+    0%   { box-shadow: 0 0 0px hsla(30, 95%, 55%, 0); }
+    100% { box-shadow: 0 0 20px hsla(30, 95%, 55%, 0.45); }
+  }
+
+  /* ═══════════════════════════════════════════════
+     RACE TIMER MODULE
+     ═══════════════════════════════════════════════ */
+  .timer-row {
+    display: flex;
+    overflow: hidden;
+    max-height: 0;
+    transition: max-height 0.4s ease;
+  }
+  .timer-row.timer-visible {
+    max-height: 80px;
+  }
+  /* Right corners (RTL): timer aligns right, offset past logo + tacho */
+  .dashboard.layout-tr .timer-row,
+  .dashboard.layout-br .timer-row {
+    justify-content: flex-end;
+    padding-right: calc(var(--row-h) + 140px + var(--gap) * 2);
+  }
+  /* Left corners (LTR): timer aligns left, offset past logo + tacho */
+  .dashboard.layout-tl .timer-row,
+  .dashboard.layout-bl .timer-row,
+  .dashboard.layout-ac .timer-row {
+    justify-content: flex-start;
+    padding-left: calc(var(--row-h) + 140px + var(--gap) * 2);
+  }
+
+  .race-timer-block {
+    width: 150px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-end;
+    padding: 6px 8px;
+  }
+  .race-timer-value {
+    font-family: var(--ff-mono);
+    font-size: 26px;
+    font-weight: 700;
+    color: #FFFFFF;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: -0.03em;
+  }
+  .race-timer-lap {
+    font-family: var(--ff-mono);
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+    line-height: 1.2;
+    margin-top: 3px;
+    letter-spacing: -0.02em;
+  }
+  .race-timer-lap .timer-label {
+    font-family: var(--ff);
+    font-weight: var(--fw-semi);
+    color: var(--text-secondary);
+    margin-right: 3px;
+    letter-spacing: 0;
+  }
+
+  /* ═══════════════════════════════════════════════
+     MAPS — stacked
+     ═══════════════════════════════════════════════ */
+  .maps-col {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap);
+    flex-shrink: 0;
+    width: 96px;
+  }
+  .map-panel {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+  }
+  .map-svg { width: 92%; height: 92%; }
+  .map-track {
+    fill: none;
+    stroke: hsla(0,0%,100%,0.35);
+    stroke-width: 3;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+  .map-sector {
+    fill: none;
+    stroke: transparent;
+    stroke-width: 3.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    pointer-events: none;
+    transition: stroke 0.3s;
+  }
+  .map-player {
+    fill: var(--map-player-color, var(--cyan));
+    transition: fill 0.4s ease;
+    filter: drop-shadow(0 0 2px hsla(0,0%,100%,0.7))
+            drop-shadow(0 0 4px var(--map-player-color, var(--cyan)));
+    animation: map-player-pulse 2s ease-in-out infinite;
+  }
+  @keyframes map-player-pulse {
+    0%, 100% {
+      filter: drop-shadow(0 0 2px hsla(0,0%,100%,0.7))
+              drop-shadow(0 0 4px var(--map-player-color, var(--cyan)));
+    }
+    50% {
+      filter: drop-shadow(0 0 3px hsla(0,0%,100%,0.9))
+              drop-shadow(0 0 6px var(--map-player-color, var(--cyan)))
+              drop-shadow(0 0 10px var(--map-player-color, var(--cyan)));
+    }
+  }
+  .map-gforce-trail {
+    pointer-events: none;
+    opacity: 0.8;
+    transition: stroke 0.15s ease;
+  }
+  .map-opponent { fill: hsla(0,0%,100%,0.35); }
+  .map-opponent.close { fill: var(--orange); }
+
+  /* Pulse animation for nearby opponents */
+  @keyframes map-opponent-pulse {
+    0%, 100% {
+      opacity: 0.7;
+      filter: none;
+    }
+    50% {
+      opacity: 1;
+      filter: drop-shadow(0 0 3px hsla(0,70%,60%,0.6));
+    }
+  }
+  .map-opponent.map-opponent-near {
+    animation: map-opponent-pulse 1.5s ease-in-out infinite;
+  }
+
+  /* SVG radial glow pulse behind player dot */
+  @keyframes map-glow-pulse {
+    0%, 100% { r: 10; opacity: 0.8; }
+    50% { r: 14; opacity: 1; }
+  }
+
+  .map-zoom-panel {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    position: relative;
+  }
+  .map-zoom-svg {
+    width: 280px;
+    height: 280px;
+  }
+  .map-zoom-label {
+    position: absolute;
+    bottom: 4px;
+    left: 0; right: 0;
+    text-align: center;
+    font-size: var(--fs-xs);
+    color: var(--text-dim);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  /* ═══════════════════════════════════════════════
+     ═══════════════════════════════════════════════ */
+
+
+/* ── modules/styles/leaderboard.css ── */
+  /* ═══════════════════════════════════════════════
+     CONTROLS + LAYERED PEDALS
+     ═══════════════════════════════════════════════ */
+  .controls-pedals-block {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap);
+    flex-shrink: 0;
+    width: 240px;
+  }
+
+  .car-controls {
+    display: flex;
+    gap: var(--gap);
+    flex: 1;
+  }
+  .ctrl-item {
+    flex: 1;
+    text-align: center;
+    padding: 4px;
+    border-radius: var(--corner-r-sm);
+    background: hsla(0,0%,100%,0.03);
+    border: 1px solid transparent;
+    transition: all var(--t-med);
+    position: relative;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+  }
+  .ctrl-item::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    opacity: 0;
+    pointer-events: none;
+  }
+  .ctrl-item.changed::after { animation: value-flash 1.4s ease-out forwards; }
+  @keyframes value-flash {
+    0%   { background: var(--flash-color, hsla(45,100%,60%,0.22)); }
+    100% { background: transparent; }
+  }
+  .ctrl-item { --flash-color: hsla(45, 80%, 55%, 0.18); --ctrl-pct: 0%; }
+  .ctrl-item::before {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: var(--ctrl-pct);
+    background: hsla(0,0%,100%,0.04);
+    pointer-events: none;
+    transition: height var(--t-med);
+  }
+  .ctrl-label {
+    font-size: var(--fs-xs);
+    font-weight: var(--fw-semi);
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    position: relative;
+    z-index: 1;
+  }
+  .ctrl-value {
+    font-size: 22px;
+    font-weight: var(--fw-black);
+    position: relative;
+    z-index: 1;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  /* Per-control bar colors */
+  #ctrlBB::before  { background: hsla(355, 75%, 33%, 0.12); }
+  #ctrlTC::before  { background: hsla(215, 75%, 33%, 0.12); }
+  #ctrlABS::before { background: hsla(48, 80%, 33%, 0.12); }
+  #ctrlBB .ctrl-value  { color: hsl(355, 80%, 65%); }
+  #ctrlTC .ctrl-value  { color: hsl(215, 80%, 68%); }
+  #ctrlABS .ctrl-value { color: hsl(48, 85%, 62%); }
+  #ctrlBB .ctrl-label  { color: hsl(355, 50%, 55%); }
+  #ctrlTC .ctrl-label  { color: hsl(215, 50%, 58%); }
+  #ctrlABS .ctrl-label { color: hsl(48, 55%, 52%); }
+
+  /* Control bar change flash — brightens the fill bar and value */
+  .ctrl-item.ctrl-changed::before {
+    background: hsla(0, 0%, 100%, 0.14) !important;
+    transition: none !important;
+  }
+  .ctrl-item.ctrl-changed .ctrl-value {
+    filter: brightness(1.4);
+  }
+  @keyframes ctrl-bar-flash {
+    0%   { filter: brightness(1.4); }
+    100% { filter: brightness(1.0); }
+  }
+  .ctrl-item.ctrl-flash-out::before {
+    transition: background 1.2s ease !important;
+  }
+  .ctrl-item.ctrl-flash-out .ctrl-value {
+    animation: ctrl-bar-flash 1.2s ease forwards;
+  }
+
+  /* ABS/TC system activity glow — background pulse on the adjustments bar */
+  .ctrl-item.ctrl-active::after {
+    opacity: 1 !important;
+  }
+  #ctrlABS.ctrl-active { background: hsla(48, 80%, 55%, 0.23); }
+  #ctrlTC.ctrl-active  { background: hsla(215, 75%, 55%, 0.23); }
+  #ctrlBB.ctrl-active  { background: hsla(355, 75%, 55%, 0.23); }
+
+  /* Hidden controls (car doesn't have TC/ABS) */
+  .ctrl-item.ctrl-hidden { display: none; }
+  .ctrl-value-fixed {
+    opacity: 0.5 !important;
+    font-size: 14px !important;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  /* "No Adjustments" fallback when all controls are hidden */
+  .ctrl-no-adj {
+    display: none;
+    flex: 1;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    font-size: 11px;
+    font-weight: var(--fw-bold);
+    letter-spacing: 0.08em;
+    color: hsla(0, 0%, 100%, 0.25);
+    text-transform: uppercase;
+  }
+  .car-controls.no-adj .ctrl-no-adj {
+    display: flex;
+  }
+
+  /* Layered pedals — all three histograms overlaid */
+  .pedals-area {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    position: relative;
+  }
+  .pedal-labels-row {
+    display: flex;
+    gap: 6px;
+    justify-content: space-around;
+  }
+  .pedal-label-group {
+    text-align: center;
+  }
+  .pedal-channel-label {
+    font-size: var(--fs-xs);
+    font-weight: var(--fw-semi);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .pedal-channel-label.throttle { color: var(--green); }
+  .pedal-channel-label.brake { color: var(--red); }
+  .pedal-channel-label.clutch { color: var(--blue); }
+  .pedal-pct {
+    font-size: var(--fs-xs);
+    font-weight: var(--fw-bold);
+    font-variant-numeric: tabular-nums;
+    line-height: 1.1;
+  }
+  .pedal-viz-stack {
+    flex: 1;
+    position: relative;
+  }
+  .pedal-viz-layer {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    gap: 1px;
+    align-items: stretch;
+  }
+  .pedal-viz-layer.throttle-layer { z-index: 1; }
+  .pedal-viz-layer.brake-layer { z-index: 2; flex-direction: row-reverse; }
+  .pedal-viz-layer.clutch-layer { z-index: 3; }
+  .pedal-hist-bar {
+    flex: 1;
+    height: 100%;
+    border-radius: 1px 1px 0 0;
+    transform-origin: bottom;
+    transform: scaleY(0.01);
+    transition: transform 60ms linear;
+    will-change: transform;
+  }
+  .pedal-hist-bar.throttle { background: var(--green); opacity: 0.54; }
+  .pedal-hist-bar.brake { background: var(--red); opacity: 0.66; }
+  .pedal-hist-bar.clutch { background: var(--blue); opacity: 0.54; }
+  .pedal-hist-bar.live { opacity: 1; flex: 0 0 4px; border-radius: 2px; }
+
+  /* Pedal trace — smooth waveform overlay on histograms */
+  .pedal-trace-canvas {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 4;
+    pointer-events: none;
+    opacity: 0.85;
+  }
+
+  /* ── Pedal curve overlay (response curves fill histogram area) ── */
+  .pedal-curve-canvas {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 5;
+    pointer-events: none;
+    opacity: 0.55;
+    transition: opacity 300ms ease;
+  }
+  .pedal-curve-canvas.no-profile { display: none; }
+  .pedal-trace-canvas.no-profile { display: none; }
+  .pedals-area:hover .pedal-curve-canvas {
+    opacity: 0.85;
+  }
+  .pedal-profile-label {
+    position: absolute;
+    bottom: 1px;
+    right: 4px;
+    font-size: 8px;
+    font-weight: 600;
+    color: hsla(0, 0%, 100%, 0.3);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    white-space: nowrap;
+    z-index: 5;
+    pointer-events: none;
+  }
+
+  /* ═══════════════════════════════════════════════
+     FUEL + TYRES (separate stacked panels)
+     ═══════════════════════════════════════════════ */
+  .fuel-tyres-col {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap);
+    flex-shrink: 0;
+    width: 160px;
+  }
+  .fuel-block, .tyres-block {
+    flex: 1;
+  }
+
+  .fuel-remaining {
+    font-size: 22px;
+    font-weight: var(--fw-black);
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+    text-align: center;
+    margin-bottom: 2px;
+  }
+  .fuel-remaining .unit {
+    font-size: var(--fs-lg);
+    font-weight: var(--fw-semi);
+    color: var(--text-secondary);
+  }
+  .fuel-bar-outer {
+    height: 8px;
+    border-radius: 2px;
+    background: hsla(0,0%,100%,0.06);
+    position: relative;
+    overflow: hidden;
+    margin-bottom: 3px;
+  }
+  .fuel-bar-inner {
+    height: 100%;
+    border-radius: 2px;
+    transition: width var(--t-med), background var(--t-med);
+  }
+  .fuel-bar-inner.healthy { background: linear-gradient(90deg, hsl(123,45%,35%), hsl(123,50%,45%)); }
+  .fuel-bar-inner.caution { background: linear-gradient(90deg, hsl(35,90%,40%), hsl(45,100%,50%)); }
+  .fuel-bar-inner.critical { background: linear-gradient(90deg, hsl(0,70%,35%), hsl(0,70%,50%)); animation: fuel-warn 1s ease-in-out infinite alternate; }
+  @keyframes fuel-warn { 0%{opacity:.84} 100%{opacity:1} }
+  .fuel-bar-pit-marker {
+    position: absolute;
+    top: 0; bottom: 0;
+    width: 2px;
+    background: var(--text-primary);
+    opacity: 0.84;
+  }
+  .fuel-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2px 6px;
+    font-size: var(--fs-xs);
+    font-weight: var(--fw-medium);
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+    justify-content: center;
+  }
+  .fuel-stats .val { font-weight: var(--fw-bold); color: var(--text-primary); }
+  .fuel-pit-suggest {
+    font-size: var(--fs-xs);
+    font-weight: var(--fw-bold);
+    color: var(--amber);
+    margin-top: 2px;
+    text-align: center;
+  }
+
+  .tyre-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 3px;
+  }
+  .tyre-cell {
+    font-size: 13px;
+    font-weight: var(--fw-black);
+    text-align: center;
+    padding: 3px 2px;
+    border-radius: 4px;
+    font-variant-numeric: tabular-nums;
+    border: 1px solid hsla(0,0%,100%,0.05);
+  }
+  .tyre-cell.cold { color: hsl(200,70%,60%); border-color: hsla(200,70%,60%,0.15); }
+  .tyre-cell.optimal { color: var(--green); border-color: hsla(123,40%,50%,0.15); }
+  .tyre-cell.hot { color: var(--amber); border-color: hsla(45,100%,50%,0.12); }
+  .tyre-cell.danger { color: var(--red); border-color: hsla(0,70%,50%,0.15); }
+  .tyre-label {
+    font-size: 6px;
+    color: var(--text-dim);
+    text-align: center;
+  }
+  .tyre-wear-bar {
+    height: 5px;
+    border-radius: 3px;
+    background: hsla(0,0%,100%,0.08);
+    margin-top: 2px;
+  }
+  .tyre-wear-fill {
+    height: 100%;
+    border-radius: 2px;
+    background: var(--green);
+  }
+
+  /* ═══════════════════════════════════════════════
+     LEADERBOARD PANEL
+     ═══════════════════════════════════════════════ */
+  .leaderboard-panel {
+    width: 310px;
+    transition: opacity 0.4s ease;
+    flex-shrink: 0;
+  }
+  .leaderboard-panel.section-hidden { display: none; }
+  /* Position offsets removed — now handled by .sec-container flex layout */
+
+  .lb-inner {
+    background: hsla(0, 0%, 5%, 0.90);
+    border: 1px solid hsla(0, 0%, 100%, 0.14);
+    border-radius: 8px;
+    padding: 6px 0;
+    overflow: hidden;
+  }
+  .lb-header {
+    font-size: 9px;
+    font-weight: var(--fw-bold);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: hsla(0, 0%, 100%, 0.35);
+    padding: 2px 10px 5px;
+    border-bottom: 1px solid hsla(0, 0%, 100%, 0.12);
+  }
+  .lb-row {
+    display: grid;
+    grid-template-columns: 22px 1fr 54px 44px 52px;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 10px;
+    font-size: 11px;
+    font-variant-numeric: tabular-nums; /* TODO: extract to shared numeric-display class (used 17 times total) */
+    border-bottom: 1px solid hsla(0, 0%, 100%, 0.06);
+    transition: background 0.3s ease;
+    position: relative;
+  }
+  .lb-row:last-child { border-bottom: none; }
+  .lb-row.lb-player {
+    background: hsla(195, 80%, 30%, 0.20);
+    border-left: 2px solid var(--cyan);
+    padding-left: 8px;
+    transition: background 0.6s ease, border-color 0.6s ease;
+  }
+  .lb-row.lb-player.lb-p1 {
+    background: hsla(42, 70%, 27%, 0.24);
+    border-left-color: hsla(42, 80%, 55%, 1.0);
+  }
+  .lb-row.lb-player.lb-ahead {
+    background: hsla(145, 70%, 25%, 0.20);
+    border-left-color: hsla(145, 75%, 50%, 1.0);
+  }
+  .lb-row.lb-player.lb-behind {
+    background: hsla(0, 70%, 30%, 0.20);
+    border-left-color: hsla(0, 75%, 50%, 1.0);
+  }
+  .lb-row.lb-player.lb-same {
+    background: hsla(210, 70%, 30%, 0.20);
+    border-left-color: hsla(210, 75%, 55%, 1.0);
+  }
+  .lb-row.lb-start-pos {
+    background: hsla(0, 0%, 100%, 0.10);
+    border-left: 2px solid hsla(0, 0%, 100%, 0.20);
+    padding-left: 8px;
+    border-top: 1px solid hsla(0, 0%, 100%, 0.10);
+    border-bottom: 1px solid hsla(0, 0%, 100%, 0.10);
+  }
+  .lb-row.lb-pit { opacity: 0.45; }
+  .lb-pos {
+    font-weight: var(--fw-black);
+    color: var(--text-dim);
+    text-align: center;
+    font-size: 12px;
+  }
+  .lb-row.lb-player .lb-pos { color: var(--cyan); }
+  .lb-row.lb-player.lb-p1 .lb-pos { color: hsla(42, 80%, 60%, 1.0); }
+  .lb-row.lb-player.lb-ahead .lb-pos { color: hsla(145, 75%, 55%, 1.0); }
+  .lb-row.lb-player.lb-behind .lb-pos { color: hsla(0, 75%, 55%, 1.0); }
+  .lb-row.lb-player.lb-same .lb-pos { color: hsla(210, 75%, 60%, 1.0); }
+  .lb-name {
+    font-weight: var(--fw-semi);
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .lb-row.lb-player .lb-name { color: var(--text-primary); font-weight: var(--fw-bold); }
+  .lb-ir {
+    font-size: 10px;
+    color: var(--text-dim);
+    text-align: right;
+  }
+  .lb-gap {
+    font-family: var(--ff-mono);
+    font-size: 9px;
+    text-align: right;
+    font-weight: 500;
+    letter-spacing: -0.03em;
+  }
+  .lb-gap.gap-ahead { color: var(--green); }
+  .lb-gap.gap-behind { color: var(--red); }
+  .lb-gap.gap-player { color: var(--cyan); }
+  .lb-lap {
+    font-family: var(--ff-mono);
+    font-size: 9px;
+    text-align: right;
+    font-weight: 500;
+    color: var(--text-dim);
+    letter-spacing: -0.03em;
+  }
+  .lb-lap.lap-pb { color: hsla(270, 80%, 65%, 1.0); }
+  .lb-lap.lap-fast { color: var(--green); }
+  .lb-lap.lap-slow { color: hsla(45, 90%, 55%, 1.0); }
+  /* WebGL player highlight canvas */
+  .lb-gl {
+    position: absolute;
+    left: 0; right: 0;
+    top: 0; bottom: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 0;
+    border-radius: inherit;
+  }
+  .lb-inner { position: relative; }
+  /* Sparkline canvas */
+  .lb-spark {
+    position: absolute;
+    right: 10px;
+    bottom: 0;
+    width: 48px;
+    height: 16px;
+    opacity: 0.5;
+  }
+
+  /* ═══════════════════════════════════════════════
+     ═══════════════════════════════════════════════ */
+
+
+/* ── modules/styles/connections.css ── */
+  /* ═══════════════════════════════════════════════
+     CONNECTIONS TAB
+     ═══════════════════════════════════════════════ */
+  .conn-card {
+    background: hsla(0,0%,100%,0.04);
+    border: 1px solid hsla(0,0%,100%,0.08);
+    border-radius: 8px;
+    padding: 14px;
+    margin-bottom: 10px;
+  }
+  .conn-card-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 10px;
+  }
+  .conn-card-icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+  .conn-card-icon.simhub { background: hsla(210, 60%, 50%, 0.2); }
+  .conn-card-icon.discord { background: hsla(235, 86%, 65%, 0.2); }
+  .conn-card-icon svg { width: 18px; height: 18px; }
+  .conn-card-title {
+    font-size: 13px;
+    font-weight: 700;
+    color: hsla(0,0%,100%,0.9);
+  }
+  .conn-card-subtitle {
+    font-size: 10px;
+    color: hsla(0,0%,100%,0.4);
+    margin-top: 1px;
+  }
+  .conn-card-status {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 0;
+  }
+  .conn-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .conn-dot.green { background: #4caf50; box-shadow: 0 0 6px rgba(76,175,80,0.4); }
+  .conn-dot.red { background: #f44336; box-shadow: 0 0 6px rgba(244,67,54,0.3); }
+  .conn-dot.orange { background: #ff9800; box-shadow: 0 0 6px rgba(255,152,0,0.3); }
+  .conn-dot.blue { background: #5865F2; box-shadow: 0 0 6px rgba(88,101,242,0.3); }
+  .conn-status-text {
+    font-size: 11px;
+    color: hsla(0,0%,100%,0.7);
+  }
+  .conn-status-text strong { font-weight: 600; color: hsla(0,0%,100%,0.9); }
+  .conn-card-detail {
+    font-size: 10px;
+    color: hsla(0,0%,100%,0.35);
+    margin-top: 4px;
+    line-height: 1.4;
+  }
+  .conn-card-actions {
+    margin-top: 10px;
+    display: flex;
+    gap: 8px;
+  }
+  .conn-btn {
+    padding: 6px 14px;
+    border: none;
+    border-radius: 6px;
+    font-size: 11px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: opacity 0.2s, transform 0.1s;
+    font-family: var(--ff);
+  }
+  .conn-btn:hover { opacity: 0.85; }
+  .conn-btn:active { transform: scale(0.97); }
+  .conn-btn.discord-btn {
+    background: #5865F2;
+    color: #fff;
+  }
+  .conn-btn.discord-btn:disabled {
+    background: hsla(235, 50%, 45%, 0.5);
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+  .conn-btn.disconnect-btn {
+    background: hsla(0,0%,100%,0.08);
+    color: hsla(0, 75%, 60%, 0.9);
+    border: 1px solid hsla(0, 75%, 60%, 0.2);
+  }
+  .conn-btn.invite-btn {
+    background: hsla(0,0%,100%,0.06);
+    color: hsla(0,0%,100%,0.6);
+    border: 1px solid hsla(0,0%,100%,0.1);
+  }
+  .conn-user-info {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 0;
+  }
+  .conn-user-avatar {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: hsla(235, 60%, 55%, 0.3);
+    overflow: hidden;
+  }
+  .conn-user-avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+  .conn-user-name {
+    font-size: 12px;
+    font-weight: 600;
+    color: hsla(0,0%,100%,0.85);
+  }
+  .conn-user-id {
+    font-size: 9px;
+    color: hsla(0,0%,100%,0.3);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* ── Rally Mode ─────────────────────────────────────────────── */
+
+
+/* ── modules/styles/datastream.css ── */
+  /* ═══════════════════════════════════════════════
+     RACE TIMELINE STRIP
+     ═══════════════════════════════════════════════ */
+  .race-timeline {
+    margin-top: 4px;
+    border-radius: 6px;
+    overflow: hidden;
+    background: hsla(0, 0%, 5%, 0.90);
+    border: 1px solid hsla(0, 0%, 100%, 0.14);
+    padding: 2px;
+  }
+  .rt-canvas {
+    display: block;
+    width: 100%;
+    height: 9px;
+    border-radius: 3px;
+  }
+
+  /* ═══════════════════════════════════════════════
+     DATASTREAM PANEL
+     ═══════════════════════════════════════════════ */
+  .datastream-panel {
+    width: 200px;
+    transition: opacity 0.4s ease;
+    flex-shrink: 0;
+  }
+  .datastream-panel.section-hidden { display: none; }
+  /* Position offsets removed — now handled by .sec-container flex layout */
+
+  .ds-inner {
+    background: hsla(0, 0%, 5%, 0.90);
+    border: 1px solid hsla(0, 0%, 100%, 0.14);
+    border-radius: 8px;
+    padding: 6px 10px 8px;
+    position: relative;
+  }
+  .ds-header {
+    font-size: 9px;
+    font-weight: var(--fw-bold);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: hsla(0, 0%, 100%, 0.35);
+    padding-bottom: 5px;
+    border-bottom: 1px solid hsla(0, 0%, 100%, 0.06);
+    margin-bottom: 6px;
+  }
+
+  /* G-force diamond */
+  .ds-gforce {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 6px;
+  }
+  .ds-gforce-diamond {
+    position: relative;
+    width: 64px;
+    height: 64px;
+    flex-shrink: 0;
+  }
+  .ds-gforce-diamond canvas {
+    width: 100%;
+    height: 100%;
+  }
+  .ds-gforce-vals {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  /* Data rows */
+  .ds-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 2px 0;
+    border-bottom: 1px solid hsla(0, 0%, 100%, 0.03);
+  }
+  .ds-row:last-child { border-bottom: none; }
+  .ds-label {
+    font-size: 9px;
+    font-weight: var(--fw-semi);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: hsla(0, 0%, 100%, 0.35);
+  }
+  .ds-value {
+    font-family: var(--ff-mono);
+    font-size: 11px;
+    font-weight: var(--fw-semi);
+    color: var(--text-secondary);
+    letter-spacing: -0.02em;
+    text-align: right;
+  }
+  .ds-value.ds-positive { color: hsla(0, 70%, 55%, 1.0); }
+  .ds-value.ds-negative { color: hsla(145, 65%, 50%, 1.0); }
+  .ds-value.ds-neutral  { color: var(--text-dim); }
+
+
+  /* Yaw rate mini bar */
+  .ds-yaw-bar {
+    height: 3px;
+    background: hsla(0, 0%, 100%, 0.06);
+    border-radius: 2px;
+    margin-top: 2px;
+    position: relative;
+    overflow: hidden;
+  }
+  .ds-yaw-fill {
+    position: absolute;
+    top: 0;
+    height: 100%;
+    border-radius: 2px;
+    background: hsla(210, 70%, 55%, 0.7);
+    transition: left 0.1s, width 0.1s;
+  }
+
+  /* Yaw trail canvas — subtle waveform showing turn shape */
+  .ds-yaw-trail {
+    width: 100%;
+    height: 28px;
+    margin-top: 2px;
+    opacity: 0.7;
+    border-radius: 3px;
+  }
+
+  /* Datastream value-change highlights */
+  .ds-value.ds-flash {
+    animation: ds-val-flash 1.2s ease forwards;
+  }
+  @keyframes ds-val-flash {
+    0%   { filter: brightness(1.8); text-shadow: 0 0 6px currentColor; }
+    100% { filter: brightness(1.0); }
+  }
+
+  /* ═══════════════════════════════════════════════
+     INCIDENTS MODULE
+     ═══════════════════════════════════════════════ */
+  .incidents-panel {
+    position: fixed;
+    z-index: 50;
+    width: fit-content;
+    transition: opacity 0.4s ease;
+  }
+  .incidents-panel.section-hidden { display: none; }
+  .incidents-panel.inc-bottom { bottom: var(--edge-z, var(--edge)); }
+  .incidents-panel.inc-top { top: var(--edge-z, var(--edge)); }
+  .incidents-panel.inc-right { right: var(--edge-z, var(--edge)); }
+  .incidents-panel.inc-left { left: var(--edge-z, var(--edge)); }
+
+  .inc-gl-canvas {
+    position: absolute;
+    inset: -8px;
+    width: calc(100% + 16px);
+    height: calc(100% + 16px);
+    pointer-events: none;
+    z-index: 0;
+    border-radius: 12px;
+    opacity: 0;
+    transition: opacity 0.4s ease;
+  }
+  .incidents-panel.inc-bonkers .inc-gl-canvas { opacity: 1; }
+
+  .inc-inner {
+    position: relative;
+    z-index: 1;
+    background: hsla(0, 0%, 5%, 0.90);
+    border: 1px solid hsla(0, 0%, 100%, 0.14);
+    border-radius: 8px;
+    padding: 4px 8px 6px;
+    text-align: center;
+    transition: background 0.4s ease, border-color 0.4s ease;
+  }
+  .inc-label {
+    font-size: 9px;
+    font-weight: var(--fw-bold);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: hsla(0, 0%, 100%, 0.35);
+    padding-bottom: 3px;
+    border-bottom: 1px solid hsla(0, 0%, 100%, 0.06);
+    margin-bottom: 3px;
+  }
+  .inc-value-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: center;
+    gap: 6px;
+  }
+  .inc-count {
+    font-size: 56px;
+    font-weight: var(--fw-bold);
+    letter-spacing: -0.02em;
+    color: hsl(145, 65%, 50%);
+    transition: color 0.4s ease;
+    line-height: 1;
+  }
+  .inc-x {
+    font-size: 28px;
+    font-weight: var(--fw-semi);
+    color: hsla(0, 0%, 100%, 0.25);
+    line-height: 1;
+  }
+
+  /* Progressive color escalation: green → yellow → orange → red */
+  .incidents-panel.inc-level-0 .inc-count { color: hsl(145, 65%, 50%); }
+  .incidents-panel.inc-level-1 .inc-count { color: hsl(90, 60%, 50%); }
+  .incidents-panel.inc-level-2 .inc-count { color: hsl(48, 80%, 55%); }
+  .incidents-panel.inc-level-3 .inc-count { color: hsl(30, 80%, 52%); }
+  .incidents-panel.inc-level-4 .inc-count { color: hsl(8, 75%, 52%); }
+  .incidents-panel.inc-level-5 .inc-count { color: hsl(0, 80%, 50%); }
+
+  /* Border + background escalation */
+  .incidents-panel.inc-level-0 .inc-inner { border-color: hsla(145, 50%, 40%, 0.24); }
+  .incidents-panel.inc-level-1 .inc-inner { border-color: hsla(90, 50%, 40%, 0.30); }
+  .incidents-panel.inc-level-2 .inc-inner { border-color: hsla(48, 60%, 40%, 0.36); }
+  .incidents-panel.inc-level-3 .inc-inner { border-color: hsla(30, 65%, 40%, 0.40); background: hsla(30, 40%, 8%, 1.0); }
+  .incidents-panel.inc-level-4 .inc-inner { border-color: hsla(8, 65%, 40%, 0.50); background: hsla(8, 40%, 8%, 1.0); }
+  .incidents-panel.inc-level-5 .inc-inner { border-color: hsla(0, 70%, 40%, 0.60); background: hsla(0, 45%, 8%, 1.0); }
+
+  /* Threshold rows — penalty / DQ remaining */
+  .inc-thresholds {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin-top: 4px;
+    padding-top: 4px;
+    border-top: 1px solid hsla(0, 0%, 100%, 0.06);
+  }
+  .inc-thresh-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 4px;
+    font-size: 12px;
+    font-weight: var(--fw-medium);
+    letter-spacing: 0.04em;
+    color: hsla(0, 0%, 100%, 0.35);
+  }
+  .inc-thresh-val {
+    font-weight: var(--fw-semi);
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    color: hsla(0, 0%, 100%, 0.50);
+    transition: color 0.4s ease;
+  }
+  .inc-thresh-val.thresh-near { color: hsl(48, 80%, 55%); }
+  .inc-thresh-val.thresh-crit { color: hsl(0, 75%, 55%); }
+  .inc-thresh-val.thresh-hit  { color: hsl(0, 80%, 50%); font-weight: var(--fw-black); }
+
+  /* Incident progress bar — accrued vs penalty vs DQ */
+  .inc-progress {
+    margin-top: 4px;
+    padding: 0 1px;
+  }
+  .inc-bar-track {
+    position: relative;
+    width: 100%;
+    height: 6px;
+    background: hsla(0, 0%, 100%, 0.08);
+    border-radius: 3px;
+    overflow: visible;
+  }
+  .inc-bar-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    border-radius: 3px;
+    min-width: 0;
+    transition: width 0.5s cubic-bezier(0.22, 1, 0.36, 1),
+                background 0.4s ease;
+    background: hsl(145, 65%, 45%);
+  }
+  /* Fill color follows incident level */
+  .incidents-panel.inc-level-0 .inc-bar-fill { background: hsl(145, 65%, 45%); }
+  .incidents-panel.inc-level-1 .inc-bar-fill { background: hsl(90, 60%, 45%); }
+  .incidents-panel.inc-level-2 .inc-bar-fill { background: hsl(48, 75%, 50%); }
+  .incidents-panel.inc-level-3 .inc-bar-fill { background: hsl(30, 75%, 48%); }
+  .incidents-panel.inc-level-4 .inc-bar-fill { background: hsl(8, 70%, 48%); }
+  .incidents-panel.inc-level-5 .inc-bar-fill { background: hsl(0, 75%, 45%); }
+
+  .inc-bar-marker {
+    position: absolute;
+    top: -2px;
+    width: 2px;
+    height: 10px;
+    border-radius: 1px;
+    transition: left 0.3s ease;
+  }
+  .inc-marker-pen {
+    background: hsl(48, 80%, 55%);
+    opacity: 0.7;
+  }
+  .inc-marker-dq {
+    background: hsl(0, 75%, 55%);
+    opacity: 0.7;
+  }
+
+  /* Flash on increment */
+  @keyframes inc-flash {
+    0%   { filter: brightness(1.6); transform: scale(1.06); }
+    100% { filter: brightness(1.0); transform: scale(1.0); }
+  }
+  .inc-count.inc-flash {
+    animation: inc-flash 0.8s ease forwards;
+  }
+
+  /* ═══════════════════════════════════════════════
+     ═══════════════════════════════════════════════ */
+
+
+/* ── modules/styles/pitbox.css ── */
+  /* ═══════════════════════════════════════════════
+     PIT BOX PANEL — Driver panel: tyres, fuel, weather, setup, camera
+     Tabbed interface matching the dashboard glass panel aesthetic.
+     ═══════════════════════════════════════════════ */
+  .pitbox-panel {
+    width: 230px;
+    transition: opacity 0.4s ease;
+    flex-shrink: 0;
+  }
+  .pitbox-panel.section-hidden { display: none; }
+  .pitbox-panel.pb-dismissed { opacity: 0; pointer-events: none; }
+
+  .pb-inner {
+    background: hsla(0, 0%, 5%, 0.90);
+    border: 1px solid hsla(0, 0%, 100%, 0.14);
+    border-radius: 8px;
+    padding: 0;
+    font-family: 'Barlow Condensed', sans-serif;
+    overflow: hidden;
+  }
+
+  /* ── Tab bar ── */
+  .pb-tabs {
+    display: flex;
+    border-bottom: 1px solid hsla(0, 0%, 100%, 0.08);
+    background: hsla(0, 0%, 100%, 0.02);
+  }
+  .pb-tab {
+    flex: 1;
+    text-align: center;
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    padding: 7px 2px;
+    color: hsla(0, 0%, 100%, 0.35);
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s;
+    border-bottom: 2px solid transparent;
+  }
+  .pb-tab:hover {
+    color: hsla(0, 0%, 100%, 0.6);
+    background: hsla(0, 0%, 100%, 0.03);
+  }
+  .pb-tab.active {
+    color: hsla(0, 0%, 100%, 0.9);
+    border-bottom-color: var(--green, #4ade80);
+  }
+
+  /* ── Page container ── */
+  .pb-content { position: relative; }
+  .pb-page {
+    display: none;
+    padding: 8px 10px 10px;
+  }
+  .pb-page.active { display: block; }
+
+  /* ── Section dividers ── */
+  .pb-section-label {
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: var(--text-dim, hsla(0, 0%, 100%, 0.4));
+    margin-bottom: 4px;
+  }
+  .pb-divider {
+    height: 1px;
+    background: hsla(0, 0%, 100%, 0.06);
+    margin: 6px 0;
+  }
+
+  /* ── Key-value rows ── */
+  .pb-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 2px 0;
+    font-size: 12px;
+    line-height: 1.4;
+    position: relative;
+  }
+  .pb-row.hidden { display: none; }
+  .pb-label {
+    color: hsla(0, 0%, 100%, 0.55);
+    font-weight: 500;
+  }
+  .pb-value {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    font-weight: 600;
+    color: hsla(0, 0%, 100%, 0.9);
+    text-align: right;
+  }
+  .pb-value.active  { color: var(--green, #4ade80); }
+  .pb-value.inactive { color: hsla(0, 0%, 100%, 0.25); }
+  .pb-value.on  { color: var(--orange, #ff8c00); }
+  .pb-value.off { color: hsla(0, 0%, 100%, 0.25); }
+
+  /* ── Tire grid (2×2 layout) ── */
+  .pb-tire-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 3px 10px;
+  }
+  .pb-tire-cell {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    padding: 2px 0;
+    position: relative;
+  }
+  .pb-tire-pos {
+    font-weight: 600;
+    font-size: 10px;
+    color: hsla(0, 0%, 100%, 0.5);
+    min-width: 18px;
+  }
+  .pb-tire-status {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 9px;
+    font-weight: 600;
+  }
+  .pb-tire-status.changing { color: var(--green, #4ade80); }
+  .pb-tire-status.keeping {
+    color: hsla(0, 0%, 100%, 0.2);
+    font-size: 9px;
+  }
+  .pb-tire-pressure {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    color: hsla(0, 0%, 100%, 0.7);
+    margin-left: auto;
+  }
+  .pb-tire-temp {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    color: hsla(0, 0%, 100%, 0.8);
+    margin-left: auto;
+  }
+
+  /* ── Tyre wear bars ── */
+  .pb-tire-bar {
+    flex: 1;
+    height: 4px;
+    background: hsla(0, 0%, 100%, 0.08);
+    border-radius: 2px;
+    overflow: hidden;
+    margin: 0 4px;
+  }
+  .pb-tire-bar-fill {
+    height: 100%;
+    border-radius: 2px;
+    background: var(--green, #4ade80);
+    transition: width 0.4s ease, background 0.4s ease;
+    width: 0%;
+  }
+  .pb-tire-bar-fill.warn { background: var(--orange, #ff8c00); }
+  .pb-tire-bar-fill.crit { background: #ef4444; }
+  .pb-tire-pct {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    color: hsla(0, 0%, 100%, 0.7);
+    min-width: 28px;
+    text-align: right;
+  }
+
+  /* ── Fuel gauge ── */
+  .pb-fuel-gauge {
+    text-align: center;
+    margin-bottom: 8px;
+    padding: 6px 0;
+  }
+  .pb-fuel-bar-bg {
+    height: 6px;
+    background: hsla(0, 0%, 100%, 0.08);
+    border-radius: 3px;
+    overflow: hidden;
+    margin-bottom: 6px;
+  }
+  .pb-fuel-bar-fill {
+    height: 100%;
+    border-radius: 3px;
+    background: var(--green, #4ade80);
+    transition: width 0.4s ease, background 0.4s ease;
+    width: 0%;
+  }
+  .pb-fuel-bar-fill.warn { background: var(--orange, #ff8c00); }
+  .pb-fuel-bar-fill.crit { background: #ef4444; }
+  .pb-fuel-level {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 22px;
+    font-weight: 700;
+    color: white;
+    line-height: 1.1;
+  }
+  .pb-fuel-unit {
+    font-size: 10px;
+    font-weight: 500;
+    color: hsla(0, 0%, 100%, 0.4);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  /* ── Weather hero ── */
+  .pb-weather-hero {
+    text-align: center;
+    padding: 10px 0 8px;
+  }
+  .pb-weather-icon {
+    font-size: 28px;
+    line-height: 1;
+    margin-bottom: 4px;
+  }
+  .pb-weather-temp {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 26px;
+    font-weight: 700;
+    color: white;
+    line-height: 1.1;
+  }
+
+  /* ── Car adjustments compact grid ── */
+  .pb-adj-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1px 10px;
+  }
+  .pb-adj-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 2px 0;
+    position: relative;
+  }
+  .pb-adj-item.hidden { display: none; }
+  .pb-adj-label {
+    font-size: 10px;
+    font-weight: 500;
+    color: hsla(0, 0%, 100%, 0.45);
+  }
+  .pb-adj-val {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    font-weight: 600;
+    color: hsla(0, 0%, 100%, 0.8);
+  }
+  .pb-adj-val.zero { color: hsla(0, 0%, 100%, 0.2); }
+
+  /* ── Info text ── */
+  .pb-info {
+    font-size: 10px;
+    color: hsla(0, 0%, 100%, 0.25);
+    font-style: italic;
+    text-align: center;
+    padding: 10px 0 4px;
+    line-height: 1.4;
+  }
+
+  /* ── Change flash animation ── */
+  .pb-flash { position: relative; }
+  .pb-flash::after {
+    content: '';
+    position: absolute;
+    inset: -1px -4px;
+    border-radius: 3px;
+    pointer-events: none;
+    animation: pb-value-flash 1.4s ease-out forwards;
+  }
+  @keyframes pb-value-flash {
+    0%   { background: hsla(45, 100%, 60%, 0.22); }
+    100% { background: transparent; }
+  }
+  .pb-flash .pb-value,
+  .pb-flash .pb-adj-val,
+  .pb-flash .pb-tire-status {
+    filter: brightness(1.5);
+    transition: filter 1.4s ease;
+  }
+
+  /* ── No data state ── */
+  .pb-no-data {
+    text-align: center;
+    font-size: 10px;
+    color: hsla(0, 0%, 100%, 0.3);
+    padding: 8px 10px;
+    font-style: italic;
+  }
+
+  /* ── Green screen mode ── */
+  body.opaque-mode .pitbox-panel { display: none; }
+
+
+/* ── modules/styles/settings.css ── */
+  /* ═══════════════════════════════════════════════
+     SECONDARY PANELS FLEX CONTAINER
+     Wraps leaderboard, datastream, pitbox in a flex row.
+     Flows horizontally from the same corner as the main HUD.
+     Hidden panels collapse, remaining panels reflow automatically.
+     ═══════════════════════════════════════════════ */
+  .sec-container {
+    position: fixed;
+    z-index: 50;
+    display: flex;
+    flex-direction: row;
+    gap: var(--panel-gap);
+    align-items: flex-start;
+    pointer-events: none;
+  }
+  .sec-container > * { pointer-events: auto; }
+
+  /* Vertical edge — uses --edge-z (zoom-compensated) for consistent visual margins */
+  .sec-container.sec-top    { top: var(--edge-z, var(--edge)); }
+  .sec-container.sec-bottom { bottom: var(--edge-z, var(--edge)); align-items: flex-end; }
+
+  /* Horizontal edge — right positions use row-reverse so
+     the first child (leaderboard) stays at the screen edge */
+  .sec-container.sec-right  { right: var(--edge-z, var(--edge)); flex-direction: row-reverse; }
+  .sec-container.sec-left   { left: var(--edge-z, var(--edge)); }
+
+  /* Panels inside container: relative flow, no fixed offsets */
+  .sec-container .leaderboard-panel,
+  .sec-container .datastream-panel,
+  .sec-container .pitbox-panel {
+    position: relative;
+    top: auto; bottom: auto; left: auto; right: auto;
+    margin: 0;
+  }
+
+  /* Minimal: leaderboard only, datastream + pit box hidden */
+  body.sec-minimal .datastream-panel,
+  body.sec-minimal .pitbox-panel { display: none !important; }
+
+  /* ═══════════════════════════════════════════════
+     SETTINGS PANEL
+     ═══════════════════════════════════════════════ */
+
+  /* Connection status indicator — only visible in settings mode */
+  .conn-status {
+    position: absolute;
+    bottom: -28px;
+    right: 0;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: #555;
+    z-index: 9999;
+    transition: background 0.5s, opacity 0.3s;
+    opacity: 0;
+    pointer-events: none;
+  }
+  /* Bottom layouts: dot goes above */
+  .dashboard.layout-br .conn-status,
+  .dashboard.layout-bl .conn-status {
+    bottom: auto;
+    top: -28px;
+  }
+  body.settings-active .conn-status { opacity: 0.96; pointer-events: auto; }
+  .conn-status.connected { background: #4caf50; }
+  .conn-status.disconnected { background: #f44336; animation: conn-pulse 2s infinite; }
+  .conn-status.connecting { background: #ff9800; }
+  @keyframes conn-pulse { 0%,100% { opacity: 0.48; } 50% { opacity: 1; } }
+
+  /* Connection setup banner */
+  .conn-banner {
+    display: none;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(20, 20, 28, 0.95);
+    border: 1px solid rgba(255,255,255,0.12);
+    border-radius: 12px;
+    padding: 28px 32px;
+    z-index: 10001;
+    text-align: center;
+    font-family: var(--ff);
+    color: #ccc;
+    min-width: 340px;
+  }
+  .conn-banner.visible { display: block; }
+  .conn-banner h3 { margin: 0 0 6px; font-size: 15px; color: #fff; font-weight: 600; }
+  .conn-banner p { margin: 0 0 16px; font-size: 16px; color: #888; line-height: 1.5; }
+  .conn-banner input {
+    width: 100%;
+    box-sizing: border-box;
+    background: rgba(255,255,255,0.08);
+    border: 1px solid rgba(255,255,255,0.15);
+    border-radius: 6px;
+    padding: 8px 12px;
+    color: #fff;
+    font-size: 13px;
+    font-family: var(--ff);
+    outline: none;
+    margin-bottom: 12px;
+  }
+  .conn-banner input:focus { border-color: rgba(255,255,255,0.3); }
+  .conn-banner button {
+    background: #4a6cf7;
+    border: none;
+    border-radius: 6px;
+    padding: 8px 24px;
+    color: #fff;
+    font-size: 13px;
+    font-family: var(--ff);
+    cursor: pointer;
+    font-weight: 500;
+  }
+  .conn-banner button:hover { background: #5b7af8; }
+  .conn-banner .conn-skip {
+    background: none;
+    color: #666;
+    font-size: 15px;
+    margin-left: 8px;
+    padding: 8px 12px;
+  }
+  .conn-banner .conn-skip:hover { color: #999; }
+
+  /* Settings-embedded connection warning banner */
+  .settings-conn-warn {
+    display: none;
+    background: hsla(10, 70%, 12%, 0.95);
+    border: 1px solid hsla(10, 80%, 50%, 0.45);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 16px;
+    text-align: left;
+  }
+  .settings-conn-warn.warn-visible { display: block; }
+  .settings-conn-warn .warn-icon {
+    display: inline-block;
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    background: #f44336;
+    margin-right: 8px;
+    animation: conn-pulse 2s infinite;
+    vertical-align: middle;
+  }
+  .settings-conn-warn .warn-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: hsl(10, 80%, 70%);
+    display: inline;
+    vertical-align: middle;
+  }
+  .settings-conn-warn .warn-detail {
+    font-size: 15px;
+    color: hsla(0, 0%, 100%, 0.55);
+    line-height: 1.5;
+    margin-top: 6px;
+  }
+  .settings-conn-warn .warn-url {
+    font-family: var(--ff-mono);
+    font-size: 14px;
+    color: hsla(0, 0%, 100%, 0.40);
+    margin-top: 4px;
+    word-break: break-all;
+  }
+  .conn-banner .conn-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #f44336;
+    margin-right: 6px;
+    vertical-align: middle;
+    animation: conn-pulse 2s infinite;
+  }
+
+  /* ═══════════════════════════════════════════════
+     DRIVER PROFILE PANEL (Ctrl+Shift+V)
+     ═══════════════════════════════════════════════ */
+  .dp-overlay {
+    position: fixed; inset: 0; z-index: 10000;
+    display: none; align-items: center; justify-content: center;
+    background: rgba(0,0,0,0.75);
+    backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px);
+    font-family: var(--ff);
+  }
+  .dp-overlay.open { display: flex; }
+  .dp-panel {
+    background: hsla(230,15%,7%,0.98);
+    border: 1px solid hsla(0,0%,100%,0.1);
+    border-radius: 16px;
+    padding: 28px 32px;
+    width: 90vw; max-width: 960px;
+    max-height: 90vh; overflow-y: auto;
+    color: #e8e8f0;
+  }
+  .dp-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
+  .dp-title { font-size: 24px; font-weight: 800; }
+  .dp-close {
+    width: 36px; height: 36px; border: none; border-radius: 8px;
+    background: hsla(0,0%,100%,0.06); color: hsla(0,0%,100%,0.5);
+    font-size: 20px; cursor: pointer; transition: background 0.15s;
+  }
+  .dp-close:hover { background: hsla(0,0%,100%,0.12); }
+
+  /* 3-column assessment under title */
+  .dp-assess-row { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; margin-bottom: 18px; }
+  .dp-assess-col {
+    font-size: 15px; line-height: 1.6; color: hsla(0,0%,100%,0.6);
+    background: hsla(0,0%,100%,0.03); border-radius: 10px; padding: 14px 16px;
+  }
+  .dp-assess-col strong { color: hsla(0,0%,100%,0.85); }
+
+  /* Big ratings row */
+  .dp-ratings-card { display: flex; gap: 14px; margin-bottom: 16px; }
+  .dp-rating-big {
+    flex: 1; text-align: center;
+    background: hsla(0,0%,100%,0.04); border-radius: 10px; padding: 16px 8px;
+  }
+  .dp-rating-label { font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; color: hsla(0,0%,100%,0.35); margin-bottom: 4px; }
+  .dp-rating-value { font-family: 'JetBrains Mono', monospace; font-size: 36px; font-weight: 700; }
+  .dp-rating-delta { font-family: 'JetBrains Mono', monospace; font-size: 14px; margin-top: 4px; color: hsla(0,0%,100%,0.35); }
+  .dp-rating-delta.positive { color: var(--green); }
+  .dp-rating-delta.negative { color: var(--red); }
+
+  .dp-ir-bar-inline { margin-top: 8px; }
+  .dp-ir-bar-inline .ir-bar-track { height: 4px; }
+  .dp-sr-pie { width: 48px; height: 48px; margin: 8px auto 0; display: block; }
+
+  .dp-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+  .dp-section-title {
+    font-size: 12px; font-weight: 700; text-transform: uppercase;
+    letter-spacing: 0.1em; color: hsla(0,0%,100%,0.4); margin-bottom: 8px;
+  }
+  .dp-chart { width: 100%; border-radius: 8px; background: hsla(0,0%,100%,0.02); }
+  .dp-heatmap { display: flex; flex-wrap: wrap; gap: 6px; }
+  .dp-hm-cell {
+    border-radius: 6px; padding: 6px 10px; font-size: 11px; font-weight: 600;
+    background: hsla(0,0%,100%,0.04); color: hsla(0,0%,100%,0.5);
+    transition: background 0.2s;
+  }
+  .dp-hm-cell .dp-hm-count { font-family: 'JetBrains Mono', monospace; font-size: 13px; font-weight: 700; display: block; }
+  .dp-hm-cell .dp-hm-name { font-size: 9px; display: block; color: hsla(0,0%,100%,0.35); }
+
+  /* ═══════════════════════════════════════════════
+     RATING EDITOR (iRacing tab)
+     ═══════════════════════════════════════════════ */
+  .re-field {
+    margin-bottom: 16px;
+  }
+  .re-field-label {
+    font-size: 15px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: hsla(0,0%,100%,0.5);
+    margin-bottom: 6px;
+  }
+  .re-field-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .re-input {
+    width: 90px;
+    padding: 6px 8px;
+    border-radius: 6px;
+    border: 1px solid hsla(0,0%,100%,0.12);
+    background: hsla(0,0%,100%,0.05);
+    color: #fff;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 14px;
+    font-weight: 600;
+    text-align: center;
+    outline: none;
+  }
+  .re-input:focus { border-color: hsla(260,60%,60%,0.6); }
+  .re-slider {
+    flex: 1;
+    height: 4px;
+    -webkit-appearance: none;
+    appearance: none;
+    background: hsla(0,0%,100%,0.1);
+    border-radius: 2px;
+    outline: none;
+  }
+  .re-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 14px; height: 14px;
+    border-radius: 50%;
+    background: hsl(260,60%,55%);
+    border: 2px solid hsla(0,0%,100%,0.2);
+    cursor: pointer;
+  }
+  .re-field-hint {
+    font-size: 13px;
+    color: hsla(0,0%,100%,0.25);
+    margin-top: 4px;
+  }
+  .re-history {
+    font-size: 14px;
+    color: hsla(0,0%,100%,0.4);
+    margin: 12px 0;
+    max-height: 200px;
+    overflow-y: auto;
+    line-height: 1.6;
+  }
+  .re-history-entry { display: flex; align-items: center; gap: 6px; padding: 3px 0; border-bottom: 1px solid hsla(0,0%,100%,0.04); }
+  .re-history-entry span { flex: 1; }
+  .re-history-del {
+    flex: 0 0 auto;
+    width: 22px; height: 22px;
+    border: none; border-radius: 4px;
+    background: hsla(0,0%,100%,0.06);
+    color: hsla(0,0%,100%,0.3);
+    font-size: 14px; line-height: 22px;
+    text-align: center; cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+    padding: 0;
+  }
+  .re-history-del:hover { background: hsla(0,70%,50%,0.25); color: hsla(0,80%,65%,0.9); }
+  .re-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 16px;
+  }
+  .re-btn {
+    flex: 1;
+    padding: 8px 0;
+    border: none;
+    border-radius: 8px;
+    font-size: 16px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+  .re-btn-save { background: hsl(260,55%,48%); color: #fff; }
+  .re-btn-save:hover { background: hsl(260,55%,55%); }
+  .re-btn-reset { background: hsla(0,0%,100%,0.08); color: hsla(0,0%,100%,0.6); }
+  .re-btn-reset:hover { background: hsla(0,0%,100%,0.12); }
+  .re-btn-close { background: hsla(0,0%,100%,0.05); color: hsla(0,0%,100%,0.4); }
+  .re-btn-close:hover { background: hsla(0,0%,100%,0.08); }
+
+  .settings-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 9998;
+    display: none;
+    font-family: var(--ff);
+    align-items: center;
+    justify-content: center;
+    background: hsla(0,0%,0%,0.5);
+  }
+  .settings-overlay.open { display: flex; }
+
+  /* ── Popout mode: settings fill the entire window ── */
+  body.settings-popout { background: #1a1a1a !important; }
+  body.settings-popout .settings-overlay {
+    display: flex;
+    background: none;
+  }
+  body.settings-popout .settings-panel {
+    width: 100%;
+    max-height: 100vh;
+    border: none;
+    border-radius: 0;
+    background: #1a1a1a;
+  }
+  body.settings-popout .settings-close { display: none; }
+  /* Hide all dashboard content in popout */
+  body.settings-popout #mainContainer,
+  body.settings-popout #secContainer,
+  body.settings-popout .gl-overlay,
+  body.settings-popout .game-logo,
+  body.settings-popout .drive-hud { display: none !important; }
+
+  .settings-panel {
+    background: hsla(0,0%,6%,0.97);
+    border: 1px solid hsla(0,0%,100%,0.10);
+    border-radius: 12px;
+    width: 720px;
+    max-height: 80vh;
+    color: white;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 24px 80px rgba(0,0,0,0.6);
+    overflow: hidden;
+  }
+  /* Draggable title bar */
+  .settings-titlebar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 20px 10px;
+    cursor: grab;
+    user-select: none;
+    border-bottom: 1px solid hsla(0,0%,100%,0.06);
+    flex-shrink: 0;
+  }
+  .settings-titlebar:active { cursor: grabbing; }
+  .settings-popout-btn {
+    background: hsla(0,0%,100%,0.06);
+    border: 1px solid hsla(0,0%,100%,0.1);
+    border-radius: 6px;
+    color: hsla(0,0%,100%,0.5);
+    font-size: 16px;
+    width: 30px;
+    height: 30px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    transition: background 0.15s, color 0.15s;
+  }
+  .settings-popout-btn:hover {
+    background: hsla(0,0%,100%,0.12);
+    color: hsla(0,0%,100%,0.8);
+  }
+  /* Hide popout button when already in popout window */
+  body.settings-popout .settings-popout-btn { display: none; }
+  .settings-titlebar-logo {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+  .settings-titlebar-logo img,
+  .settings-titlebar-logo svg {
+    height: 16px;
+    width: auto;
+    filter: brightness(0) invert(1);
+  }
+  .settings-body {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+  }
+  /* ── Sidebar navigation ── */
+  .settings-sidebar {
+    width: 160px;
+    flex-shrink: 0;
+    background: hsla(0,0%,100%,0.02);
+    border-right: 1px solid hsla(0,0%,100%,0.06);
+    padding: 10px 0;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .settings-sidebar-item {
+    padding: 8px 16px;
+    font-size: 13px;
+    font-weight: 600;
+    color: hsla(0,0%,100%,0.4);
+    cursor: pointer;
+    letter-spacing: 0.04em;
+    transition: color 0.15s, background 0.15s;
+    user-select: none;
+  }
+  .settings-sidebar-item:hover { color: hsla(0,0%,100%,0.65); background: hsla(0,0%,100%,0.03); }
+  .settings-sidebar-item.active { color: hsla(0,0%,100%,0.95); background: hsla(0,0%,100%,0.06); }
+  .settings-sidebar-item.disabled { opacity: 0.25; pointer-events: none; }
+  /* ── Content area (replaces tab content) ── */
+  .settings-content {
+    flex: 1;
+    padding: 16px 22px;
+    overflow-y: auto;
+    overflow-x: hidden;
+    -webkit-overflow-scrolling: touch;
+    min-height: 0;
+  }
+  /* Two-column grid for section toggles */
+  .settings-two-col {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0 20px;
+  }
+  .settings-two-col .settings-group-label {
+    grid-column: 1 / -1;
+  }
+  .settings-title {
+    font-size: 16px;
+    font-weight: 900;
+    margin-bottom: 4px;
+  }
+  .settings-subtitle {
+    font-size: 14px;
+    color: hsla(0,0%,100%,0.4);
+    margin-bottom: 16px;
+  }
+  .settings-group-label {
+    font-size: 13px;
+    font-weight: 700;
+    color: hsla(0,0%,100%,0.35);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin: 14px 0 6px;
+  }
+
+  /* ── Subtab bar within a settings tab ── */
+  .settings-subtabs {
+    display: flex;
+    gap: 2px;
+    padding: 0 0 12px;
+    border-bottom: 1px solid hsla(0,0%,100%,0.06);
+    margin-bottom: 12px;
+    flex-wrap: wrap;
+  }
+  .settings-subtab {
+    font-size: 12px;
+    font-weight: 600;
+    color: hsla(0,0%,100%,0.35);
+    padding: 5px 10px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .settings-subtab:hover {
+    color: hsla(0,0%,100%,0.6);
+    background: hsla(0,0%,100%,0.04);
+  }
+  .settings-subtab.active {
+    color: hsla(0,0%,100%,0.9);
+    background: hsla(0,0%,100%,0.08);
+  }
+  .settings-subtab-page {
+    display: none;
+  }
+  .settings-subtab-page.active {
+    display: block;
+  }
+  .settings-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 0;
+    border-bottom: 1px solid hsla(0,0%,100%,0.05);
+  }
+  .settings-row:last-child { border-bottom: none; }
+  .settings-row.settings-sub {
+    padding-left: 14px;
+    border-bottom-color: hsla(0,0%,100%,0.03);
+  }
+  .settings-row.settings-sub .settings-label { color: hsla(0,0%,100%,0.45); font-size: 15px; }
+  .settings-label {
+    font-size: 16px;
+    font-weight: 500;
+    color: hsla(0,0%,100%,0.8);
+  }
+  .settings-toggle {
+    position: relative;
+    width: 36px;
+    height: 20px;
+    background: hsla(0,0%,100%,0.1);
+    border-radius: 10px;
+    cursor: pointer;
+    transition: background 0.2s;
+    flex-shrink: 0;
+  }
+  .settings-toggle.on { background: var(--green); }
+  .settings-toggle::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: white;
+    transition: transform 0.2s;
+  }
+  .settings-toggle.on::after { transform: translateX(16px); }
+
+  /* Disabled toggle (e.g. Discord-gated features) */
+  .settings-toggle.disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+  .toggle-hint {
+    font-size: 14px;
+    color: hsla(0,0%,100%,0.35);
+    font-style: italic;
+    margin-top: 2px;
+  }
+  .settings-hint {
+    font-size: 14px;
+    color: hsla(0,0%,100%,0.35);
+    font-style: italic;
+    padding: 0 0 6px;
+  }
+
+  .settings-input {
+    background: hsla(0,0%,100%,0.08);
+    border: 1px solid hsla(0,0%,100%,0.15);
+    border-radius: 4px;
+    padding: 4px 8px;
+    font-size: 15px;
+    color: white;
+    width: 160px;
+    font-family: var(--ff);
+  }
+  .settings-input:focus { outline: none; border-color: var(--cyan); }
+  .settings-select {
+    background: hsla(0,0%,100%,0.08);
+    border: 1px solid hsla(0,0%,100%,0.15);
+    border-radius: 4px;
+    padding: 4px 8px;
+    font-size: 15px;
+    color: white;
+    font-family: var(--ff);
+    cursor: pointer;
+    -webkit-appearance: none;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%23999'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 6px center;
+    padding-right: 20px;
+  }
+  .settings-select:focus { outline: none; border-color: var(--cyan); }
+  .settings-select option { background: #1a1a1a; color: white; }
+  .settings-range-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .settings-range {
+    -webkit-appearance: none;
+    appearance: none;
+    flex: 1;
+    height: 4px;
+    background: hsla(0,0%,100%,0.12);
+    border-radius: 2px;
+    outline: none;
+    cursor: pointer;
+  }
+  .settings-range::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: white;
+    cursor: pointer;
+  }
+  .settings-range-val {
+    font-size: 15px;
+    color: hsla(0,0%,100%,0.6);
+    font-variant-numeric: tabular-nums;
+    min-width: 32px;
+    text-align: right;
+  }
+  .settings-close {
+    margin: 12px 22px 16px;
+    width: calc(100% - 44px);
+    padding: 8px;
+    background: hsla(0,0%,100%,0.06);
+    border: 1px solid hsla(0,0%,100%,0.10);
+    border-radius: 6px;
+    color: hsla(0,0%,100%,0.6);
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    font-family: var(--ff);
+    flex-shrink: 0;
+  }
+  .settings-close:hover { background: hsla(0,0%,100%,0.12); color: white; }
+
+  .settings-version {
+    text-align: center;
+    font-size: 10px;
+    color: hsla(0,0%,100%,0.2);
+    padding: 0 20px 12px;
+  }
+
+  /* ── Settings tabs (hidden — replaced by sidebar) ── */
+  .settings-tabs { display: none; }
+  .settings-tab-content { display: none; }
+  .settings-tab-content.active { display: block; }
+
+  /* ── Key Commands tab ── */
+  .settings-key-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 0;
+    border-bottom: 1px solid hsla(0,0%,100%,0.06);
+    font-size: 16px;
+    color: hsla(0,0%,100%,0.55);
+  }
+  .settings-key-row:last-child { border-bottom: none; }
+  .settings-key-row kbd {
+    background: hsla(0,0%,100%,0.08);
+    border: 1px solid hsla(0,0%,100%,0.18);
+    border-radius: 3px;
+    padding: 2px 5px;
+    font-family: var(--ff-mono, var(--ff));
+    font-size: 14px;
+    color: hsla(0,0%,100%,0.7);
+    line-height: 1.4;
+  }
+  .settings-key-row span {
+    margin-left: auto;
+    padding-left: 12px;
+    color: hsla(0,0%,100%,0.4);
+    font-size: 15px;
+  }
+
+  /* ── Pedal settings tab ── */
+  .pedal-settings-curve-preview {
+    margin: 8px 0;
+    text-align: center;
+  }
+  .pedal-settings-curve-preview canvas {
+    width: 100%;
+    max-width: 200px;
+    height: auto;
+    border-radius: 6px;
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px solid hsla(0, 0%, 100%, 0.08);
+  }
+  .pedal-curve-legend {
+    display: flex;
+    justify-content: center;
+    gap: 12px;
+    margin-top: 6px;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+  }
+  .curve-legend-item { opacity: 0.6; }
+  .settings-info-text {
+    font-size: 11px;
+    color: hsla(0, 0%, 100%, 0.3);
+    padding: 4px 0;
+    line-height: 1.5;
+  }
+
+  /* ── Moza debug panel ── */
+  .moza-debug-panel {
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 6px;
+    padding: 8px 10px;
+    margin-top: 4px;
+    font-family: 'JetBrains Mono', 'SF Mono', monospace;
+    font-size: 10px;
+    line-height: 1.6;
+  }
+  .moza-debug-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .moza-debug-key {
+    color: hsla(0, 0%, 100%, 0.35);
+    white-space: nowrap;
+  }
+  .moza-debug-val {
+    color: hsla(0, 0%, 100%, 0.6);
+    text-align: right;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 180px;
+  }
+  .moza-debug-json {
+    font-size: 8px;
+    max-width: 180px;
+    word-break: break-all;
+    white-space: normal;
+    max-height: 60px;
+    overflow-y: auto;
+  }
+
+  /* Hidden sections */
+  .section-hidden { display: none !important; }
+
+  /* ═══════════════════════════════════════════════
+     VERSION FOOTER (defined in settings-close block above)
+     ═══════════════════════════════════════════════ */
+
+
+/* ── modules/styles/effects.css ── */
+  /* ═══════════════════════════════════════════════
+     RACE CONTROL MESSAGE BANNER
+     ═══════════════════════════════════════════════ */
+  .rc-banner {
+    position: fixed;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%) translateY(-100%);
+    z-index: 200;
+    pointer-events: none;
+    transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.45s ease;
+    opacity: 0;
+  }
+  .rc-banner.rc-visible {
+    transform: translateX(-50%) translateY(0);
+    opacity: 1;
+  }
+  .rc-inner {
+    display: flex;
+    align-items: center;
+    gap: 18px;
+    background: hsla(0, 0%, 3%, 0.90);
+    border: 2px solid hsla(48, 90%, 55%, 0.80);
+    border-top: none;
+    border-radius: 0 0 14px 14px;
+    padding: 16px 36px 18px 28px;
+    box-shadow: 0 6px 40px hsla(0, 0%, 0%, 0.7), inset 0 -1px 0 hsla(48, 90%, 55%, 0.10);
+    position: relative;
+    overflow: hidden;
+  }
+  /* Animated flag stripe background */
+  .rc-inner::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    opacity: 0;
+    transition: opacity 0.5s ease;
+    background: repeating-linear-gradient(
+      -45deg,
+      hsla(48, 90%, 55%, 0.08) 0px,
+      hsla(48, 90%, 55%, 0.08) 12px,
+      transparent 12px,
+      transparent 24px
+    );
+    background-size: 34px 34px;
+    animation: rc-flag-scroll 1.5s linear infinite;
+    pointer-events: none;
+  }
+  .rc-banner.rc-visible .rc-inner::after {
+    opacity: 1;
+  }
+  @keyframes rc-flag-scroll {
+    0%   { background-position: 0 0; }
+    100% { background-position: 34px 34px; }
+  }
+  /* Per-flag stripe color overrides — only critical flags */
+  .rc-banner.rc-flag-red .rc-inner::after {
+    background: repeating-linear-gradient(-45deg, hsla(0, 85%, 55%, 0.10) 0px, hsla(0, 85%, 55%, 0.10) 12px, transparent 12px, transparent 24px);
+    background-size: 34px 34px;
+  }
+  .rc-banner.rc-flag-checkered .rc-inner::after {
+    background: repeating-linear-gradient(-45deg, hsla(0, 0%, 100%, 0.08) 0px, hsla(0, 0%, 100%, 0.08) 12px, hsla(0, 0%, 0%, 0.08) 12px, hsla(0, 0%, 0%, 0.08) 24px);
+    background-size: 34px 34px;
+  }
+  .rc-banner.rc-flag-black .rc-inner::after {
+    background: repeating-linear-gradient(-45deg, hsla(0, 75%, 45%, 0.10) 0px, hsla(0, 75%, 45%, 0.10) 12px, transparent 12px, transparent 24px);
+    background-size: 34px 34px;
+  }
+  .rc-icon {
+    width: 52px;
+    height: 52px;
+    flex-shrink: 0;
+    position: relative;
+    z-index: 1;
+  }
+  .rc-content {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    position: relative;
+    z-index: 1;
+  }
+  .rc-title {
+    font-family: var(--ff);
+    font-size: 28px;
+    font-weight: var(--fw-black);
+    text-transform: uppercase;
+    letter-spacing: 0.10em;
+    color: #FFFFFF;
+    line-height: 1.1;
+    white-space: nowrap;
+  }
+  .rc-detail {
+    font-family: var(--ff-semi);
+    font-size: 15px;
+    font-weight: var(--fw-semi);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: hsl(48, 80%, 55%);
+    line-height: 1.25;
+    white-space: nowrap;
+  }
+
+  /* Yellow stripe accent on left edge */
+  .rc-inner::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 4px;
+    z-index: 2;
+    background: hsl(48, 90%, 55%);
+    border-radius: 0 0 0 14px;
+  }
+
+  /* ── Dim HUD elements when RC banner is active (not the game background) ── */
+  body.rc-active #dashboard,
+  body.rc-active .leaderboard-panel,
+  body.rc-active .datastream-panel,
+  body.rc-active .pitbox-panel,
+  body.rc-active .incidents-panel {
+    opacity: 0.5;
+    transition: opacity 0.5s ease;
+  }
+
+  /* Pulse glow on the border */
+  .rc-banner.rc-visible .rc-inner {
+    animation: rc-glow 3s ease-in-out infinite alternate;
+  }
+  @keyframes rc-glow {
+    0%   { box-shadow: 0 4px 24px hsla(0, 0%, 0%, 0.6), inset 0 -1px 0 hsla(48, 90%, 55%, 0.24), 0 0 8px hsla(48, 85%, 50%, 0.24); }
+    100% { box-shadow: 0 4px 24px hsla(0, 0%, 0%, 0.6), inset 0 -1px 0 hsla(48, 90%, 55%, 0.45), 0 0 18px hsla(48, 85%, 50%, 0.54); }
+  }
+
+  /* Per-flag accent overrides — only critical flags (red, black, yellow, checkered) */
+
+  /* ── Yellow / Caution — default yellow accents already apply ── */
+
+  /* ── Red Flag ── */
+  .rc-banner.rc-flag-red .rc-inner    { border-color: hsla(0, 85%, 55%, 0.45); }
+  .rc-banner.rc-flag-red .rc-inner::before { background: hsl(0, 85%, 55%); }
+  .rc-banner.rc-flag-red .rc-detail   { color: hsl(0, 80%, 65%); }
+  .rc-banner.rc-flag-red.rc-visible .rc-inner { animation-name: rc-glow-red; }
+  @keyframes rc-glow-red {
+    0%   { box-shadow: 0 4px 24px hsla(0, 0%, 0%, 0.6), 0 0 8px hsla(0, 80%, 50%, 0.30); }
+    100% { box-shadow: 0 4px 24px hsla(0, 0%, 0%, 0.6), 0 0 18px hsla(0, 80%, 50%, 0.66); }
+  }
+
+  /* ── Checkered ── */
+  .rc-banner.rc-flag-checkered .rc-inner { border-color: hsla(0, 0%, 100%, 0.30); }
+  .rc-banner.rc-flag-checkered .rc-inner::before { background: repeating-linear-gradient(180deg, #fff 0 4px, #222 4px 8px); }
+  .rc-banner.rc-flag-checkered .rc-detail { color: hsl(0, 0%, 80%); }
+
+  /* ── Black Flag ── */
+  .rc-banner.rc-flag-black .rc-inner  { border-color: hsla(0, 75%, 40%, 0.40); }
+  .rc-banner.rc-flag-black .rc-inner::before { background: hsl(0, 75%, 45%); }
+  .rc-banner.rc-flag-black .rc-detail { color: hsl(0, 60%, 60%); }
+
+  /* ── Meatball Flag — red circle accent ── */
+  .rc-banner.rc-flag-meatball .rc-inner  { border-color: hsla(0, 90%, 50%, 0.50); }
+  .rc-banner.rc-flag-meatball .rc-inner::before { background: radial-gradient(circle, hsl(0, 85%, 52%) 40%, hsl(0, 0%, 10%) 42%); }
+  .rc-banner.rc-flag-meatball .rc-detail { color: hsl(0, 80%, 65%); }
+  .rc-banner.rc-flag-meatball.rc-visible .rc-inner { animation-name: rc-glow-meatball; }
+  @keyframes rc-glow-meatball {
+    0%   { box-shadow: 0 4px 24px hsla(0, 0%, 0%, 0.6), 0 0 8px hsla(0, 90%, 50%, 0.35); }
+    100% { box-shadow: 0 4px 24px hsla(0, 0%, 0%, 0.6), 0 0 20px hsla(0, 90%, 50%, 0.70); }
+  }
+  .rc-banner.rc-flag-meatball .rc-inner::after {
+    background: repeating-linear-gradient(-45deg, hsla(0, 85%, 55%, 0.12) 0px, hsla(0, 85%, 55%, 0.12) 12px, transparent 12px, transparent 24px);
+    background-size: 34px 34px;
+  }
+
+  /* ═══════════════════════════════════════════════
+     PIT LIMITER INDICATOR
+     ═══════════════════════════════════════════════ */
+  .pit-banner {
+    position: fixed;
+    top: 0; left: 0; right: 0;
+    z-index: 55;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    padding-top: 8px;
+    opacity: 0;
+    transform: translateY(-12px);
+    transition: opacity 0.5s ease, transform 0.5s ease;
+  }
+  .pit-banner.pit-visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  .pit-gl-canvas {
+    position: absolute;
+    inset: -16px -24px;
+    width: calc(100% + 48px);
+    height: calc(100% + 32px);
+    pointer-events: none;
+    z-index: 0;
+    border-radius: 20px;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+  }
+  .pit-banner.pit-bonkers .pit-gl-canvas {
+    opacity: 1;
+  }
+  .pit-inner {
+    position: relative;
+    overflow: visible;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    background: hsla(200, 60%, 8%, 0.90);
+    border: 2px solid hsla(200, 80%, 60%, 0.60);
+    border-radius: 10px;
+    padding: 10px 28px;
+    animation: pit-glow 2.5s ease-in-out infinite alternate;
+  }
+  .pit-icon {
+    width: 22px; height: 22px;
+    border-radius: 50%;
+    background: hsl(200, 80%, 60%);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 11px; font-weight: 800; color: #000;
+    line-height: 1;
+  }
+  .pit-label {
+    font-size: 15px;
+    font-weight: var(--fw-black);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: hsl(200, 80%, 70%);
+  }
+  .pit-speed {
+    font-size: 13px;
+    font-weight: var(--fw-bold);
+    color: hsla(0, 0%, 100%, 0.60);
+    font-variant-numeric: tabular-nums;
+  }
+  @keyframes pit-glow {
+    0%   { box-shadow: inset 0 0 14px hsla(200, 80%, 60%, 0.15), 0 0 10px hsla(200, 80%, 60%, 0.10); }
+    100% { box-shadow: inset 0 0 28px hsla(200, 80%, 60%, 0.35), 0 0 20px hsla(200, 80%, 60%, 0.22); }
+  }
+
+  /* Keep all modules at full opacity in pit lane */
+  body.pit-mode .panel,
+  body.pit-mode .leaderboard-panel,
+  body.pit-mode .datastream-panel,
+  body.pit-mode .pitbox-panel,
+  body.pit-mode .incidents-panel,
+  body.pit-mode .spotter-panel {
+    transition: opacity 1.2s ease;
+    opacity: 1;
+  }
+  body:not(.pit-mode) .panel,
+  body:not(.pit-mode) .leaderboard-panel,
+  body:not(.pit-mode) .datastream-panel,
+  body:not(.pit-mode) .pitbox-panel,
+  body:not(.pit-mode) .incidents-panel,
+  body:not(.pit-mode) .spotter-panel {
+    transition: opacity 1.2s ease;
+  }
+
+  /* ═══════════════════════════════════════════════
+     IDLE STATE — K10 logo only when not in-car
+     ═══════════════════════════════════════════════ */
+  .idle-logo {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    z-index: 50;
+    width: 98px;
+    height: 98px;
+    background: var(--bg-logo);
+    border: 1px solid var(--border);
+    border-radius: var(--corner-r);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transform: scale(0.5);
+    transform-origin: top right;
+    pointer-events: none;
+    transition: opacity 0.6s ease, transform 0.6s ease;
+  }
+  .idle-logo.idle-visible {
+    opacity: 0.5;
+    transform: scale(1);
+    pointer-events: auto;
+  }
+  .idle-logo img {
+    width: 75%;
+    height: auto;
+  }
+  /* Hide dashboard in idle */
+  body.idle-state #dashboard,
+  body.idle-state .leaderboard-panel,
+  body.idle-state .datastream-panel,
+  body.idle-state .pitbox-panel,
+  body.idle-state .incidents-panel,
+  body.idle-state .spotter-panel,
+  body.idle-state .pit-banner,
+  body.idle-state .rc-banner,
+  body.idle-state .grid-module {
+    opacity: 0 !important;
+    pointer-events: none !important;
+    transition: opacity 0.6s ease;
+  }
+  /* Settings overlay must stay accessible in idle */
+  body.idle-state .settings-overlay {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  /* ═══════════════════════════════════════════════
+     LOGO-ONLY STARTUP — clean broadcast intro
+     Only logos visible until session goes active
+     ═══════════════════════════════════════════════ */
+  body.logo-only #dashboard .panel:not(.k10-logo-square):not(.car-logo-square),
+  body.logo-only .leaderboard-panel,
+  body.logo-only .datastream-panel,
+  body.logo-only .pitbox-panel,
+  body.logo-only .incidents-panel,
+  body.logo-only .spotter-panel,
+  body.logo-only .pit-banner,
+  body.logo-only .rc-banner,
+  body.logo-only .grid-module,
+  body.logo-only .commentary-col,
+  body.logo-only .fuel-tyres-col,
+  body.logo-only .controls-pedals-block,
+  body.logo-only .tacho-block,
+  body.logo-only .pos-gaps-col,
+  body.logo-only .maps-col,
+  body.logo-only .pedals-area {
+    opacity: 0 !important;
+    pointer-events: none !important;
+  }
+  /* Reveal transition: panels fade in when session starts */
+  body.logo-only-reveal #dashboard .panel,
+  body.logo-only-reveal .leaderboard-panel,
+  body.logo-only-reveal .datastream-panel,
+  body.logo-only-reveal .pitbox-panel,
+  body.logo-only-reveal .incidents-panel,
+  body.logo-only-reveal .spotter-panel,
+  body.logo-only-reveal .commentary-col,
+  body.logo-only-reveal .fuel-tyres-col,
+  body.logo-only-reveal .controls-pedals-block,
+  body.logo-only-reveal .tacho-block,
+  body.logo-only-reveal .pos-gaps-col,
+  body.logo-only-reveal .maps-col,
+  body.logo-only-reveal .pedals-area {
+    transition: opacity 1s ease-out;
+  }
+  /* Settings always accessible */
+  body.logo-only .settings-overlay {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  /* ═══════════════════════════════════════════════
+     PIT LIMITER — WARNING FLASH (limiter OFF in pit)
+     ═══════════════════════════════════════════════ */
+  .pit-banner.pit-warning .pit-inner {
+    background: hsla(10, 80%, 12%, 1.0);
+    border-color: hsla(10, 90%, 55%, 0.80);
+    animation: pit-warn-flash 0.6s ease-in-out infinite alternate;
+  }
+  .pit-banner.pit-warning .pit-icon {
+    background: hsl(10, 90%, 55%);
+  }
+  .pit-banner.pit-warning .pit-label {
+    color: hsl(10, 90%, 70%);
+  }
+  @keyframes pit-warn-flash {
+    0%   { box-shadow: inset 0 0 14px hsla(10, 90%, 55%, 0.25), 0 0 10px hsla(10, 90%, 55%, 0.15); }
+    100% { box-shadow: inset 0 0 40px hsla(10, 90%, 55%, 0.55), 0 0 30px hsla(10, 90%, 55%, 0.40); }
+  }
+
+  /* ═══════════════════════════════════════════════
+     PIT LIMITER — BONKERS (speeding over limit)
+     Violent shake, layered glow, color cycling, sparks
+     ═══════════════════════════════════════════════ */
+  .pit-banner.pit-bonkers .pit-inner {
+    background: hsla(0, 95%, 8%, 1.0);
+    border-color: hsla(0, 100%, 50%, 0.95);
+    border-width: 3px;
+    animation: pit-bonkers-shake 0.07s linear infinite,
+               pit-bonkers-glow 0.25s ease-in-out infinite alternate;
+  }
+  @keyframes pit-bonkers-shake {
+    0%   { transform: translate(0, 0) rotate(0deg); }
+    20%  { transform: translate(-3px, 1px) rotate(-0.6deg); }
+    40%  { transform: translate(2px, -2px) rotate(0.4deg); }
+    60%  { transform: translate(-1px, 2px) rotate(-0.3deg); }
+    80%  { transform: translate(3px, -1px) rotate(0.5deg); }
+    100% { transform: translate(-2px, -1px) rotate(-0.2deg); }
+  }
+  @keyframes pit-bonkers-glow {
+    0% {
+      box-shadow:
+        inset 0 0 30px hsla(0, 100%, 50%, 0.6),
+        0 0 20px hsla(0, 100%, 50%, 0.5),
+        0 0 50px hsla(20, 100%, 50%, 0.35),
+        0 0 90px hsla(40, 100%, 50%, 0.15);
+    }
+    100% {
+      box-shadow:
+        inset 0 0 50px hsla(0, 100%, 55%, 0.8),
+        0 0 35px hsla(0, 100%, 50%, 0.7),
+        0 0 70px hsla(25, 100%, 50%, 0.5),
+        0 0 120px hsla(45, 100%, 50%, 0.25);
+    }
+  }
+
+  /* Icon: rapid red↔yellow pulse */
+  .pit-banner.pit-bonkers .pit-icon {
+    animation: pit-bonkers-icon 0.12s ease-in-out infinite alternate;
+  }
+  @keyframes pit-bonkers-icon {
+    0%   { background: hsl(0, 100%, 50%); box-shadow: 0 0 10px hsla(0, 100%, 50%, 0.8); }
+    100% { background: hsl(50, 100%, 50%); box-shadow: 0 0 14px hsla(50, 100%, 50%, 0.8); }
+  }
+
+  /* Label: color-cycling red→orange→yellow */
+  .pit-banner.pit-bonkers .pit-label {
+    animation: pit-bonkers-text 0.3s linear infinite;
+    font-size: 17px;
+    letter-spacing: 0.2em;
+  }
+  @keyframes pit-bonkers-text {
+    0%   { color: hsl(0, 100%, 65%); text-shadow: 0 0 8px hsla(0, 100%, 50%, 0.5); }
+    33%  { color: hsl(25, 100%, 60%); text-shadow: 0 0 8px hsla(25, 100%, 50%, 0.5); }
+    66%  { color: hsl(50, 100%, 58%); text-shadow: 0 0 8px hsla(50, 100%, 50%, 0.5); }
+    100% { color: hsl(0, 100%, 65%); text-shadow: 0 0 8px hsla(0, 100%, 50%, 0.5); }
+  }
+
+  /* Speed value: enlarged, red, shaking independently */
+  .pit-banner.pit-bonkers .pit-speed {
+    color: hsl(0, 100%, 70%);
+    font-size: 17px;
+    font-weight: 900;
+    animation: pit-bonkers-speed 0.06s linear infinite;
+    text-shadow: 0 0 6px hsla(0, 100%, 50%, 0.6);
+  }
+  @keyframes pit-bonkers-speed {
+    0%   { transform: translateX(0) scale(1); }
+    33%  { transform: translateX(2px) scale(1.03); }
+    66%  { transform: translateX(-2px) scale(0.97); }
+    100% { transform: translateX(1px) scale(1.01); }
+  }
+
+  /* Limit value: pulsing red */
+  .pit-banner.pit-bonkers .pit-limit {
+    color: hsla(0, 100%, 65%, 0.8) !important;
+    font-size: 13px !important;
+  }
+
+  /* ── Spark particles (spawned by JS) ── */
+  @keyframes pit-spark-fly {
+    0%   { transform: translate(0, 0) scale(1); opacity: 1; }
+    30%  { opacity: 1; }
+    100% { transform: translate(var(--spark-dx), var(--spark-dy)) scale(0.3); opacity: 0; }
+  }
+
+  /* ── Bonkers border flicker pseudo-element ── */
+  .pit-banner.pit-bonkers .pit-inner::before {
+    content: '';
+    position: absolute;
+    inset: -4px;
+    border-radius: 14px;
+    border: 2px solid transparent;
+    pointer-events: none;
+    animation: pit-bonkers-ring 0.2s ease-in-out infinite alternate;
+  }
+  @keyframes pit-bonkers-ring {
+    0%   { border-color: hsla(0, 100%, 50%, 0.3); box-shadow: inset 0 0 20px hsla(0, 100%, 50%, 0.1); }
+    50%  { border-color: hsla(30, 100%, 55%, 0.5); box-shadow: inset 0 0 30px hsla(30, 100%, 50%, 0.15); }
+    100% { border-color: hsla(50, 100%, 50%, 0.2); box-shadow: inset 0 0 15px hsla(50, 100%, 50%, 0.08); }
+  }
+
+  /* ── Outer heat haze (second pseudo-element) ── */
+  .pit-banner.pit-bonkers .pit-inner::after {
+    content: '';
+    position: absolute;
+    inset: -10px;
+    border-radius: 20px;
+    pointer-events: none;
+    animation: pit-bonkers-haze 0.4s ease-in-out infinite alternate;
+  }
+  @keyframes pit-bonkers-haze {
+    0%   { box-shadow: 0 0 40px 8px hsla(0, 100%, 50%, 0.12), 0 0 80px 16px hsla(30, 100%, 50%, 0.06); }
+    100% { box-shadow: 0 0 60px 12px hsla(10, 100%, 50%, 0.18), 0 0 120px 24px hsla(40, 100%, 50%, 0.10); }
+  }
+
+  /* ── Bonkers-off: keep colors, kill all motion + WebGL ── */
+  body.bonkers-off .pit-banner.pit-bonkers .pit-inner {
+    animation: none;
+  }
+  body.bonkers-off .pit-banner.pit-bonkers .pit-icon {
+    animation: none;
+  }
+  body.bonkers-off .pit-banner.pit-bonkers .pit-label {
+    animation: none;
+  }
+  body.bonkers-off .pit-banner.pit-bonkers .pit-speed {
+    animation: none;
+  }
+  body.bonkers-off .pit-banner.pit-bonkers .pit-inner::before {
+    animation: none;
+  }
+  body.bonkers-off .pit-banner.pit-bonkers .pit-inner::after {
+    animation: none;
+    box-shadow: none;
+  }
+  body.bonkers-off .pit-banner.pit-bonkers .pit-gl-canvas {
+    display: none;
+  }
+
+  /* ═══════════════════════════════════════════════
+     RACE END SCREEN — within HUD bounds
+     ═══════════════════════════════════════════════ */
+  .race-end-screen {
+    position: fixed;
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.6s ease-out;
+  }
+  .race-end-screen.re-visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .race-end-bg {
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: hsla(0, 0%, 4%, 0.92);
+    border-radius: var(--corner-r);
+    border: 1px solid var(--border);
+    backdrop-filter: blur(8px);
+  }
+  .race-end-content {
+    position: relative;
+    z-index: 1;
+    text-align: center;
+    padding: 28px 36px;
+    animation: re-slide-in 0.6s ease-out both;
+  }
+  @keyframes re-slide-in {
+    from { opacity: 0; transform: scale(0.9) translateY(-16px); }
+    to   { opacity: 1; transform: scale(1) translateY(0); }
+  }
+  @keyframes re-pos-reveal {
+    from { opacity: 0; transform: scale(0); }
+    to   { opacity: 1; transform: scale(1); }
+  }
+  @keyframes re-gold-pulse {
+    0%, 100% { text-shadow: 0 0 30px hsla(45, 100%, 50%, 0.5); }
+    50%      { text-shadow: 0 0 50px hsla(45, 100%, 50%, 0.9); }
+  }
+  @keyframes re-confetti {
+    to { transform: translateY(300px) rotate(360deg); opacity: 0; }
+  }
+
+  .re-position {
+    font-family: var(--ff-mono);
+    font-size: 72px;
+    font-weight: var(--fw-black);
+    line-height: 1;
+    margin-bottom: 8px;
+    letter-spacing: -0.05em;
+    animation: re-pos-reveal 0.8s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  }
+  /* Tint variants */
+  .re-tint-gold .re-position {
+    color: #ffb300;
+    animation: re-pos-reveal 0.8s cubic-bezier(0.34, 1.56, 0.64, 1) both,
+               re-gold-pulse 2s ease-in-out 0.6s infinite;
+  }
+  .re-tint-silver .re-position { color: #c0c0c0; text-shadow: 0 0 30px hsla(0, 0%, 75%, 0.4); }
+  .re-tint-bronze .re-position { color: #cd7f32; text-shadow: 0 0 30px hsla(30, 80%, 50%, 0.4); }
+  .re-tint-green  .re-position { color: var(--green); text-shadow: 0 0 24px hsla(120, 60%, 50%, 0.3); }
+  .re-tint-purple .re-position { color: var(--purple); text-shadow: 0 0 24px hsla(280, 80%, 70%, 0.3); }
+  .re-tint-neutral .re-position { color: var(--text-primary); opacity: 0.8; }
+
+  .re-title {
+    font-family: var(--ff);
+    font-size: 32px;
+    font-weight: var(--fw-black);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin: 0 0 4px 0;
+    line-height: 1.2;
+    color: var(--text-primary);
+  }
+  .re-subtitle {
+    font-size: 12px;
+    font-weight: var(--fw-regular);
+    color: var(--text-secondary);
+    margin: 0;
+    max-width: 320px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .re-clean-badge {
+    display: inline-block;
+    padding: 5px 12px;
+    background: hsla(120, 60%, 50%, 0.12);
+    border: 1px solid var(--green);
+    border-radius: var(--corner-r-sm);
+    color: var(--green);
+    font-size: 10px;
+    font-weight: var(--fw-bold);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin: 12px 0 8px 0;
+    animation: re-slide-in 0.6s ease-out 0.2s both;
+  }
+  .re-clean-badge span { margin-right: 4px; font-weight: var(--fw-black); }
+
+  .re-stats {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 12px;
+    margin-top: 20px;
+  }
+  .re-stat {
+    padding: 14px 10px;
+    background: hsla(0, 0%, 100%, 0.04);
+    border: 1px solid hsla(0, 0%, 100%, 0.08);
+    border-radius: var(--corner-r-sm);
+    flex: 1;
+  }
+  .re-stat-label {
+    font-size: 10px;
+    font-weight: var(--fw-semi);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-dim);
+    margin-bottom: 6px;
+  }
+  .re-stat-val {
+    font-family: var(--ff-mono);
+    font-size: 18px;
+    font-weight: var(--fw-bold);
+    color: var(--text-primary);
+  }
+  /* Tinted stat items */
+  .re-tint-gold .re-stat   { border-color: hsla(45, 100%, 50%, 0.18); background: hsla(45, 100%, 50%, 0.06); }
+  .re-tint-silver .re-stat { border-color: hsla(0, 0%, 75%, 0.18); background: hsla(0, 0%, 75%, 0.06); }
+  .re-tint-bronze .re-stat { border-color: hsla(30, 80%, 50%, 0.18); background: hsla(30, 80%, 50%, 0.06); }
+  .re-tint-green .re-stat  { border-color: hsla(120, 60%, 50%, 0.18); background: hsla(120, 60%, 50%, 0.06); }
+  .re-tint-purple .re-stat { border-color: hsla(280, 80%, 70%, 0.18); background: hsla(280, 80%, 70%, 0.06); }
+  .re-tint-neutral .re-stat { border-color: hsla(0, 0%, 100%, 0.12); background: hsla(0, 0%, 100%, 0.04); }
+
+  /* Confetti container within race-end bounds */
+  .re-confetti {
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    pointer-events: none;
+    overflow: hidden;
+    border-radius: var(--corner-r);
+  }
+  .re-confetti-dot {
+    position: absolute;
+    top: -6px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    opacity: 0.7;
+    animation: re-confetti 3s ease-in forwards;
+  }
+  .re-confetti-dot:nth-child(even) { background: var(--cyan); }
+  .re-confetti-dot:nth-child(odd)  { background: var(--amber); }
+  .re-confetti-dot:nth-child(3n)   { background: var(--red); }
+  .re-confetti-dot:nth-child(4n)   { background: var(--green); }
+
+  /* ═══════════════════════════════════════════════
+     SPOTTER MESSAGES
+     ═══════════════════════════════════════════════ */
+  .spotter-panel {
+    position: fixed;
+    z-index: 52;
+    max-width: 280px;
+    width: auto;
+    pointer-events: none;
+    transition: opacity 0.4s ease;
+    /* Co-located with race control banner at top center */
+    top: 8px;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+  .spotter-panel.section-hidden { display: none; }
+  /* When RC banner is visible, push spotter below it */
+  body.rc-active .spotter-panel { top: 100px; }
+
+  .sp-gl-canvas {
+    position: absolute;
+    inset: -4px;
+    width: calc(100% + 8px);
+    height: calc(100% + 8px);
+    pointer-events: none;
+    border-radius: 12px;
+    z-index: -1;
+    transition: height 0.5s ease, opacity 0.4s ease;
+  }
+
+  .sp-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .sp-inner {
+    position: relative;
+    background: hsla(220, 30%, 8%, 0.92);
+    border: 1px solid hsla(220, 60%, 50%, 0.20);
+    border-radius: 8px;
+    padding: 8px 12px;
+    opacity: 0;
+    transform: translateY(6px);
+    transition: opacity 0.4s ease, transform 0.4s ease;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .spotter-panel.sp-top .sp-inner { transform: translateY(-6px); }
+  .sp-inner.sp-active {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  /* Progressive fade — older messages in stack are dimmer */
+  .sp-inner.sp-active:nth-child(2) { opacity: 0.55; }
+  .sp-inner.sp-active:nth-child(3) { opacity: 0.30; }
+  .sp-inner.sp-active:nth-child(n+4) { opacity: 0.15; }
+  /* Fade out older messages in the stack — collapse height to avoid growing the glow canvas */
+  .sp-inner.sp-fading {
+    opacity: 0;
+    transform: translateY(6px);
+    max-height: 0;
+    padding: 0 12px;
+    margin-top: -6px;
+    overflow: hidden;
+    transition: opacity 0.35s ease, transform 0.35s ease, max-height 0.4s ease 0.1s, padding 0.4s ease 0.1s, margin-top 0.4s ease 0.1s;
+  }
+  .spotter-panel.sp-top .sp-inner.sp-fading { transform: translateY(-6px); }
+  .sp-icon {
+    flex-shrink: 0;
+    width: 18px;
+    height: 18px;
+    color: hsla(220, 60%, 60%, 0.55);
+  }
+  .sp-inner.sp-warn .sp-icon { color: hsl(35, 80%, 65%); }
+  .sp-inner.sp-danger .sp-icon { color: hsl(0, 70%, 65%); }
+  .sp-inner.sp-clear .sp-icon { color: hsl(145, 60%, 60%); }
+  .sp-header {
+    font-size: 9px;
+    font-weight: var(--fw-bold);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: hsla(220, 60%, 60%, 0.55);
+    margin-bottom: 2px;
+  }
+  .sp-message {
+    font-size: 24px;
+    font-weight: var(--fw-semi);
+    color: hsla(220, 50%, 80%, 0.90);
+    line-height: 1.3;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+  }
+  .sp-inner.sp-warn { border-color: hsla(35, 80%, 50%, 0.30); }
+  .sp-inner.sp-warn .sp-message { color: hsl(35, 80%, 65%); }
+  .sp-inner.sp-danger { border-color: hsla(0, 70%, 50%, 0.30); }
+  .sp-inner.sp-danger .sp-message { color: hsl(0, 70%, 65%); }
+  .sp-inner.sp-clear { border-color: hsla(145, 60%, 45%, 0.25); }
+  .sp-inner.sp-clear .sp-message { color: hsl(145, 60%, 60%); }
+  /* Adjustment icon colors — use a neutral blue-white for car settings */
+  .sp-inner.sp-clear .sp-icon[data-adj] { color: hsl(210, 60%, 70%); }
+
+  /* ═══════════════════════════════════════════════
+     FORMATION LAP / GRID START MODULE
+     ═══════════════════════════════════════════════ */
+  .grid-module {
+    position: fixed;
+    top: 33%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 200;
+    text-align: center;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.8s ease;
+  }
+  .grid-module.grid-visible {
+    opacity: 1;
+  }
+  .grid-module.grid-fadeout {
+    opacity: 0;
+    transition: opacity 3s ease;
+  }
+
+  /* Flag WebGL — escapes card bounds with flag-colored energy */
+  .grid-flag-gl {
+    position: absolute;
+    top: -60px;
+    left: -80px;
+    right: -80px;
+    bottom: -60px;
+    width: calc(100% + 160px);
+    height: calc(100% + 120px);
+    pointer-events: none;
+    z-index: 0;
+    opacity: 0;
+    transition: opacity 1.0s ease;
+  }
+  .grid-module.grid-visible .grid-flag-gl {
+    opacity: 1;
+  }
+
+  /* Pre-race info card */
+  .grid-info {
+    position: relative;
+    z-index: 1;
+    background: hsla(220, 25%, 6%, 0.96);
+    border: 1px solid hsla(220, 60%, 40%, 0.25);
+    border-radius: 14px;
+    padding: 28px 48px;
+    min-width: 340px;
+    transition: opacity 0.6s ease, transform 0.5s ease, background 1.0s ease;
+  }
+  /* When flag is active, let it show through as the card background */
+  .grid-info:has(.grid-flag.flag-active) {
+    background: transparent;
+  }
+  /* All direct text children sit above the flag + dark bg panel */
+  .grid-info > *:not(.grid-flag):not(.grid-bg) {
+    position: relative;
+    z-index: 2;
+  }
+  .grid-info.info-hidden {
+    opacity: 0;
+    transform: scale(0.92);
+    pointer-events: none;
+    position: absolute;
+  }
+  .grid-title {
+    font-size: 10px;
+    font-weight: var(--fw-bold);
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: hsla(220, 60%, 65%, 0.60);
+    margin-bottom: 14px;
+  }
+  .grid-countdown {
+    position: relative;
+    z-index: 1;
+    font-size: 64px;
+    font-weight: var(--fw-black);
+    color: var(--text-primary);
+    line-height: 1;
+    margin-bottom: 16px;
+    font-variant-numeric: tabular-nums;
+    text-shadow: 0 0 30px hsla(220, 80%, 60%, 0.15);
+  }
+  .grid-cars {
+    font-size: 22px;
+    font-weight: var(--fw-bold);
+    color: hsla(0, 0%, 100%, 0.85);
+    margin-bottom: 8px;
+  }
+  .grid-cars-total {
+    color: hsla(0, 0%, 100%, 0.35);
+    font-weight: var(--fw-medium);
+  }
+  /* Mini grid strip — dot per car, player in blue */
+  .grid-strip {
+    display: flex;
+    gap: 3px;
+    justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+    max-width: 260px;
+    margin: 10px auto 4px;
+    min-height: 10px;
+  }
+  .grid-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 2px;
+    background: hsla(0, 0%, 30%, 0.45);
+    transition: background 0.4s ease, box-shadow 0.4s ease, transform 0.3s ease;
+  }
+  .grid-dot.gridded {
+    background: hsla(0, 0%, 45%, 0.6);
+  }
+  .grid-dot.player {
+    background: hsla(210, 80%, 55%, 1);
+    box-shadow: 0 0 6px hsla(210, 90%, 60%, 0.7), 0 0 14px hsla(210, 80%, 50%, 0.3);
+    transform: scale(1.3);
+    border-radius: 2px;
+  }
+
+  .grid-start-type {
+    font-size: 12px;
+    font-weight: var(--fw-semi);
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: hsla(220, 50%, 65%, 0.70);
+    margin-top: 6px;
+  }
+  .grid-start-type.standing { color: hsla(35, 80%, 60%, 0.85); }
+  .grid-start-type.rolling  { color: hsla(145, 60%, 55%, 0.75); }
+
+  /* ── F1-STYLE START LIGHTS ───────────────────── */
+  .start-lights {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    gap: 18px;
+    justify-content: center;
+    align-items: center;
+    padding: 20px 0;
+    opacity: 0;
+    transform: scale(0.8);
+    transition: opacity 0.5s ease, transform 0.5s ease;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) scale(0.8);
+  }
+  .start-lights.lights-active {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
+  .light-col {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    align-items: center;
+  }
+  .light-bulb {
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    background: hsla(0, 0%, 15%, 0.95);
+    border: 3px solid hsla(0, 0%, 25%, 0.60);
+    transition: background 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+    position: relative;
+  }
+  .light-bulb::after {
+    content: '';
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    width: 16px;
+    height: 12px;
+    border-radius: 50%;
+    background: hsla(0, 0%, 100%, 0.06);
+  }
+  .light-bulb.lit-red {
+    background: hsl(0, 85%, 48%);
+    border-color: hsl(0, 90%, 55%);
+    box-shadow: 0 0 24px 8px hsla(0, 90%, 50%, 0.50),
+                0 0 60px 16px hsla(0, 90%, 50%, 0.20),
+                inset 0 0 12px hsla(0, 100%, 70%, 0.40);
+    animation: light-pulse-red 0.6s ease-in-out infinite alternate;
+  }
+  .light-bulb.lit-green {
+    background: hsl(130, 85%, 42%);
+    border-color: hsl(130, 90%, 50%);
+    box-shadow: 0 0 32px 12px hsla(130, 90%, 45%, 0.55),
+                0 0 80px 24px hsla(130, 90%, 45%, 0.25),
+                inset 0 0 16px hsla(130, 100%, 65%, 0.45);
+    animation: light-pulse-green 0.3s ease-in-out infinite alternate;
+  }
+  @keyframes light-pulse-red {
+    0%   { box-shadow: 0 0 20px 6px hsla(0, 90%, 50%, 0.45), 0 0 50px 14px hsla(0, 90%, 50%, 0.15), inset 0 0 10px hsla(0, 100%, 70%, 0.35); }
+    100% { box-shadow: 0 0 30px 10px hsla(0, 90%, 50%, 0.60), 0 0 70px 20px hsla(0, 90%, 50%, 0.25), inset 0 0 14px hsla(0, 100%, 70%, 0.50); }
+  }
+  @keyframes light-pulse-green {
+    0%   { box-shadow: 0 0 28px 10px hsla(130, 90%, 45%, 0.50), 0 0 70px 20px hsla(130, 90%, 45%, 0.20), inset 0 0 14px hsla(130, 100%, 65%, 0.40); }
+    100% { box-shadow: 0 0 40px 16px hsla(130, 90%, 45%, 0.65), 0 0 100px 30px hsla(130, 90%, 45%, 0.30), inset 0 0 18px hsla(130, 100%, 65%, 0.55); }
+  }
+
+  /* Light housing plate */
+  .lights-housing {
+    background: hsla(0, 0%, 4%, 0.98);
+    border: 2px solid hsla(0, 0%, 20%, 0.50);
+    border-radius: 16px;
+    padding: 22px 30px;
+    display: flex;
+    gap: 18px;
+    box-shadow: 0 8px 40px hsla(0, 0%, 0%, 0.60);
+  }
+
+  /* GO! flash text */
+  .lights-go {
+    position: absolute;
+    bottom: -52px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 48px;
+    font-weight: var(--fw-black);
+    color: hsl(130, 85%, 50%);
+    text-shadow: 0 0 30px hsla(130, 90%, 50%, 0.60), 0 0 60px hsla(130, 90%, 50%, 0.30);
+    letter-spacing: 0.08em;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+  }
+  .lights-go.go-visible { opacity: 1; animation: go-flash 0.4s ease-in-out 3 alternate; }
+  @keyframes go-flash {
+    0%   { transform: translateX(-50%) scale(1); }
+    100% { transform: translateX(-50%) scale(1.12); }
+  }
+
+  /* ── Country flag — fills grid-info card as background ────────── */
+  .grid-flag {
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    z-index: 0;
+    overflow: hidden;
+    border-radius: 14px;
+    background: hsl(0, 0%, 0%);
+    opacity: 0;
+    transition: opacity 1.2s ease;
+  }
+  .grid-flag.flag-active {
+    opacity: 1;
+  }
+  .grid-flag-stripe {
+    position: absolute;
+    left: -20%;
+    width: 140%;
+    height: 34%;
+  }
+  .grid-flag-stripe:nth-child(1) { top: 0; }
+  .grid-flag-stripe:nth-child(2) { top: 33%; }
+  .grid-flag-stripe:nth-child(3) { top: 66%; }
+
+  /* Slow majestic wave — wider period, gentler amplitude than warning flags */
+  .grid-flag-stripe {
+    animation: flag-wave-majestic 6s ease-in-out infinite;
+    transform-origin: left center;
+  }
+  .grid-flag-stripe:nth-child(2) {
+    animation-delay: -1.2s;
+  }
+  .grid-flag-stripe:nth-child(3) {
+    animation-delay: -2.4s;
+  }
+  @keyframes flag-wave-majestic {
+    0%   { transform: skewY(0deg) scaleX(1); }
+    25%  { transform: skewY(1.5deg) scaleX(1.02); }
+    50%  { transform: skewY(0deg) scaleX(1); }
+    75%  { transform: skewY(-1.5deg) scaleX(1.02); }
+    100% { transform: skewY(0deg) scaleX(1); }
+  }
+  /* Remove the old full-coverage darkener — replaced by inset .grid-bg */
+  .grid-flag::after { display: none; }
+
+  /* ── Dark panel: sits above the flag, below text ──
+     Inset so flag colors bleed around all edges */
+  .grid-bg {
+    position: absolute;
+    top: 6px; left: 6px; right: 6px; bottom: 6px;
+    z-index: 1;
+    background: hsla(0, 0%, 0%, 0.80);
+    border-radius: 10px;
+    pointer-events: none;
+  }
+
+  /* Dim other modules during grid/lights */
+  body.grid-active .panel,
+  body.grid-active .leaderboard-panel,
+  body.grid-active .datastream-panel,
+  body.grid-active .pitbox-panel,
+  body.grid-active .incidents-panel,
+  body.grid-active .spotter-panel {
+    transition: opacity 1.0s ease;
+    opacity: 0.15;
+  }
+  body.grid-active .grid-module {
+    opacity: 1;
+  }
+
+  /* ═══════════════════════════════════════════════
+     ═══════════════════════════════════════════════ */
+
+
+/* ── modules/styles/ambient.css ── */
+/* ═══════════════════════════════════════════════════════════════
+   AMBIENT LIGHT — Per-panel glow + glass reflections
+   ═══════════════════════════════════════════════════════════════
+   Every panel/module gets TWO pseudo-element layers:
+     ::before — radial ambient glow (illumination wash)
+     ::after  — glass reflection highlight (diagonal streak)
+
+   Both are tinted by --ambient-r / --ambient-g / --ambient-b
+   (0-255) set on :root from JS.  A CSS breathing animation
+   pulses the glow subtly.
+
+   Modes: reflective (WebGL), matte (WebGL 50%), plastic (CSS-only), off.
+   Toggled off via body.ambient-off or body.opaque-mode.
+   ═══════════════════════════════════════════════════════════════ */
+
+/* Hide legacy elements */
+.ambient-canvas { display: none; }
+#ambientGlowDiv { display: none; }
+#ambientGlowCanvas { display: none; }
+
+/* Dashboard positioning */
+.dashboard {
+  z-index: 55;
+  pointer-events: none;
+}
+
+/* ── Ambient color vars (set by JS) ── */
+:root {
+  --ambient-r: 80;
+  --ambient-g: 100;
+  --ambient-b: 140;
+  --ambient-lum: 0.35;   /* perceptual luminance 0-1, drives panel dimming */
+  /* Plastic mode telemetry vars (set by ambient-light.js render loop) */
+  --plastic-rotate: 0deg;   /* steering → glow rotation (±4°) */
+  --plastic-sweep: 0px;     /* speed → horizontal sweep offset */
+  --plastic-phase: 0.5;     /* time-based sweep position (0-1) */
+}
+
+/* ── Selector list for ALL panel/module types ── */
+.panel,
+.tacho-block,
+.commentary-inner,
+.leaderboard-panel,
+.datastream-panel,
+.pitbox-panel {
+  position: relative;
+}
+/* incidents + spotter need position:fixed for viewport placement;
+   their ::before/::after still work because the inner wrapper
+   (.inc-inner / .spotter-inner) provides the relative context. */
+.incidents-panel,
+.spotter-panel {
+  position: fixed;
+}
+
+/* ── ::before — PLASTIC MODE ONLY ──
+   CSS-only ambient illumination for the "plastic" mode.
+   Replaces the WebGL postfx glow with layered gradients tinted by
+   the ambient color. Animates via CSS custom properties:
+     --plastic-rotate  → steering rotation (GPU-composited transform)
+     --plastic-sweep   → speed-based horizontal sweep (background-position)
+     --plastic-phase   → time-based breathing (drives box-shadow on panels)
+   Hidden by default; shown only when body.ambient-plastic is set. */
+.panel::before,
+.tacho-block::before,
+.commentary-inner::before,
+.leaderboard-panel::before,
+.datastream-panel::before,
+.pitbox-panel::before,
+.incidents-panel::before,
+.spotter-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  pointer-events: none;
+  border-radius: inherit;
+  overflow: hidden;
+  /* Multi-layer glow — overhead radial + sweep + wash.
+     Ported from the WebGL ambientGlow() center glow + sweep, but
+     using stacked gradients instead of per-pixel exp/sin math.
+     Rotates with steering via --plastic-rotate (GPU-composited transform).
+     Sweep shifts with speed via --plastic-sweep (background-position). */
+  background:
+    /* Layer 1: Overhead radial — main illumination source */
+    radial-gradient(
+      ellipse 140% 90% at 50% 10%,
+      rgba(var(--ambient-r), var(--ambient-g), var(--ambient-b), 0.38) 0%,
+      rgba(var(--ambient-r), var(--ambient-g), var(--ambient-b), 0.18) 30%,
+      rgba(var(--ambient-r), var(--ambient-g), var(--ambient-b), 0.05) 60%,
+      transparent 85%
+    ),
+    /* Layer 2: Diagonal sweep — simulates the WebGL light sweep band.
+       background-position shifts with speed for movement illusion. */
+    linear-gradient(
+      155deg,
+      transparent 5%,
+      rgba(var(--ambient-r), var(--ambient-g), var(--ambient-b), 0.18) 25%,
+      rgba(var(--ambient-r), var(--ambient-g), var(--ambient-b), 0.08) 50%,
+      transparent 70%
+    ),
+    /* Layer 3: Soft full-panel tint wash — base color presence */
+    linear-gradient(
+      180deg,
+      rgba(var(--ambient-r), var(--ambient-g), var(--ambient-b), 0.10) 0%,
+      rgba(var(--ambient-r), var(--ambient-g), var(--ambient-b), 0.03) 100%
+    );
+  /* Sweep layer shifts with speed; other layers stay put */
+  background-position: 0 0, var(--plastic-sweep) 0, 0 0;
+  background-size: 100% 100%;
+  /* Steer rotation (GPU-composited — no layout/paint cost).
+     Inset by -6px so the rotated layer still covers corners without
+     escaping the parent's overflow:hidden clip. */
+  inset: -6px;
+  transform: rotate(var(--plastic-rotate));
+  transform-origin: 50% 40%;
+  will-change: transform, background-position;
+  /* Scale intensity with ambient brightness */
+  opacity: calc(0.4 + var(--ambient-lum) * 0.5);
+  transition: opacity 600ms ease;
+  /* Hidden by default — only plastic mode enables this */
+  display: none;
+}
+
+/* Show ::before glow ONLY in plastic mode */
+body.ambient-plastic .panel::before,
+body.ambient-plastic .tacho-block::before,
+body.ambient-plastic .commentary-inner::before,
+body.ambient-plastic .leaderboard-panel::before,
+body.ambient-plastic .datastream-panel::before,
+body.ambient-plastic .pitbox-panel::before,
+body.ambient-plastic .incidents-panel::before,
+body.ambient-plastic .spotter-panel::before {
+  display: block;
+}
+
+/* Plastic mode: clip ::before to panel bounds.
+   overflow:hidden clips the rotated pseudo-element to the panel's rounded rect.
+   All box-shadows are inset so the glow never escapes the module boundaries —
+   outer box-shadow bleeds through overflow:hidden by CSS spec, which is what
+   caused the "front and back lit" look. Inset-only keeps it front-lit. */
+body.ambient-plastic .panel,
+body.ambient-plastic .tacho-block,
+body.ambient-plastic .commentary-inner,
+body.ambient-plastic .leaderboard-panel,
+body.ambient-plastic .datastream-panel,
+body.ambient-plastic .pitbox-panel,
+body.ambient-plastic .incidents-panel,
+body.ambient-plastic .spotter-panel {
+  overflow: hidden;
+  box-shadow:
+    inset 0 0 32px 10px rgba(var(--ambient-r), var(--ambient-g), var(--ambient-b),
+      calc((0.15 + var(--plastic-phase) * 0.15) * var(--ambient-lum))),
+    inset 0 1px 0 rgba(var(--ambient-r), var(--ambient-g), var(--ambient-b), 0.18);
+  transition: box-shadow 600ms ease;
+}
+
+/* ── ::after — Glass refraction surface ──
+   Simulates light refracting across a glass panel surface.
+   Shows a diagonal caustic sweep tinted by the ambient color,
+   plus a sharp specular highlight at the leading edge.
+   Dark ambient → subtle, bright ambient → prominent refraction. */
+.panel::after,
+.tacho-block::after,
+.commentary-inner::after,
+.leaderboard-panel::after,
+.datastream-panel::after,
+.pitbox-panel::after,
+.incidents-panel::after,
+.spotter-panel::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+  border-radius: inherit;
+  overflow: hidden;
+  /* Glass refraction: sharp specular highlight + ambient tint sweep */
+  background:
+    /* Specular highlight — bright leading edge of refraction */
+    linear-gradient(
+      160deg,
+      rgba(255, 255, 255, 0.22) 0%,
+      rgba(255, 255, 255, 0.06) 12%,
+      transparent 24%
+    ),
+    /* Caustic refraction — ambient color refracting across surface */
+    linear-gradient(
+      165deg,
+      transparent 10%,
+      rgba(var(--ambient-r), var(--ambient-g), var(--ambient-b), 0.08) 30%,
+      rgba(var(--ambient-r), var(--ambient-g), var(--ambient-b), 0.03) 55%,
+      transparent 75%
+    ),
+    /* Secondary refraction — softer, offset angle for glass depth */
+    linear-gradient(
+      175deg,
+      transparent 25%,
+      rgba(var(--ambient-r), var(--ambient-g), var(--ambient-b), 0.03) 50%,
+      transparent 70%
+    );
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  /* Scale with ambient brightness */
+  opacity: calc(0.25 + var(--ambient-lum) * 0.35);
+  transition: opacity 400ms ease;
+}
+
+/* ── Matte mode: glass reflections at 50% ── */
+body.ambient-matte .panel::after,
+body.ambient-matte .tacho-block::after,
+body.ambient-matte .commentary-inner::after,
+body.ambient-matte .leaderboard-panel::after,
+body.ambient-matte .datastream-panel::after,
+body.ambient-matte .pitbox-panel::after,
+body.ambient-matte .incidents-panel::after,
+body.ambient-matte .spotter-panel::after {
+  opacity: calc((0.25 + var(--ambient-lum) * 0.35) * 0.5) !important;
+}
+
+/* ── Plastic mode: glass reflections at full (same as reflective) ── */
+/* (::after stays as-is — no override needed, inherits default full opacity) */
+
+/* ── Kill glass reflections + glow when ambient is off ── */
+body.ambient-off .panel::after,
+body.ambient-off .tacho-block::after,
+body.ambient-off .commentary-inner::after,
+body.ambient-off .leaderboard-panel::after,
+body.ambient-off .datastream-panel::after,
+body.ambient-off .pitbox-panel::after,
+body.ambient-off .incidents-panel::after,
+body.ambient-off .spotter-panel::after,
+body.ambient-off .panel::before,
+body.ambient-off .tacho-block::before,
+body.ambient-off .commentary-inner::before,
+body.ambient-off .leaderboard-panel::before,
+body.ambient-off .datastream-panel::before,
+body.ambient-off .pitbox-panel::before,
+body.ambient-off .incidents-panel::before,
+body.ambient-off .spotter-panel::before {
+  display: none !important;
+}
+
+/* ── Green-screen mode: also disable reflections + glow ── */
+body.opaque-mode .panel::after,
+body.opaque-mode .tacho-block::after,
+body.opaque-mode .commentary-inner::after,
+body.opaque-mode .leaderboard-panel::after,
+body.opaque-mode .datastream-panel::after,
+body.opaque-mode .pitbox-panel::after,
+body.opaque-mode .incidents-panel::after,
+body.opaque-mode .spotter-panel::after,
+body.opaque-mode .panel::before,
+body.opaque-mode .tacho-block::before,
+body.opaque-mode .commentary-inner::before,
+body.opaque-mode .leaderboard-panel::before,
+body.opaque-mode .datastream-panel::before,
+body.opaque-mode .pitbox-panel::before,
+body.opaque-mode .incidents-panel::before,
+body.opaque-mode .spotter-panel::before {
+  display: none !important;
+}
+
+/* ═══════════════════════════════════════════════
+   CAPTURE AREA SELECTION OVERLAY
+   ═══════════════════════════════════════════════ */
+.capture-area-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  background: rgba(0, 0, 0, 0.35);
+  cursor: crosshair;
+  user-select: none;
+  -webkit-user-select: none;
+}
+.capture-area-instructions {
+  position: absolute;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  pointer-events: none;
+  white-space: nowrap;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+}
+.capture-area-rect {
+  position: absolute;
+  border: 2px solid hsl(45, 100%, 60%);
+  background: hsla(45, 100%, 60%, 0.12);
+  border-radius: 3px;
+  pointer-events: none;
+  display: none;
+  box-shadow: 0 0 12px hsla(45, 100%, 60%, 0.3);
+}
+
+/* Settings button style */
+.settings-btn {
+  background: hsla(0, 0%, 100%, 0.08);
+  color: var(--text-primary, #eee);
+  border: 1px solid hsla(0, 0%, 100%, 0.15);
+  border-radius: 4px;
+  padding: 4px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 200ms ease, border-color 200ms ease;
+}
+.settings-btn:hover {
+  background: hsla(0, 0%, 100%, 0.15);
+  border-color: hsla(45, 100%, 60%, 0.5);
+}
+.settings-btn.active {
+  background: hsla(45, 100%, 60%, 0.2);
+  border-color: hsla(45, 100%, 60%, 0.7);
+  color: hsl(45, 100%, 75%);
+}
+
+/* ═══════════════════════════════════════════════
+   AMBIENT CAPTURE PREVIEW (in settings panel)
+   ═══════════════════════════════════════════════ */
+.ambient-preview-container {
+  margin-top: 8px;
+  padding: 8px;
+  background: hsla(0, 0%, 0%, 0.35);
+  border-radius: 6px;
+  border: 1px solid hsla(0, 0%, 100%, 0.08);
+}
+.ambient-preview-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: hsla(0, 0%, 100%, 0.5);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 6px;
+}
+.ambient-preview-canvas {
+  width: 100%;
+  height: auto;
+  border-radius: 4px;
+  background: #111;
+  display: block;
+}
+.ambient-preview-info {
+  font-size: 11px;
+  color: hsla(0, 0%, 100%, 0.4);
+  margin-top: 4px;
+  text-align: center;
+}
+.ambient-preview-swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  vertical-align: middle;
+  margin-right: 4px;
+  border: 1px solid hsla(0, 0%, 100%, 0.2);
+}
+
+</style>
+<style>
+
+/* ── Web demo overrides ── */
+html, body {
+  margin: 0; padding: 0;
+  background: #0a0a14 !important;
+  overflow: hidden;
+  /* Ensure dashboard fonts apply even if Google Fonts loads slowly */
+  font-family: 'Barlow Condensed', 'Barlow Semi Condensed', system-ui, sans-serif;
+}
+
+/* Hide non-essential elements that may get created by JS */
+.conn-status,
+.conn-banner,
+.sec-container,
+.commentary-col,
+.settings-overlay,
+.drive-hud,
+#connBanner,
+#connStatus,
+#secContainer,
+#gameLogoOverlay {
+  display: none !important;
+}
+
+/* Dashboard: relative position, shrink to content width */
+.dashboard {
+  position: relative !important;
+  top: auto !important;
+  right: auto !important;
+  bottom: auto !important;
+  left: auto !important;
+  margin: 0 auto !important;
+  padding: 0 !important;
+  width: fit-content !important;
+}
+/* Kill the edge inset variable — we want zero margins in the embed */
+:root { --edge: 0px !important; --edge-z: 0px !important; }
+
+/* Ensure panels are visible (some toggled via settings) */
+.tacho-block,
+.fuel-tyres-col,
+.controls-pedals-block,
+.maps-col,
+.pos-gaps-col,
+.logo-col,
+.timer-row {
+  display: flex !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+}
+
+/* Timer row defaults to max-height:0 — force it open */
+.timer-row {
+  max-height: 80px !important;
+  overflow: visible !important;
+  padding: 0 !important;
+}
+.race-timer-block {
+  display: flex !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+}
+
+/* Suppress Electron-specific hover states and click targets */
+.settings-toggle,
+.settings-overlay {
+  pointer-events: none !important;
+}
+
+/* Kill any startup/splash animations that expect Electron IPC */
+.startup-overlay,
+.logo-splash {
+  display: none !important;
+}
+
+/* WebGL canvases — fill the iframe viewport, behind the dashboard */
+.ambient-canvas,
+#glareCanvas {
+  position: fixed !important;
+  inset: 0;
+  width: 100vw !important;
+  height: 100vh !important;
+}
+
+/* ── Responsive breakpoints ──
+   Hide panels when viewport can no longer fit them.
+   Cumulative widths (incl. 4px gaps):
+     All 6:  904px
+     −logo:  802px
+     −maps:  702px
+     −fuel:  538px
+     −peds:  294px                                               */
+
+/* ≤ 903px — drop logo (remaining ≈ 802px) */
+@media (max-width: 903px) {
+  .logo-col { display: none !important; }
+}
+
+/* ≤ 801px — drop maps (remaining ≈ 702px) */
+@media (max-width: 801px) {
+  .maps-col { display: none !important; }
+}
+
+/* ≤ 701px — drop fuel & tyres (remaining ≈ 538px) */
+@media (max-width: 701px) {
+  .fuel-tyres-col { display: none !important; }
+}
+
+/* ≤ 537px — drop pedals/controls (remaining ≈ 294px) */
+@media (max-width: 537px) {
+  .controls-pedals-block { display: none !important; }
+}
+
+/* ≤ 293px — drop position, tacho only */
+@media (max-width: 293px) {
+  .pos-gaps-col { display: none !important; }
+}
+
+</style>
+</head>
+<body class="game-iracing">
+
+<canvas class="ambient-canvas" id="ambientGlCanvas"></canvas>
+<canvas id="glareCanvas" style="position:fixed;inset:0;width:100vw;height:100vh;pointer-events:none;z-index:60;"></canvas>
+
+<!-- COMPONENT: Main Dashboard -->
+<div class="dashboard layout-tr" id="dashboard">
+
+  <div class="main-row">
+  <div class="main-area">
+
+    <!-- COL: Fuel (top) + Tyres (bottom) — separate panels -->
+    <div class="fuel-tyres-col">
+      <div class="panel fuel-block">
+        <div class="panel-label">Fuel</div>
+        <div class="fuel-remaining">— <span class="unit">L</span></div>
+        <div class="fuel-bar-outer">
+          <div class="fuel-bar-inner healthy" style="width: 0%;"></div>
+        </div>
+        <div class="fuel-stats">
+          <span>Avg <span class="val">—</span> L/lap</span>
+          <span>Est <span class="val">—</span> laps</span>
+        </div>
+        <div class="fuel-pit-suggest"></div>
+      </div>
+      <div class="panel tyres-block">
+        <div class="panel-label">Tyres °F</div>
+        <div class="tyre-grid">
+          <div><div class="tyre-label">FL</div><div class="tyre-cell">—</div><div class="tyre-wear-bar"><div class="tyre-wear-fill" style="width:0%;"></div></div></div>
+          <div><div class="tyre-label">FR</div><div class="tyre-cell">—</div><div class="tyre-wear-bar"><div class="tyre-wear-fill" style="width:0%;"></div></div></div>
+          <div><div class="tyre-label">RL</div><div class="tyre-cell">—</div><div class="tyre-wear-bar"><div class="tyre-wear-fill" style="width:0%;"></div></div></div>
+          <div><div class="tyre-label">RR</div><div class="tyre-cell">—</div><div class="tyre-wear-bar"><div class="tyre-wear-fill" style="width:0%;"></div></div></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- COL: Controls + Layered Pedals -->
+    <div class="controls-pedals-block">
+      <div class="panel car-controls">
+        <div class="ctrl-item" id="ctrlBB" style="--ctrl-pct:0%;"><div class="ctrl-label">BB</div><div class="ctrl-value">—</div></div>
+        <div class="ctrl-item" id="ctrlTC" style="--ctrl-pct:0%;"><div class="ctrl-label">TC</div><div class="ctrl-value">—</div></div>
+        <div class="ctrl-item" id="ctrlABS" style="--ctrl-pct:0%;"><div class="ctrl-label">ABS</div><div class="ctrl-value">—</div></div>
+        <div class="ctrl-no-adj" id="ctrlNoAdj">NO ADJUSTMENTS</div>
+      </div>
+      <div class="panel pedals-area" id="pedalsArea">
+        <div class="pedal-labels-row">
+          <div class="pedal-label-group">
+            <div class="pedal-channel-label throttle">THROTTLE</div>
+            <div class="pedal-pct" style="color:var(--green);">0%</div>
+          </div>
+          <div class="pedal-label-group">
+            <div class="pedal-channel-label brake">BRAKE</div>
+            <div class="pedal-pct" style="color:var(--red);">0%</div>
+          </div>
+          <div class="pedal-label-group" id="clutchLabelGroup">
+            <div class="pedal-channel-label clutch">CLUTCH</div>
+            <div class="pedal-pct" style="color:var(--blue);">0%</div>
+          </div>
+        </div>
+        <div class="pedal-viz-stack">
+          <div class="pedal-viz-layer throttle-layer" id="throttleHist"></div>
+          <div class="pedal-viz-layer brake-layer" id="brakeHist"></div>
+          <div class="pedal-viz-layer clutch-layer" id="clutchHist"></div>
+          <canvas class="pedal-trace-canvas" id="pedalTraceCanvas" width="240" height="80"></canvas>
+          <!-- Pedal curve overlay: response curves fill the histogram space -->
+          <canvas class="pedal-curve-canvas" id="pedalCurveCanvas" width="240" height="80"></canvas>
+        </div>
+        <div class="pedal-profile-label" id="pedalProfileLabel"></div>
+      </div>
+    </div>
+
+    <!-- COL: Maps stacked — rendered dynamically from TrackMapProvider -->
+    <div class="maps-col">
+      <div class="panel map-panel">
+        <svg class="map-svg" id="fullMapSvg" viewBox="0 0 100 100">
+          <path class="map-track" id="fullMapTrack" d="" />
+          <path class="map-sector" id="mapSector1" d="" />
+          <path class="map-sector" id="mapSector2" d="" />
+          <path class="map-sector" id="mapSector3" d="" />
+          <g id="fullMapSF" class="map-sf" style="display:none;">
+            <line x1="0" y1="-3.5" x2="0" y2="3.5" stroke="#fff" stroke-width="1.2" stroke-linecap="round"/>
+            <rect x="-5" y="-2.5" width="5" height="2.5" fill="#fff" opacity="0.9"/>
+            <rect x="0" y="-2.5" width="5" height="2.5" fill="#111" stroke="#fff" stroke-width="0.3"/>
+            <rect x="-5" y="0" width="5" height="2.5" fill="#111" stroke="#fff" stroke-width="0.3"/>
+            <rect x="0" y="0" width="5" height="2.5" fill="#fff" opacity="0.9"/>
+          </g>
+          <g id="fullMapOpponents"></g>
+          <circle class="map-player" id="fullMapPlayer" cx="50" cy="50" r="4" />
+        </svg>
+        <div class="map-zoom-label" id="fullMapLabel">Full</div>
+      </div>
+      <div class="panel map-zoom-panel">
+        <svg class="map-zoom-svg" id="zoomMapSvg" viewBox="0 0 100 100" overflow="visible">
+          <!-- Rotate group: track + opponents rotate around the player so
+               driving direction always points up. Player dot is OUTSIDE
+               this group so it stays upright and visually centered. -->
+          <g id="zoomMapRotateGroup">
+            <path class="map-track" id="zoomMapTrack" d="" style="stroke-width:1.5;" />
+            <g id="zoomMapSF" class="map-sf" style="display:none;">
+              <line x1="0" y1="-2" x2="0" y2="2" stroke="#fff" stroke-width="0.6" stroke-linecap="round"/>
+              <rect x="-2.5" y="-1.25" width="2.5" height="1.25" fill="#fff" opacity="0.9"/>
+              <rect x="0" y="-1.25" width="2.5" height="1.25" fill="#111" stroke="#fff" stroke-width="0.15"/>
+              <rect x="-2.5" y="0" width="2.5" height="1.25" fill="#111" stroke="#fff" stroke-width="0.15"/>
+              <rect x="0" y="0" width="2.5" height="1.25" fill="#fff" opacity="0.9"/>
+            </g>
+            <g id="zoomMapOpponents"></g>
+          </g>
+          <!-- Player dot outside rotate group — always upright at center -->
+          <circle class="map-player" id="zoomMapPlayer" cx="50" cy="50" r="2" />
+        </svg>
+        <div class="map-zoom-label" id="zoomMapLabel">Local</div>
+      </div>
+    </div>
+
+    <!-- COL: Position/Rating + Gaps -->
+    <div class="pos-gaps-col">
+      <div class="panel cycle-container rating-pos-block" id="cycleRatingPos">
+        <div class="cycle-sizer">
+          <div class="pos-layout">
+            <div class="pos-number"><span class="skew-accent">P—</span><div class="pos-delta"></div></div>
+            <div class="pos-meta">
+              <div class="pos-meta-row">Lap <span class="val">—</span></div>
+              <div class="pos-meta-row current-row"><span class="val">—:——.———</span></div>
+              <div class="pos-meta-row delta-row"><span class="val"></span></div>
+            </div>
+          </div>
+        </div>
+        <!-- Page A: iRating + SR with charts -->
+        <div class="cycle-page active" id="ratingPage">
+          <div class="rating-row">
+            <div class="rating-item">
+              <div class="panel-label">iRating</div>
+              <div class="rating-value">—</div>
+              <div class="rating-delta">—</div>
+              <div class="ir-bar-container">
+                <div class="ir-bar-track">
+                  <div class="ir-bar-fill" id="irBarFill" style="width: 0%;"></div>
+                  <div class="ir-bar-ticks">
+                    <div class="ir-bar-tick" style="left: 20%;"></div>
+                    <div class="ir-bar-tick-label" style="left: 20%;">1k</div>
+                    <div class="ir-bar-tick" style="left: 40%;"></div>
+                    <div class="ir-bar-tick-label" style="left: 40%;">2k</div>
+                    <div class="ir-bar-tick" style="left: 60%;"></div>
+                    <div class="ir-bar-tick-label" style="left: 60%;">3k</div>
+                    <div class="ir-bar-tick" style="left: 80%;"></div>
+                    <div class="ir-bar-tick-label" style="left: 80%;">4k</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="rating-item">
+              <div class="panel-label">SR</div>
+              <div class="rating-value" style="font-size:14px;">—</div>
+              <div class="rating-delta">—</div>
+              <div class="sr-pie-container">
+                <svg class="sr-pie-svg" viewBox="0 0 40 40">
+                  <circle class="sr-pie-bg" cx="20" cy="20" r="15"/>
+                  <circle class="sr-pie-fill" id="srPieFill" cx="20" cy="20" r="15"
+                    stroke="var(--green)"
+                    stroke-dasharray="94.25"
+                    stroke-dashoffset="18.85"/>
+                  <!-- no text overlay -->
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Page B: Position + Best (purple) -->
+        <div class="cycle-page inactive" id="positionPage">
+          <div class="pos-layout">
+            <div class="pos-number"><span class="skew-accent">P—</span><div class="pos-delta"></div></div>
+            <div class="pos-meta">
+              <div class="pos-meta-row">Lap <span class="val">—</span></div>
+              <div class="pos-meta-row current-row"><span class="val">—:——.———</span></div>
+              <div class="pos-meta-row delta-row"><span class="val"></span></div>
+            </div>
+          </div>
+        </div>
+        <div class="cycle-dots"><div class="cycle-dot active" id="dotRating"></div><div class="cycle-dot" id="dotPos"></div></div>
+      </div>
+
+      <div class="panel gaps-block" id="gapsBlock">
+        <!-- Race mode: ahead/behind -->
+        <div class="gap-item" id="gapAheadItem">
+          <div class="gap-normal">
+            <div class="panel-label">Ahead</div>
+            <div class="gap-time ahead">—</div>
+            <div class="gap-driver">—</div>
+            <div class="gap-ir"></div>
+          </div>
+        </div>
+        <div class="gap-item" id="gapBehindItem">
+          <div class="gap-normal">
+            <div class="panel-label">Behind</div>
+            <div class="gap-time behind">—</div>
+            <div class="gap-driver">—</div>
+            <div class="gap-ir"></div>
+          </div>
+        </div>
+        <!-- Non-race mode: F1-style sector indicator -->
+        <div class="sector-indicator" id="sectorIndicator" style="display:none;">
+          <div class="sector-cell" id="sector1"><div class="sector-label">S1</div><div class="sector-time" id="sector1Time">—</div><div class="sector-delta" id="sector1Delta"></div></div>
+          <div class="sector-cell" id="sector2"><div class="sector-label">S2</div><div class="sector-time" id="sector2Time">—</div><div class="sector-delta" id="sector2Delta"></div></div>
+          <div class="sector-cell" id="sector3"><div class="sector-label">S3</div><div class="sector-time" id="sector3Time">—</div><div class="sector-delta" id="sector3Delta"></div></div>
+        </div>
+        <canvas class="flag-gl gl-overlay" id="flagGlCanvas"></canvas>
+        <div class="flag-overlay" id="flagOverlay">
+          <div class="flag-label" id="flagLabel1"></div>
+          <div class="flag-context" id="flagCtx1"></div>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- COL: Tachometer -->
+    <div class="panel tacho-block">
+      <canvas class="gl-overlay" id="tachoGlCanvas"></canvas>
+      <div class="tacho-top-row">
+        <div class="tacho-gear" id="gearText">N</div>
+        <div class="tacho-speed-cluster">
+          <div class="speed-value" id="speedText">0</div>
+          <div class="speed-unit">MPH</div>
+        </div>
+      </div>
+      <span class="tacho-rpm" id="rpmText" style="color: var(--text-dim);">0</span>
+      <div class="tacho-bar-track" id="tachoBar"></div>
+    </div>
+
+    <!-- COL: Logo (two stacked squares) -->
+    <div class="logo-col">
+      <div class="logo-square" id="k10LogoSquare">
+        <canvas class="gl-overlay" id="k10LogoGlCanvas" style="z-index:1;"></canvas>
+        <img src="images/branding/logomark.png" alt="K10 Motorsports" style="width:75%;height:auto;opacity:1;position:relative;z-index:2;">
+      </div>
+      <div class="logo-square" id="carLogoSquare">
+        <canvas class="mfr-flag-canvas" id="mfrFlagCanvas"></canvas>
+        <!-- Generic logo (replaced by JS when CarModel data arrives) -->
+        <div class="car-logo-icon" id="carLogoIcon">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80">
+            <circle cx="40" cy="40" r="30" fill="none" stroke="hsla(0,0%,100%,0.3)" stroke-width="4"/>
+            <circle cx="40" cy="40" r="22" fill="none" stroke="hsla(0,0%,100%,0.15)" stroke-width="2"/>
+            <circle cx="40" cy="40" r="5" fill="hsla(0,0%,100%,0.3)"/>
+            <line x1="40" y1="10" x2="40" y2="18" stroke="hsla(0,0%,100%,0.3)" stroke-width="3" stroke-linecap="round"/>
+            <line x1="40" y1="62" x2="40" y2="70" stroke="hsla(0,0%,100%,0.3)" stroke-width="3" stroke-linecap="round"/>
+            <line x1="10" y1="40" x2="18" y2="40" stroke="hsla(0,0%,100%,0.3)" stroke-width="3" stroke-linecap="round"/>
+            <line x1="62" y1="40" x2="70" y2="40" stroke="hsla(0,0%,100%,0.3)" stroke-width="3" stroke-linecap="round"/>
+          </svg>
+        </div>
+        <span class="car-model-label" id="carModelLabel"></span>
+      </div>
+    </div>
+
+  </div><!-- /main-area -->
+  </div><!-- /main-row -->
+
+  <!-- ROW: Race Timer — aligned with position box -->
+  <div class="timer-row">
+    <div class="panel race-timer-block" id="raceTimerBlock">
+      <div class="race-timer-value" id="raceTimerValue">0:00:00</div>
+      <div class="race-timer-lap"><span class="timer-label">Last</span> <span id="lastLapTimeValue">—:——.———</span></div>
+    </div>
+  </div>
+
+  <div class="conn-status connecting" id="connStatus" title="Connecting to plugin server..."></div>
+
+</div><!-- /dashboard -->
+
+<script>
+// ── modules/js/config.js ──
+// K10 Motorsports Dashboard — Shared Configuration & State
+// This module defines all global constants and state variables used across other modules.
+// All variables are implicitly global (shared scope) since modules load via <script src> tags.
+
+// ═══════════════════════════════════════════════════════════════
+// SIMHUB HTTP API CONFIGURATION
+// ═══════════════════════════════════════════════════════════════
+
+const SIMHUB_URL = 'http://localhost:8889/k10mediabroadcaster/';
+const POLL_MS = 33; // ~30fps
+
+// All properties we need, batched into a single request
+const PROP_KEYS = [
+  'DataCorePlugin.GameRunning',
+  'K10Motorsports.Plugin.GameId',
+  'DataCorePlugin.GameData.Gear',
+  'DataCorePlugin.GameData.Rpms',
+  'DataCorePlugin.GameData.CarSettings_MaxRPM',
+  'DataCorePlugin.GameData.SpeedMph',
+  'DataCorePlugin.GameData.Throttle',
+  'DataCorePlugin.GameData.Brake',
+  'DataCorePlugin.GameData.Clutch',
+  'DataCorePlugin.GameData.Fuel',
+  'DataCorePlugin.GameData.MaxFuel',
+  'DataCorePlugin.Computed.Fuel_LitersPerLap',
+  'DataCorePlugin.GameData.RemainingLaps',
+  'DataCorePlugin.GameData.TyreTempFrontLeft',
+  'DataCorePlugin.GameData.TyreTempFrontRight',
+  'DataCorePlugin.GameData.TyreTempRearLeft',
+  'DataCorePlugin.GameData.TyreTempRearRight',
+  'DataCorePlugin.GameData.TyreWearFrontLeft',
+  'DataCorePlugin.GameData.TyreWearFrontRight',
+  'DataCorePlugin.GameData.TyreWearRearLeft',
+  'DataCorePlugin.GameData.TyreWearRearRight',
+  'DataCorePlugin.GameRawData.Telemetry.dcBrakeBias',
+  'DataCorePlugin.GameRawData.Telemetry.dcTractionControl',
+  'DataCorePlugin.GameRawData.Telemetry.dcABS',
+  'DataCorePlugin.GameRawData.Telemetry.dcAntiRollFront',
+  'DataCorePlugin.GameRawData.Telemetry.dcAntiRollRear',
+  'DataCorePlugin.GameData.Position',
+  'DataCorePlugin.GameData.CurrentLap',
+  'DataCorePlugin.GameData.BestLapTime',
+  'DataCorePlugin.GameData.CarModel',
+  'IRacingExtraProperties.iRacing_DriverInfo_IRating',
+  'IRacingExtraProperties.iRacing_DriverInfo_SafetyRating',
+  'IRacingExtraProperties.iRacing_Opponent_Ahead_Gap',
+  'IRacingExtraProperties.iRacing_Opponent_Behind_Gap',
+  'IRacingExtraProperties.iRacing_Opponent_Ahead_Name',
+  'IRacingExtraProperties.iRacing_Opponent_Behind_Name',
+  'IRacingExtraProperties.iRacing_Opponent_Ahead_IRating',
+  'IRacingExtraProperties.iRacing_Opponent_Behind_IRating',
+  'DataCorePlugin.GameRawData.Telemetry.FrameRate',
+  'DataCorePlugin.GameRawData.Telemetry.SteeringWheelAngle',
+  'DataCorePlugin.GameData.SessionTimeSpan',
+  'DataCorePlugin.GameData.CurrentLapTime',
+  'DataCorePlugin.GameData.LastLapTime',
+  'DataCorePlugin.GameData.RemainingTime',
+  'DataCorePlugin.GameData.TotalLaps',
+  'K10Motorsports.Plugin.CommentaryVisible',
+  'K10Motorsports.Plugin.CommentaryText',
+  'K10Motorsports.Plugin.CommentaryTopicTitle',
+  'K10Motorsports.Plugin.CommentaryTopicId',
+  'K10Motorsports.Plugin.CommentaryCategory',
+  'K10Motorsports.Plugin.CommentarySentimentColor',
+  'K10Motorsports.Plugin.CommentarySeverity',
+  // Strategy engine properties
+  'K10Motorsports.Plugin.Strategy.Visible',
+  'K10Motorsports.Plugin.Strategy.Text',
+  'K10Motorsports.Plugin.Strategy.Label',
+  'K10Motorsports.Plugin.Strategy.Severity',
+  'K10Motorsports.Plugin.Strategy.Color',
+  'K10Motorsports.Plugin.Strategy.TextColor',
+  'K10Motorsports.Plugin.Strategy.FuelLapsRemaining',
+  'K10Motorsports.Plugin.Strategy.FuelHealthState',
+  'K10Motorsports.Plugin.Strategy.CanMakeItToEnd',
+  'K10Motorsports.Plugin.Strategy.PitWindowOpen',
+  'K10Motorsports.Plugin.Strategy.PitWindowClose',
+  'K10Motorsports.Plugin.Strategy.TireHealthState',
+  'K10Motorsports.Plugin.Strategy.TireLapsRemaining',
+  'K10Motorsports.Plugin.Strategy.GripScore',
+  'K10Motorsports.Plugin.Strategy.StintNumber',
+  'K10Motorsports.Plugin.Strategy.StintLaps',
+  'K10Motorsports.Plugin.SessionTypeName',
+  // Demo mode properties
+  'K10Motorsports.Plugin.DemoMode',
+  'K10Motorsports.Plugin.Demo.Gear',
+  'K10Motorsports.Plugin.Demo.Rpm',
+  'K10Motorsports.Plugin.Demo.MaxRpm',
+  'K10Motorsports.Plugin.Demo.SpeedMph',
+  'K10Motorsports.Plugin.Demo.Throttle',
+  'K10Motorsports.Plugin.Demo.Brake',
+  'K10Motorsports.Plugin.Demo.Clutch',
+  'K10Motorsports.Plugin.Demo.Fuel',
+  'K10Motorsports.Plugin.Demo.MaxFuel',
+  'K10Motorsports.Plugin.Demo.FuelPerLap',
+  'K10Motorsports.Plugin.Demo.RemainingLaps',
+  'K10Motorsports.Plugin.Demo.TyreTempFL',
+  'K10Motorsports.Plugin.Demo.TyreTempFR',
+  'K10Motorsports.Plugin.Demo.TyreTempRL',
+  'K10Motorsports.Plugin.Demo.TyreTempRR',
+  'K10Motorsports.Plugin.Demo.TyreWearFL',
+  'K10Motorsports.Plugin.Demo.TyreWearFR',
+  'K10Motorsports.Plugin.Demo.TyreWearRL',
+  'K10Motorsports.Plugin.Demo.TyreWearRR',
+  'K10Motorsports.Plugin.Demo.BrakeBias',
+  'K10Motorsports.Plugin.Demo.TC',
+  'K10Motorsports.Plugin.Demo.ABS',
+  'K10Motorsports.Plugin.Demo.SessionTypeName',
+  'K10Motorsports.Plugin.Demo.Position',
+  'K10Motorsports.Plugin.Demo.CurrentLap',
+  'K10Motorsports.Plugin.Demo.BestLapTime',
+  'K10Motorsports.Plugin.Demo.CarModel',
+  'K10Motorsports.Plugin.Demo.SessionTime',
+  'K10Motorsports.Plugin.Demo.CurrentLapTime',
+  'K10Motorsports.Plugin.Demo.LastLapTime',
+  'K10Motorsports.Plugin.Demo.RemainingTime',
+  'K10Motorsports.Plugin.Demo.TotalLaps',
+  'K10Motorsports.Plugin.Demo.IRating',
+  'K10Motorsports.Plugin.Demo.SafetyRating',
+  'K10Motorsports.Plugin.Demo.GapAhead',
+  'K10Motorsports.Plugin.Demo.GapBehind',
+  'K10Motorsports.Plugin.Demo.DriverAhead',
+  'K10Motorsports.Plugin.Demo.DriverBehind',
+  'K10Motorsports.Plugin.Demo.IRAhead',
+  'K10Motorsports.Plugin.Demo.IRBehind',
+  // Datastream (advanced telemetry)
+  'K10Motorsports.Plugin.DS.LatG',
+  'K10Motorsports.Plugin.DS.LongG',
+  'K10Motorsports.Plugin.DS.YawRate',
+  'K10Motorsports.Plugin.DS.SteerTorque',
+  'K10Motorsports.Plugin.DS.TrackTemp',
+  'K10Motorsports.Plugin.DS.IncidentCount',
+  'K10Motorsports.Plugin.DS.EstimatedIRatingDelta',
+  'K10Motorsports.Plugin.DS.IRatingFieldSize',
+  'K10Motorsports.Plugin.DS.AbsActive',
+  'K10Motorsports.Plugin.DS.TcActive',
+  'K10Motorsports.Plugin.DS.TrackPct',
+  'K10Motorsports.Plugin.DS.LapDelta',
+  'K10Motorsports.Plugin.DS.CurrentSector',
+  'K10Motorsports.Plugin.DS.SectorCount',
+  'K10Motorsports.Plugin.DS.SectorSplits',
+  'K10Motorsports.Plugin.DS.SectorDeltas',
+  'K10Motorsports.Plugin.DS.SectorStates',
+  'K10Motorsports.Plugin.DS.SectorBoundaryPcts',
+  'K10Motorsports.Plugin.DS.SectorSplitS1',
+  'K10Motorsports.Plugin.DS.SectorSplitS2',
+  'K10Motorsports.Plugin.DS.SectorSplitS3',
+  'K10Motorsports.Plugin.DS.SectorDeltaS1',
+  'K10Motorsports.Plugin.DS.SectorDeltaS2',
+  'K10Motorsports.Plugin.DS.SectorDeltaS3',
+  'K10Motorsports.Plugin.DS.SectorStateS1',
+  'K10Motorsports.Plugin.DS.SectorStateS2',
+  'K10Motorsports.Plugin.DS.SectorStateS3',
+  'K10Motorsports.Plugin.DS.SectorS2StartPct',
+  'K10Motorsports.Plugin.DS.SectorS3StartPct',
+  'K10Motorsports.Plugin.DS.CompletedLaps',
+  'K10Motorsports.Plugin.DS.IsInPitLane',
+  'K10Motorsports.Plugin.DS.SpeedKmh',
+  'K10Motorsports.Plugin.DS.PitLimiterOn',
+  'K10Motorsports.Plugin.DS.PitSpeedLimitKmh',
+  // Computed DS.* (server-side calculations)
+  'K10Motorsports.Plugin.DS.ThrottleNorm',
+  'K10Motorsports.Plugin.DS.BrakeNorm',
+  'K10Motorsports.Plugin.DS.ClutchNorm',
+  'K10Motorsports.Plugin.DS.RpmRatio',
+  'K10Motorsports.Plugin.DS.FuelPct',
+  'K10Motorsports.Plugin.DS.FuelLapsRemaining',
+  'K10Motorsports.Plugin.DS.SpeedMph',
+  'K10Motorsports.Plugin.DS.PitSpeedLimitMph',
+  'K10Motorsports.Plugin.DS.IsPitSpeeding',
+  'K10Motorsports.Plugin.DS.IsNonRaceSession',
+  'K10Motorsports.Plugin.DS.IsTimedRace',
+  'K10Motorsports.Plugin.DS.IsEndOfRace',
+  'K10Motorsports.Plugin.DS.PositionDelta',
+  'K10Motorsports.Plugin.DS.StartPosition',
+  'K10Motorsports.Plugin.DS.RemainingTimeFormatted',
+  'K10Motorsports.Plugin.DS.SpeedDisplay',
+  'K10Motorsports.Plugin.DS.RpmDisplay',
+  'K10Motorsports.Plugin.DS.FuelFormatted',
+  'K10Motorsports.Plugin.DS.FuelPerLapFormatted',
+  'K10Motorsports.Plugin.DS.PitSuggestion',
+  'K10Motorsports.Plugin.DS.BBNorm',
+  'K10Motorsports.Plugin.DS.TCNorm',
+  'K10Motorsports.Plugin.DS.ABSNorm',
+  'K10Motorsports.Plugin.DS.PositionDeltaDisplay',
+  'K10Motorsports.Plugin.DS.LapDeltaDisplay',
+  'K10Motorsports.Plugin.DS.SafetyRatingDisplay',
+  'K10Motorsports.Plugin.DS.GapAheadFormatted',
+  'K10Motorsports.Plugin.DS.GapBehindFormatted',
+  // Ambient light (screen color from C# plugin)
+  'K10Motorsports.Plugin.DS.AmbientR',
+  'K10Motorsports.Plugin.DS.AmbientG',
+  'K10Motorsports.Plugin.DS.AmbientB',
+  'K10Motorsports.Plugin.DS.AmbientHasData',
+  // Demo Datastream
+  'K10Motorsports.Plugin.Demo.DS.LatG',
+  'K10Motorsports.Plugin.Demo.DS.LongG',
+  'K10Motorsports.Plugin.Demo.DS.YawRate',
+  'K10Motorsports.Plugin.Demo.DS.SteerTorque',
+  'K10Motorsports.Plugin.Demo.DS.TrackTemp',
+  'K10Motorsports.Plugin.Demo.DS.IncidentCount',
+  'K10Motorsports.Plugin.Demo.DS.AbsActive',
+  'K10Motorsports.Plugin.Demo.DS.TcActive',
+  'K10Motorsports.Plugin.Demo.DS.LapDelta',
+  'K10Motorsports.Plugin.Demo.DS.IsInPitLane',
+  'K10Motorsports.Plugin.Demo.DS.SpeedKmh',
+  'K10Motorsports.Plugin.Demo.DS.PitLimiterOn',
+  'K10Motorsports.Plugin.Demo.DS.PitSpeedLimitKmh',
+  // Demo Computed DS.*
+  'K10Motorsports.Plugin.Demo.DS.ThrottleNorm',
+  'K10Motorsports.Plugin.Demo.DS.BrakeNorm',
+  'K10Motorsports.Plugin.Demo.DS.ClutchNorm',
+  'K10Motorsports.Plugin.Demo.DS.RpmRatio',
+  'K10Motorsports.Plugin.Demo.DS.FuelPct',
+  'K10Motorsports.Plugin.Demo.DS.FuelLapsRemaining',
+  'K10Motorsports.Plugin.Demo.DS.SpeedMph',
+  'K10Motorsports.Plugin.Demo.DS.PitSpeedLimitMph',
+  'K10Motorsports.Plugin.Demo.DS.IsPitSpeeding',
+  'K10Motorsports.Plugin.Demo.DS.IsNonRaceSession',
+  'K10Motorsports.Plugin.Demo.DS.IsTimedRace',
+  'K10Motorsports.Plugin.Demo.DS.IsEndOfRace',
+  'K10Motorsports.Plugin.Demo.DS.PositionDelta',
+  'K10Motorsports.Plugin.Demo.DS.StartPosition',
+  'K10Motorsports.Plugin.Demo.DS.RemainingTimeFormatted',
+  'K10Motorsports.Plugin.Demo.DS.SpeedDisplay',
+  'K10Motorsports.Plugin.Demo.DS.RpmDisplay',
+  'K10Motorsports.Plugin.Demo.DS.FuelFormatted',
+  'K10Motorsports.Plugin.Demo.DS.FuelPerLapFormatted',
+  'K10Motorsports.Plugin.Demo.DS.PitSuggestion',
+  'K10Motorsports.Plugin.Demo.DS.BBNorm',
+  'K10Motorsports.Plugin.Demo.DS.TCNorm',
+  'K10Motorsports.Plugin.Demo.DS.ABSNorm',
+  'K10Motorsports.Plugin.Demo.DS.PositionDeltaDisplay',
+  'K10Motorsports.Plugin.Demo.DS.LapDeltaDisplay',
+  'K10Motorsports.Plugin.Demo.DS.SafetyRatingDisplay',
+  'K10Motorsports.Plugin.Demo.DS.GapAheadFormatted',
+  'K10Motorsports.Plugin.Demo.DS.GapBehindFormatted',
+  // Track map
+  'K10Motorsports.Plugin.TrackMap.Ready',
+  'K10Motorsports.Plugin.TrackMap.TrackName',
+  'K10Motorsports.Plugin.TrackMap.SvgPath',
+  'K10Motorsports.Plugin.TrackMap.PlayerX',
+  'K10Motorsports.Plugin.TrackMap.PlayerY',
+  'K10Motorsports.Plugin.TrackMap.PlayerHeading',
+  'K10Motorsports.Plugin.TrackMap.Opponents',
+  'DataCorePlugin.GameData.TrackName',
+  // Leaderboard
+  'K10Motorsports.Plugin.Leaderboard',
+  // Driver name
+  'K10Motorsports.Plugin.DriverFirstName',
+  'K10Motorsports.Plugin.DriverLastName',
+  // Flag status
+  'currentFlagState',
+  // Grid / Formation state
+  'K10Motorsports.Plugin.Grid.SessionState',
+  'K10Motorsports.Plugin.Grid.GriddedCars',
+  'K10Motorsports.Plugin.Grid.TotalCars',
+  'K10Motorsports.Plugin.Grid.PaceMode',
+  'K10Motorsports.Plugin.Grid.StartType',
+  'K10Motorsports.Plugin.Grid.LightsPhase',
+  'K10Motorsports.Plugin.Demo.Grid.SessionState',
+  'K10Motorsports.Plugin.Demo.Grid.GriddedCars',
+  'K10Motorsports.Plugin.Demo.Grid.TotalCars',
+  'K10Motorsports.Plugin.Demo.Grid.PaceMode',
+  'K10Motorsports.Plugin.Demo.Grid.LightsPhase',
+  'K10Motorsports.Plugin.Demo.Grid.StartType',
+  'K10Motorsports.Plugin.Grid.TrackCountry',
+  'K10Motorsports.Plugin.Demo.Grid.TrackCountry',
+  // Pit Box (iRacing pit stop selections + car adjustments)
+  'K10Motorsports.Plugin.PitBox.PitSvFlags',
+  'K10Motorsports.Plugin.PitBox.PitSvFuel',
+  'K10Motorsports.Plugin.PitBox.PitSvLFP',
+  'K10Motorsports.Plugin.PitBox.PitSvRFP',
+  'K10Motorsports.Plugin.PitBox.PitSvLRP',
+  'K10Motorsports.Plugin.PitBox.PitSvRRP',
+  'K10Motorsports.Plugin.PitBox.TireCompound',
+  'K10Motorsports.Plugin.PitBox.FastRepair',
+  'K10Motorsports.Plugin.PitBox.Windshield',
+  'K10Motorsports.Plugin.PitBox.TireLF',
+  'K10Motorsports.Plugin.PitBox.TireRF',
+  'K10Motorsports.Plugin.PitBox.TireLR',
+  'K10Motorsports.Plugin.PitBox.TireRR',
+  'K10Motorsports.Plugin.PitBox.TiresRequested',
+  'K10Motorsports.Plugin.PitBox.FuelRequested',
+  'K10Motorsports.Plugin.PitBox.FastRepairRequested',
+  'K10Motorsports.Plugin.PitBox.WindshieldRequested',
+  'K10Motorsports.Plugin.PitBox.FuelDisplay',
+  'K10Motorsports.Plugin.PitBox.PressureLF',
+  'K10Motorsports.Plugin.PitBox.PressureRF',
+  'K10Motorsports.Plugin.PitBox.PressureLR',
+  'K10Motorsports.Plugin.PitBox.PressureRR',
+  // Car-specific adjustment availability
+  'K10Motorsports.Plugin.PitBox.HasTC',
+  'K10Motorsports.Plugin.PitBox.HasABS',
+  'K10Motorsports.Plugin.PitBox.HasARBFront',
+  'K10Motorsports.Plugin.PitBox.HasARBRear',
+  'K10Motorsports.Plugin.PitBox.HasEnginePower',
+  'K10Motorsports.Plugin.PitBox.HasFuelMixture',
+  'K10Motorsports.Plugin.PitBox.HasWeightJackerL',
+  'K10Motorsports.Plugin.PitBox.HasWeightJackerR',
+  'K10Motorsports.Plugin.PitBox.HasWingFront',
+  'K10Motorsports.Plugin.PitBox.HasWingRear',
+  // Additional car adjustments
+  'DataCorePlugin.GameRawData.Telemetry.dcEnginePower',
+  'DataCorePlugin.GameRawData.Telemetry.dcFuelMixture',
+  'DataCorePlugin.GameRawData.Telemetry.dcWeightJackerLeft',
+  'DataCorePlugin.GameRawData.Telemetry.dcWeightJackerRight',
+  'DataCorePlugin.GameRawData.Telemetry.dcWingFront',
+  'DataCorePlugin.GameRawData.Telemetry.dcWingRear'
+];
+
+// ═══════════════════════════════════════════════════════════════
+// GLOBAL STATE VARIABLES
+// ═══════════════════════════════════════════════════════════════
+
+// Polling & connection
+let _pollFrame = 0;
+let _pollActive = false;
+let _connFails = 0;
+let _backoffUntil = 0;
+let _hasEverConnected = false;
+let _settingsForcedByDisconnect = false;
+
+// Game & session state
+let _currentGameId = '';
+let _isIRacing = true;
+let _isRally = false;
+let _rallyModeEnabled = false;
+let _isIdle = true;
+let _cycleFrameCount = 0;
+let _prevLap = 0;
+
+// Driver & car state
+let _driverDisplayName = 'YOU';
+let _lastCarModel = null;
+let _lastDriverAhead = '';
+let _lastDriverBehind = '';
+let _lastPosition = 0;
+let _gapsBestLap = 0;          // best lap time for gaps module (non-race)
+let _gapsLastLap = 0;          // last completed lap for gaps module
+let _gapsWorstLap = 0;         // worst valid lap time for gaps module
+let _gapsLapNum = 0;           // current lap number for gaps module
+let _gapsNonRaceMode = false;  // currently in non-race session
+let _lapStartIncidents = 0;   // incident count at start of current lap (for invalid detection)
+let _lapInvalid = false;       // true when incidents increased during current lap
+let _prevSectorSplits = [];    // previous poll's sector splits — survives iRacing clearing on lap cross
+let _startPosition = 0;
+let _prevBB = -1, _prevTC = -1, _prevABS = -1;
+let _clutchSeenActive = false;
+let _clutchHidden = false;
+
+// Session change detection (resets event history, timeline, etc.)
+let _prevSessionTypeName = '';
+
+// Manufacturer country flag trigger state
+let _mfrFlagShownThisSession = false;  // prevent re-trigger within same session
+let _mfrFlagPrevSessState = 0;         // previous grid SessionState
+let _mfrFlagPrevInPit = true;          // previous pit lane state
+let _mfrFlagPrevCompletedLaps = 0;     // previous completed laps
+
+// Flag & race control
+let _lastFlagState = 'none';
+let _greenFlagTimeout = null;
+let _rcTimeout = null;
+let _rcVisible = false;
+let _flagHoldUntil = 0;
+let _flagHoldState = 'none';
+let _prevCheckered = false;
+let _forceFlagState = '';
+
+// Race end screen
+let _raceEndVisible = false;
+let _raceEndTimer = null;
+
+// Timer & UI
+let _timerHideTimeout = null;
+let _timerPinned = false;
+let _commentaryWasVisible = false;
+let _strategyWasVisible = false;
+let _tcSeen = false;
+let _absSeen = false;
+let _carAdj = null;  // result from getCarAdjustability() for current car
+let _tcFlashFrames = 0;   // TC active glow countdown (frames)
+let _absFlashFrames = 0;  // ABS active glow countdown (frames)
+
+// Grid / Formation
+let _gridActive = false;
+let _gridLightsPhase = 0;
+let _gridPrevSessionState = 4;
+let _gridFadeTimer = null;
+
+// Cycles & animations
+const _cycleIntervalFrames = Math.round(10000 / POLL_MS); // 10s
+
+// ═══════════════════════════════════════════════════════════════
+// DEMO MODE MODELS
+// ═══════════════════════════════════════════════════════════════
+
+const _demoModels = {
+  bmw:'M4 GT3', mclaren:'720S GT3', mazda:'MX-5 Cup', nissan:'GTP ZX-T',
+  dallara:'IR-04', ferrari:'296 GT3', porsche:'911 GT3 R', audi:'R8 LMS',
+  mercedes:'AMG GT3', lamborghini:'Huracán GT3', chevrolet:'Corvette Z06',
+  ford:'Mustang GT3', toyota:'GR86', hyundai:'Elantra N TC',
+  cadillac:'V-Series.R', astonmartin:'Vantage GT3', lotus:'Emira GT4',
+  honda:'Civic Type R', ligier:'JS P320'
+};
+
+// ═══════════════════════════════════════════════════════════════
+// MANUFACTURER BRANDING
+// ═══════════════════════════════════════════════════════════════
+
+const _defaultLogoBg = 'hsla(0, 0%, 12%, 1.0)';
+
+const _mfrBrandColors = {
+  bmw:         'hsla(204, 100%, 45%, 0.65)',
+  mclaren:     'hsla(24, 100%, 52%, 0.65)',
+  mazda:       'hsla(0, 90%, 44%, 0.65)',
+  nissan:      'hsla(0, 85%, 50%, 0.65)',
+  dallara:     'hsla(210, 85%, 48%, 0.65)',
+  ferrari:     'hsla(0, 90%, 48%, 0.65)',
+  porsche:     'hsla(0, 0%, 50%, 0.60)',
+  audi:        'hsla(0, 0%, 50%, 0.60)',
+  mercedes:    'hsla(175, 65%, 42%, 0.62)',
+  lamborghini: 'hsla(48, 90%, 48%, 0.62)',
+  chevrolet:   'hsla(40, 62%, 38%, 0.65)',
+  ford:        'hsla(237, 100%, 28%, 0.65)',
+  toyota:      'hsla(0, 85%, 48%, 0.65)',
+  hyundai:     'hsla(216, 85%, 45%, 0.65)',
+  cadillac:    'hsla(0, 0%, 50%, 0.60)',
+  astonmartin: 'hsla(155, 70%, 38%, 0.65)',
+  lotus:       'hsla(57, 100%, 50%, 0.65)',
+  ligier:      'hsla(204, 78%, 40%, 0.65)',
+  fia:         'hsla(228, 73%, 21%, 0.65)',
+  radical:     'hsla(43, 82%, 57%, 0.65)',
+  honda:       'hsla(0, 90%, 42%, 0.65)'
+};
+
+// Manufacturer → ISO 3166-1 alpha-2 country code (used for flag display)
+const _mfrCountry = {
+  bmw: 'DE', mclaren: 'GB', mazda: 'JP', nissan: 'JP',
+  dallara: 'IT', ferrari: 'IT', porsche: 'DE', audi: 'DE',
+  mercedes: 'DE', lamborghini: 'IT', chevrolet: 'US', ford: 'US',
+  toyota: 'JP', hyundai: 'KR', cadillac: 'US', astonmartin: 'GB',
+  lotus: 'GB', honda: 'JP', ligier: 'FR', fia: 'FR', radical: 'GB'
+};
+
+const _mfrMap = {
+  'bmw':'bmw', 'm4 gt':'bmw', 'm8 gte':'bmw', 'm hybrid':'bmw',
+  'mclaren':'mclaren', 'mp4':'mclaren',
+  'mazda':'mazda', 'mx-5':'mazda', 'miata':'mazda',
+  'nissan':'nissan', 'gtp zx':'nissan', 'nismo':'nissan',
+  'fia f4':'fia', 'fia':'fia',
+  'dallara':'dallara', 'ir-01':'dallara', 'ir01':'dallara', 'ir-04':'dallara', 'ir04':'dallara',
+  'ferrari':'ferrari', '488':'ferrari', '296':'ferrari', 'sf-23':'ferrari',
+  'porsche':'porsche', '911':'porsche', 'cayman':'porsche', 'boxter':'porsche', '918':'porsche',
+  'audi':'audi', 'r8':'audi', 'rs e-tron gt':'audi', 'e-tron gt':'audi',
+  'mercedes':'mercedes', 'amg gt':'mercedes', 'hypercar':'mercedes',
+  'lamborghini':'lamborghini', 'huracán':'lamborghini', 'huracan':'lamborghini', 'urus':'lamborghini',
+  'chevrolet':'chevrolet', 'corvette':'chevrolet', 'chevy':'chevrolet', 'c8':'chevrolet',
+  'ford':'ford', 'mustang':'ford', 'ford gt':'ford', 'mk iv':'ford',
+  'toyota':'toyota', 'gr86':'toyota', 'gr corolla':'toyota',
+  'hyundai':'hyundai', 'elantra':'hyundai', 'ioniq':'hyundai',
+  'cadillac':'cadillac', 'v-series':'cadillac',
+  'aston martin':'astonmartin', 'vantage':'astonmartin', 'dbs':'astonmartin',
+  'lotus':'lotus', 'emira':'lotus', 'evija':'lotus',
+  'honda':'honda', 'civic':'honda', 'nsx':'honda',
+  'ligier':'ligier', 'js p3':'ligier', 'js p320':'ligier',
+  'radical':'radical', 'sr10':'radical', 'sr8':'radical', 'sr3':'radical',
+  'generic':'generic', 'none':'none'
+};
+
+/** Match a car model string to a manufacturer key in _mfrMap */
+function detectMfr(model) {
+  if (!model) return 'none';
+  const l = ('' + model).toLowerCase();
+  for (const k in _mfrMap) { if (l.indexOf(k) !== -1) return _mfrMap[k]; }
+  return 'generic';
+}
+
+// ═══════════════════════════════════════════════════════════════
+// CAR ADJUSTABILITY — cars that truly lack BB/ABS/TC systems
+// These cars physically don't have the system, so we HIDE the module.
+// Cars not listed here that report 0 are assumed FIXED (setup-locked).
+// Each entry: substring match → { noBB, noABS, noTC, absNoAdjust }
+// absNoAdjust: true = ABS exists but isn't adjustable by driver (show when active)
+// noABS: true = no ABS system at all (hide completely)
+// ═══════════════════════════════════════════════════════════════
+const _carNoAdjust = [
+  // Formula / Open-wheel (no ABS, no TC in almost all)
+  { match: 'formula vee',      noBB: false, noABS: true, noTC: true },
+  { match: 'skip barber',      noBB: false, noABS: true, noTC: true },
+  { match: 'usf 2000',         noBB: false, noABS: true, noTC: true },
+  { match: 'usf2000',          noBB: false, noABS: true, noTC: true },
+  { match: 'indy pro 2000',    noBB: false, noABS: true, noTC: true },
+  { match: 'formula 4',        noBB: false, noABS: true, noTC: true },
+  { match: 'fia f4',           noBB: false, noABS: true, noTC: true },
+  { match: 'ir-04',            noBB: false, noABS: true, noTC: true },
+  { match: 'dallara f3',       noBB: false, noABS: true, noTC: true },
+  { match: 'lotus 49',         noBB: true,  noABS: true, noTC: true },
+  { match: 'lotus 79',         noBB: false, noABS: true, noTC: true },
+  { match: 'mp4-30',           noBB: false, noABS: true, noTC: true },
+  { match: 'w12',              noBB: false, noABS: true, noTC: true },
+  { match: 'w13',              noBB: false, noABS: true, noTC: true },
+  // LMP / Prototype (no ABS typically)
+  { match: 'js p320',          noBB: false, noABS: true, noTC: false },
+  { match: 'ligier js',        noBB: false, noABS: true, noTC: false },
+  // Porsche Cup (no ABS, no TC on 992.1)
+  { match: '992 cup',          noBB: false, noABS: true, noTC: true },
+  { match: 'gt3 cup',          noBB: false, noABS: true, noTC: true },
+  // V8 Supercars (no ABS, no TC)
+  { match: 'supercars',        noBB: false, noABS: true, noTC: true },
+  { match: 'supercar',         noBB: false, noABS: true, noTC: true },
+  { match: 'ford falcon',      noBB: false, noABS: true, noTC: true },
+  { match: 'holden commodore',  noBB: false, noABS: true, noTC: true },
+  { match: 'gen3 camaro',      noBB: false, noABS: true, noTC: true },
+  { match: 'gen3 mustang',     noBB: false, noABS: true, noTC: true },
+  // Vintage / spec
+  { match: 'spec racer',       noBB: false, noABS: true, noTC: true },
+  { match: 'legends',          noBB: true,  noABS: true, noTC: true },
+  { match: '34 ford',          noBB: true,  noABS: true, noTC: true },
+  // Production-based (ABS exists but not adjustable, no TC in iRacing implementation)
+  { match: 'mx-5 cup',         noBB: false, noABS: false, absNoAdjust: true, noTC: true },
+  { match: 'mx-5 roadster',    noBB: false, noABS: false, absNoAdjust: true, noTC: true },
+  { match: 'mx-5',             noBB: false, noABS: false, absNoAdjust: true, noTC: true },
+  { match: 'gr86',             noBB: false, noABS: false, absNoAdjust: true, noTC: true },
+  { match: 'solstice',         noBB: false, noABS: false, absNoAdjust: true, noTC: true },
+  // NASCAR / Oval (no ABS, no TC)
+  { match: 'nascar',           noBB: false, noABS: true, noTC: true },
+  { match: 'gen 6',            noBB: false, noABS: true, noTC: true },
+  { match: 'next gen',         noBB: false, noABS: true, noTC: true },
+  { match: 'trucks',           noBB: false, noABS: true, noTC: true },
+  { match: 'street stock',     noBB: true,  noABS: true, noTC: true },
+  { match: 'late model',       noBB: false, noABS: true, noTC: true },
+  { match: 'modified',         noBB: false, noABS: true, noTC: true },
+  { match: 'silver crown',     noBB: false, noABS: true, noTC: true },
+  { match: 'sprint car',       noBB: false, noABS: true, noTC: true },
+  { match: 'midget',           noBB: false, noABS: true, noTC: true },
+  { match: 'dirt',             noBB: false, noABS: true, noTC: true },
+];
+
+/** Check car model string against no-adjust list. Returns {noBB, noABS, noTC} or null. */
+function getCarAdjustability(model) {
+  if (!model) return null;
+  const l = ('' + model).toLowerCase();
+  for (const entry of _carNoAdjust) {
+    if (l.indexOf(entry.match) !== -1) return entry;
+  }
+  return null;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// SETTINGS SYSTEM
+// ═══════════════════════════════════════════════════════════════
+
+const _defaultSettings = {
+  logoOnlyStart: true, // Start in logo-only mode; HUD reveals when session goes active
+  showFuel: true, showTyres: true, showControls: true, showPedals: true,
+  showMaps: true, showPosition: true, showTacho: true, showCommentary: true,
+  showK10Logo: true, showCarLogo: true, showGameLogo: true, simhubUrl: 'http://localhost:8889/k10mediabroadcaster/',
+  layoutPosition: 'top-right',
+  greenScreen: false, showWebGL: true, showBonkers: true, ambientMode: 'reflective',
+  zoom: 165, forceFlag: '', showLeaderboard: true, showDatastream: true, showPitBox: true, showIncidents: true, showSpotter: true,
+  incPenalty: 17, incDQ: 25,
+  discordUser: null,
+  rallyMode: false,
+  driveMode: false,
+  // Leaderboard
+  lbFocus: 'me',        // 'me' = center on player, 'lead' = show from P1
+  lbMaxRows: 5,         // max visible opponent rows
+  lbExpandToFill: false, // override lbMaxRows to fill available screen space
+  // Datastream field toggles
+  dsShowGforce: true,
+  dsShowYaw: true,
+  dsShowFfb: true,
+  dsShowDelta: true,
+  dsShowTrackTemp: true,
+  dsShowFps: true
+};
+
+let _settings = Object.assign({}, _defaultSettings);
+
+// Discord state
+let _discordUser = null;
+
+// Logo cycling
+let _currentCarLogoIdx = 0;
+let _currentCarLogo = '';
+let _logoCycleTimer = null;  // Will be initialized when car-logos.js runs
+
+// ─── Utility: session type detection ───
+function _isNonRaceSession(sessionType) {
+  if (!sessionType) return false;
+  const s = sessionType.toLowerCase();
+  return s.includes('practice') || s.includes('qualify') || s.includes('test') || s.includes('warmup') || s.includes('warm up');
+}
+
+// ─── Utility: format lap time (seconds → m:ss.xxx) ───
+function _fmtLapTime(secs) {
+  if (secs <= 0) return '—';
+  const m = Math.floor(secs / 60);
+  const s = (secs % 60).toFixed(3);
+  return m + ':' + (s < 10 ? '0' : '') + s;
+}
+
+
+// ── modules/js/keyboard.js ──
+// Global keyboard shortcuts — dispatched via Electron globalShortcut → IPC
+
+  // ═══ Ctrl+Shift+D — restart demo ═══
+  if (window.k10 && window.k10.onRestartDemo) {
+    window.k10.onRestartDemo(function() {
+      var baseUrl = window._simhubUrlOverride || SIMHUB_URL;
+      var sep = baseUrl.indexOf('?') === -1 ? '?' : '&';
+      fetch(baseUrl + sep + 'action=restartdemo')
+        .then(function(r) { if (r.ok) console.log('[K10] Demo restarted'); else console.warn('[K10] Demo restart failed:', r.status); })
+        .catch(function(err) { console.warn('[K10] Demo restart error:', err); });
+    });
+  }
+
+  // ═══ Ctrl+Shift+M — reset track map ═══
+  if (window.k10 && window.k10.onResetTrackmap) {
+    window.k10.onResetTrackmap(function() {
+      if (typeof resetTrackMap === 'function') resetTrackMap();
+    });
+  }
+
+
+// ── modules/js/car-logos.js ──
+// CAR MANUFACTURER LOGOS
+
+  // ═══ CAR MANUFACTURER LOGOS (loaded from images/logos/) ═══
+  const CAR_LOGO_KEYS = ['bmw','mclaren','mazda','nissan','dallara','ferrari','porsche','audi',
+    'mercedes','lamborghini','chevrolet','ford','toyota','hyundai','cadillac','astonmartin',
+    'lotus','honda','honda_white','ligier','fia','radical','generic','none'];
+  const carLogos = {};
+  async function loadCarLogos() {
+    const results = await Promise.allSettled(
+      CAR_LOGO_KEYS.map(async key => {
+        const resp = await fetch('images/logos/' + key + '.svg');
+        if (resp.ok) carLogos[key] = await resp.text();
+      })
+    );
+  }
+
+
+  const carLogoOrder = ['bmw', 'mclaren', 'mazda', 'nissan', 'dallara', 'ferrari', 'porsche', 'audi', 'mercedes', 'lamborghini', 'chevrolet', 'ford', 'toyota', 'hyundai', 'cadillac', 'astonmartin', 'lotus', 'honda', 'ligier', 'fia', 'radical'];
+  let currentCarLogoIdx = 0;
+  // _currentCarLogo declared in config.js
+
+  // _mfrBrandColors, _defaultLogoBg, _demoModels declared in config.js
+
+  function cycleCarLogo() {
+    currentCarLogoIdx = (currentCarLogoIdx + 1) % carLogoOrder.length;
+    const key = carLogoOrder[currentCarLogoIdx];
+    console.log('[K10] Logo cycle:', key);
+    // Honda special case: use white-fill logo on red bg
+    const svg = (key === 'honda') ? carLogos.honda_white : carLogos[key];
+    document.getElementById('carLogoIcon').innerHTML = svg;
+    document.getElementById('carModelLabel').textContent = _demoModels[key] || '';
+    // Apply brand-colored background (or default dark bg)
+    const sq = document.getElementById('carLogoSquare');
+    sq.style.background = _mfrBrandColors[key] || _defaultLogoBg;
+    _currentCarLogo = ''; // reset so setCarLogo always fires on first real data
+  }
+
+  // Strip brand name from model string so label shows just the model
+  // e.g. "BMW M4 GT3" → "M4 GT3", "Porsche 911 GT3 R" → "911 GT3 R"
+  const _brandStrips = [
+    'aston martin', 'astonmartin', 'lamborghini', 'mercedes-benz', 'mercedes',
+    'chevrolet', 'mclaren', 'ferrari', 'porsche', 'hyundai', 'cadillac',
+    'dallara', 'nissan', 'toyota', 'mazda', 'honda', 'lotus', 'ligier', 'ford',
+    'audi', 'bmw'
+  ];
+  function stripBrand(model) {
+    if (!model) return '';
+    let s = model.trim();
+    const l = s.toLowerCase();
+    for (const b of _brandStrips) {
+      if (l.startsWith(b)) { s = s.substring(b.length).trim(); break; }
+    }
+    return s;
+  }
+
+  // Set car logo by manufacturer key + optional model string
+  function setCarLogo(key, modelName) {
+    if (key === _currentCarLogo && modelName === undefined) return;
+    _currentCarLogo = key;
+    // Honda special case: white-fill logo on red background
+    const svg = (key === 'honda') ? (carLogos.honda_white || carLogos.honda) : (carLogos[key] || carLogos.generic);
+    document.getElementById('carLogoIcon').innerHTML = svg;
+    document.getElementById('carModelLabel').textContent = stripBrand(modelName);
+    // Apply brand-colored background for white/mono logos, default dark bg otherwise
+    const sq = document.getElementById('carLogoSquare');
+    sq.style.background = _mfrBrandColors[key] || _defaultLogoBg;
+    // Expose full-opacity brand color for map player dot
+    const brandHsl = _mfrBrandColors[key];
+    if (brandHsl) {
+      // Convert 0.6x alpha HSLA to full-opacity for the map dot fill
+      const solidColor = brandHsl.replace(/[\d.]+\)$/, '1)');
+      document.documentElement.style.setProperty('--map-player-color', solidColor);
+    } else {
+      document.documentElement.style.setProperty('--map-player-color', 'var(--cyan)');
+    }
+  }
+
+  // ═══ TACHOMETER ═══
+
+
+// ── modules/js/game-detect.js ──
+// Game detection system
+
+  const GAME_FEATURES = {
+    iracing:     { hasIRating: true,  hasIncidents: true,  hasFlags: true,  hasFormation: true,  hasDRS: true,  hasERS: true  },
+    acc:         { hasIRating: false, hasIncidents: false, hasFlags: true,  hasFormation: true,  hasDRS: false, hasERS: true  },
+    ac:          { hasIRating: false, hasIncidents: false, hasFlags: true,  hasFormation: false, hasDRS: false, hasERS: false },
+    acevo:       { hasIRating: false, hasIncidents: false, hasFlags: true,  hasFormation: false, hasDRS: false, hasERS: false },
+    acrally:     { hasIRating: false, hasIncidents: false, hasFlags: false, hasFormation: false, hasDRS: false, hasERS: false },
+    lmu:         { hasIRating: false, hasIncidents: false, hasFlags: true,  hasFormation: true,  hasDRS: true,  hasERS: true  },
+    raceroom:    { hasIRating: false, hasIncidents: false, hasFlags: true,  hasFormation: true,  hasDRS: true,  hasERS: false },
+    eawrc:       { hasIRating: false, hasIncidents: false, hasFlags: false, hasFormation: false, hasDRS: false, hasERS: false },
+    forza:       { hasIRating: false, hasIncidents: false, hasFlags: false, hasFormation: false, hasDRS: false, hasERS: false },
+  };
+
+  function detectGameId(name) {
+    if (!name) return 'iracing';
+    const g = name.toLowerCase();
+    if (g.includes('iracing')) return 'iracing';
+    if (g.includes('assettocorsacompetizione') || g === 'acc') return 'acc';
+    if (g.includes('assettocorsaevo')) return 'acevo';
+    if (g.includes('assettocorsarally')) return 'acrally';
+    if (g.includes('assettocorsa') || g === 'ac') return 'ac';
+    if (g.includes('lemans') || g.includes('lmu') || g.includes('rfactor')) return 'lmu';
+    if (g.includes('raceroom') || g === 'rrre' || g === 'r3e') return 'raceroom';
+    if (g.includes('wrc') || g.includes('eawrc')) return 'eawrc';
+    if (g.includes('forza')) return 'forza';
+    return 'iracing'; // default
+  }
+
+  function getGameFeatures() {
+    return GAME_FEATURES[_currentGameId] || GAME_FEATURES.iracing;
+  }
+
+  // Returns true if the current game is allowed (iRacing always allowed; others require Discord)
+  function isGameAllowed() {
+    if (_currentGameId === 'iracing') return true;
+    return !!_discordUser;
+  }
+
+  function isRallyGame() {
+    return _currentGameId === 'eawrc' || _currentGameId === 'acrally';
+  }
+
+  function fmtLap(t) {
+    if (!t || t <= 0) return '—:——.———';
+    const m = Math.floor(t / 60), s = t - m * 60;
+    return m + ':' + (s < 10 ? '0' : '') + s.toFixed(3);
+  }
+  function fmtGap(g) {
+    if (!g || g === 0) return '—';
+    return g > 0 ? '+' + g.toFixed(1) : g.toFixed(1);
+  }
+  function colorToHue(hex) {
+    if (!hex || hex.length < 7) return 0;
+    let r, g, b;
+    if (hex.length === 9) { r = parseInt(hex.substr(3,2),16)/255; g = parseInt(hex.substr(5,2),16)/255; b = parseInt(hex.substr(7,2),16)/255; }
+    else { r = parseInt(hex.substr(1,2),16)/255; g = parseInt(hex.substr(3,2),16)/255; b = parseInt(hex.substr(5,2),16)/255; }
+    const mx = Math.max(r,g,b), mn = Math.min(r,g,b), d = mx - mn;
+    if (d === 0) return 0;
+    let h; if (mx === r) h = ((g-b)/d)%6; else if (mx === g) h = (b-r)/d+2; else h = (r-g)/d+4;
+    h = Math.round(h * 60); if (h < 0) h += 360; return h;
+  }
+
+  // ─── Connection status indicator & setup banner ───
+  // _hasEverConnected, _settingsForcedByDisconnect declared in config.js
+  let _connBannerDismissed = false;
+  let _connBannerShown = false;
+
+  function _updateConnStatus(state) {
+    const el = document.getElementById('connStatus');
+    if (!el) return;
+    el.className = 'conn-status ' + state;
+    const titles = { connected: 'Connected to plugin server', disconnected: 'Cannot reach plugin server — is the K10 Motorsports plugin loaded in SimHub?', connecting: 'Connecting to plugin server...' };
+    el.title = titles[state] || '';
+
+    // Settings-embedded warning banner
+    const settingsWarn = document.getElementById('settingsConnWarn');
+    const settingsWarnUrl = document.getElementById('settingsConnWarnUrl');
+
+    if (state === 'connected') {
+      _hasEverConnected = true;
+      // Hide banners
+      const banner = document.getElementById('connBanner');
+      if (banner && banner.classList.contains('visible')) {
+        banner.classList.remove('visible');
+      }
+      if (settingsWarn) settingsWarn.classList.remove('warn-visible');
+      // Stop logo demo cycle once connected
+      if (_logoCycleTimer) { clearInterval(_logoCycleTimer); _logoCycleTimer = null; }
+      // Auto-close settings if it was forced open by disconnection
+      if (_settingsForcedByDisconnect) {
+        _settingsForcedByDisconnect = false;
+        const overlay = document.getElementById('settingsOverlay');
+        if (overlay.classList.contains('open')) {
+          toggleSettings();
+        }
+      }
+    }
+
+    if (state === 'disconnected' && _connFails >= 2) {
+      if (settingsWarn) {
+        settingsWarn.classList.add('warn-visible');
+        if (settingsWarnUrl) settingsWarnUrl.textContent = window._simhubUrlOverride || SIMHUB_URL;
+      }
+    }
+
+    // Force settings mode open when disconnected (after a few retries)
+    if (state === 'disconnected' && !_hasEverConnected && _connFails >= 3 && !_settingsForcedByDisconnect) {
+      _settingsForcedByDisconnect = true;
+      const overlay = document.getElementById('settingsOverlay');
+      if (!overlay.classList.contains('open')) {
+        // Open settings so user can fix the SimHub URL
+        overlay.classList.add('open');
+        document.body.classList.add('settings-active');
+        if (window.k10?.requestInteractive) window.k10.requestInteractive();
+      }
+    }
+
+    // Also refresh the Connections tab SimHub card in real-time
+    if (typeof updateSimhubConnectionCard === 'function') updateSimhubConnectionCard();
+  }
+
+  function applyConnBanner() {
+    const inp = document.getElementById('connBannerUrl');
+    if (!inp) return;
+    let host = inp.value.trim();
+    if (!host) return;
+    // Strip protocol/path if user pasted a full URL
+    host = host.replace(/^https?:\/\//, '').replace(/\/.*$/, '').replace(/:.*$/, '');
+    const newUrl = `http://${host}:8889/k10mediabroadcaster/`;
+    window._simhubUrlOverride = newUrl;
+    _settings.simhubUrl = newUrl;
+    saveSettings();
+    // Update the settings panel input too
+    const urlInput = document.getElementById('settingsSimhubUrl');
+    if (urlInput) urlInput.value = newUrl;
+    // Reset backoff so we try immediately
+    _connFails = 0;
+    _backoffUntil = 0;
+    _hasEverConnected = false;
+    _connBannerShown = false;
+    _updateConnStatus('connecting');
+    // Hide banner and release Electron focus
+    const banner = document.getElementById('connBanner');
+    if (banner) banner.classList.remove('visible');
+    if (window.k10?.releaseInteractive) window.k10.releaseInteractive();
+    console.log('[K10 Motorsports] SimHub URL changed to ' + newUrl);
+  }
+
+  function dismissConnBanner() {
+    _connBannerDismissed = true;
+    const banner = document.getElementById('connBanner');
+    if (banner) banner.classList.remove('visible');
+    if (window.k10?.releaseInteractive) window.k10.releaseInteractive();
+  }
+
+  // Expose for onclick handlers
+  window.applyConnBanner = applyConnBanner;
+  window.dismissConnBanner = dismissConnBanner;
+
+  // ─── Fetch with timeout helper ───
+  function fetchWithTimeout(url, opts, ms) {
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), ms);
+    return fetch(url, { ...opts, signal: ac.signal }).finally(() => clearTimeout(timer));
+  }
+
+  // ─── Fetch properties from SimHub HTTP API ───
+  // Uses exponential backoff on failure to avoid socket exhaustion.
+  async function fetchProps() {
+    // Backoff: skip this cycle if we're in a cooldown window
+    if (_backoffUntil > Date.now()) return null;
+
+    const TIMEOUT_MS = 2000;
+
+    // Single GET — our plugin serves everything in one JSON blob
+    const url = window._simhubUrlOverride || SIMHUB_URL;
+    try {
+      const resp = await fetchWithTimeout(url, {}, TIMEOUT_MS);
+      if (resp.ok) {
+        const data = await resp.json();
+        _connFails = 0;
+        _updateConnStatus('connected');
+        return data;
+      }
+    } catch (e) { /* unreachable */ }
+
+    // Failed — enter exponential backoff (1s, 2s, 4s, 8s, cap 10s)
+    _connFails++;
+    _backoffUntil = Date.now() + Math.min(1000 * Math.pow(2, _connFails - 1), 10000);
+    _updateConnStatus('disconnected');
+    if (_connFails <= 3) console.warn(`[K10 Motorsports] Plugin server unreachable at ${window._simhubUrlOverride || SIMHUB_URL} — fail #${_connFails}`);
+    return null;
+  }
+
+  // ── Apply game mode styling ──
+  function applyGameMode() {
+    const feat = getGameFeatures();
+    const dashboard = document.getElementById('dashboard');
+
+    // Toggle iRacing-specific UI elements
+    const irElements = document.querySelectorAll('.ir-only');
+    irElements.forEach(el => el.style.display = feat.hasIRating ? '' : 'none');
+
+    // Toggle incident counter
+    const incElements = document.querySelectorAll('.incident-only');
+    incElements.forEach(el => el.style.display = feat.hasIncidents ? '' : 'none');
+
+    // Rally mode: hide circuit-specific elements, show rally elements
+    const rallyEls = document.querySelectorAll('.rally-only');
+    const circuitEls = document.querySelectorAll('.circuit-only');
+    rallyEls.forEach(el => el.style.display = _isRally ? '' : 'none');
+    circuitEls.forEach(el => el.style.display = _isRally ? 'none' : '');
+
+    // Update body class for CSS-level game adaptation
+    document.body.classList.toggle('game-iracing', _isIRacing);
+    document.body.classList.toggle('game-rally', _isRally);
+    document.body.classList.toggle('game-acc', _currentGameId === 'acc');
+    document.body.classList.toggle('game-lmu', _currentGameId === 'lmu');
+  }
+
+
+// ─── K10 Web Demo: postMessage data bridge ───────────────────
+// Replaces the real fetchProps() (defined in game-detect.js) with
+// one that returns data sent by the parent React page.
+(function() {
+  var _pmData = null;
+  var _pmAmbient = null;
+
+  window.addEventListener('message', function(e) {
+    if (!e.data || !e.data.type) return;
+    if (e.data.type === 'k10-telemetry') {
+      _pmData = e.data.snapshot;
+    }
+    if (e.data.type === 'k10-ambient') {
+      _pmAmbient = e.data;
+    }
+  });
+
+  // Override fetchProps — poll-engine.js calls this every 33ms
+  fetchProps = async function() {
+    return _pmData;
+  };
+
+  // Override connection status — suppress the connection banner
+  _updateConnStatus = function() {};
+  _hasEverConnected = true;
+
+  // Ambient light mock — update globals each frame
+  var _ambientRAF = null;
+  function tickAmbient() {
+    if (_pmAmbient) {
+      window._ambientGL = {
+        r: _pmAmbient.r || 0,
+        g: _pmAmbient.g || 0,
+        b: _pmAmbient.b || 0,
+        lum: _pmAmbient.lum || 0
+      };
+      window._ambientModeInt = _pmAmbient.mode != null ? _pmAmbient.mode : 0;
+    }
+    _ambientRAF = requestAnimationFrame(tickAmbient);
+  }
+  tickAmbient();
+})();
+// ─── End postMessage shim ────────────────────────────────────
+
+
+// ── modules/js/webgl-helpers.js ──
+// WebGL utility functions and data
+
+  const TACH_SEGS = 11;
+  const tachoBar = document.getElementById('tachoBar');
+  const rpmText = document.getElementById('rpmText');
+  for (let i = 0; i < TACH_SEGS; i++) {
+    const s = document.createElement('div');
+    s.className = 'tacho-seg';
+    tachoBar.appendChild(s);
+  }
+
+  const RPM_COLORS = {
+    green: 'var(--green)',
+    yellow: 'var(--amber)',
+    red: 'var(--red)',
+    dim: 'var(--text-dim)',
+  };
+
+  let _prevLitCount = 0;
+  let _rpmPulseTimer = null;
+
+  function updateTacho(pct) {
+    const segs = tachoBar.children;
+    const lit = Math.round(pct * TACH_SEGS);
+    let topColor = 'dim';
+    for (let i = 0; i < TACH_SEGS; i++) {
+      segs[i].className = 'tacho-seg';
+      if (i < lit) {
+        const f = i / TACH_SEGS;
+        if (f < 0.55) { segs[i].classList.add('lit-green'); topColor = 'green'; }
+        else if (f < 0.73) { segs[i].classList.add('lit-yellow'); topColor = 'yellow'; }
+        else if (f < 0.91) { segs[i].classList.add('lit-red'); topColor = 'red'; }
+        else { segs[i].classList.add('lit-redline'); topColor = 'red'; }
+        segs[i].style.height = '100%';
+      } else {
+        segs[i].style.height = '2px';
+      }
+    }
+    rpmText.style.color = RPM_COLORS[topColor];
+
+    // Pulse the RPM text when a new segment lights up
+    if (lit > _prevLitCount && lit > 0) {
+      const pulseClass = topColor === 'green' ? 'rpm-pulse-green'
+        : topColor === 'yellow' ? 'rpm-pulse-yellow' : 'rpm-pulse-red';
+      rpmText.classList.remove('rpm-pulse-green', 'rpm-pulse-yellow', 'rpm-pulse-red');
+      // Force reflow so the class re-triggers the transition
+      void rpmText.offsetWidth;
+      rpmText.classList.add(pulseClass);
+      if (_rpmPulseTimer) clearTimeout(_rpmPulseTimer);
+      _rpmPulseTimer = setTimeout(() => {
+        rpmText.classList.remove('rpm-pulse-green', 'rpm-pulse-yellow', 'rpm-pulse-red');
+      }, 180);
+    }
+    _prevLitCount = lit;
+  }
+  updateTacho(0); // Will be driven by SimHub RPM data
+
+  // ═══ LAYERED PEDAL HISTOGRAMS — DOM bars ═══
+  const HIST_BARS = 20;
+  function setupHist(id, cls) {
+    const c = document.getElementById(id);
+    if (!c) return;
+    for (let i = 0; i < HIST_BARS; i++) {
+      const b = document.createElement('div');
+      b.className = `pedal-hist-bar ${cls}`;
+      if (i === HIST_BARS - 1) b.classList.add('live');
+      c.appendChild(b);
+    }
+  }
+  setupHist('throttleHist', 'throttle');
+  setupHist('brakeHist', 'brake');
+  setupHist('clutchHist', 'clutch');
+
+  function renderHist(id, data) {
+    const el = document.getElementById(id);
+    if (!el) return;
+    const bars = el.children;
+    for (let i = 0; i < data.length && i < bars.length; i++)
+      bars[i].style.transform = 'scaleY(' + Math.max(0.01, data[i]) + ')';
+  }
+  // Initialize empty
+  renderHist('throttleHist', new Array(HIST_BARS).fill(0));
+  renderHist('brakeHist', new Array(HIST_BARS).fill(0));
+  renderHist('clutchHist', new Array(HIST_BARS).fill(0));
+
+  // Rolling history buffers
+  const _thrHist = new Array(HIST_BARS).fill(0);
+  const _brkHist = new Array(HIST_BARS).fill(0);
+  const _cltHist = new Array(HIST_BARS).fill(0);
+
+  // ═══ PEDAL TRACE — curve-following dots + trail (2D canvas) ═══
+  // When a pedal profile is active, dots travel along the response curves.
+  // Falls back to time-series waveforms when no profile is loaded.
+  const _pedalTraceLen = 120;
+  const _ptThr = new Float32Array(_pedalTraceLen);
+  const _ptBrk = new Float32Array(_pedalTraceLen);
+  const _ptClt = new Float32Array(_pedalTraceLen);
+  let _ptIdx = 0;
+  let _ptCount = 0;
+  const _ptCanvas = document.getElementById('pedalTraceCanvas');
+  const _ptCtx = _ptCanvas ? _ptCanvas.getContext('2d') : null;
+
+  // Trail history for curve-following dots (stores canvas positions)
+  const _trailLen = 16;
+  const _thrTrail = [];
+  const _brkTrail = [];
+  const _cltTrail = [];
+
+  // ─── rAF-gated pedal rendering ───
+  let _pedalRafId = 0;
+  let _pedalPending = false;
+  let _pendingThr = 0, _pendingBrk = 0, _pendingClt = 0;
+
+  function renderPedalTrace(thr, brk, clt) {
+    _pendingThr = thr;
+    _pendingBrk = brk;
+    _pendingClt = clt;
+    if (!_pedalPending) {
+      _pedalPending = true;
+      _pedalRafId = requestAnimationFrame(_flushPedalFrame);
+    }
+  }
+
+  function _flushPedalFrame() {
+    _pedalPending = false;
+    const thr = _pendingThr, brk = _pendingBrk, clt = _pendingClt;
+
+    // Shift rolling histogram and add new sample
+    _thrHist.shift(); _thrHist.push(thr);
+    _brkHist.shift(); _brkHist.push(brk);
+    _cltHist.shift(); _cltHist.push(clt);
+    renderHist('throttleHist', _thrHist);
+    renderHist('brakeHist', _brkHist);
+    renderHist('clutchHist', _cltHist);
+
+    // Update percentage labels
+    const labels = document.querySelectorAll('.pedal-pct');
+    if (labels.length >= 3) {
+      labels[0].textContent = Math.round(thr * 100) + '%';
+      labels[1].textContent = Math.round(brk * 100) + '%';
+      labels[2].textContent = Math.round(clt * 100) + '%';
+    }
+
+    if (!_ptCtx) return;
+    const c = _ptCanvas;
+    const rect = c.getBoundingClientRect();
+    if (c.width !== Math.round(rect.width) || c.height !== Math.round(rect.height)) {
+      c.width = Math.round(rect.width);
+      c.height = Math.round(rect.height);
+    }
+    const w = c.width, h = c.height;
+    const ctx = _ptCtx;
+    ctx.clearRect(0, 0, w, h);
+
+    // ── Curve-following mode: dots travel along response curves ──
+    const curvePos = window.getCurvePositions ? window.getCurvePositions(thr, brk, clt) : null;
+    if (curvePos && curvePos.length > 0) {
+      _renderCurveDots(ctx, curvePos, thr, brk, clt);
+      return;
+    }
+
+    // ── Fallback: time-series waveforms (no profile loaded) ──
+    _ptThr[_ptIdx] = thr;
+    _ptBrk[_ptIdx] = brk;
+    _ptClt[_ptIdx] = clt;
+    _ptIdx = (_ptIdx + 1) % _pedalTraceLen;
+    _ptCount++;
+
+    const count = Math.min(_ptCount, _pedalTraceLen);
+    if (count < 3) return;
+
+    const traces = [
+      { buf: _ptThr, color: [76, 175, 80] },
+      { buf: _ptBrk, color: [244, 67, 54] },
+      { buf: _ptClt, color: [66, 165, 245] },
+    ];
+
+    for (const tr of traces) {
+      ctx.beginPath();
+      for (let i = 0; i < count; i++) {
+        const idx = (_ptIdx - count + i + _pedalTraceLen) % _pedalTraceLen;
+        const x = (i / (count - 1)) * w;
+        const y = h - tr.buf[idx] * (h - 2) - 1;
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      const grad = ctx.createLinearGradient(0, 0, w, 0);
+      const [r, g, b] = tr.color;
+      grad.addColorStop(0, `rgba(${r},${g},${b},0.0)`);
+      grad.addColorStop(0.3, `rgba(${r},${g},${b},0.08)`);
+      grad.addColorStop(0.7, `rgba(${r},${g},${b},0.2)`);
+      grad.addColorStop(1, `rgba(${r},${g},${b},0.45)`);
+      ctx.strokeStyle = grad;
+      ctx.lineWidth = 1.5;
+      ctx.lineJoin = 'round';
+      ctx.stroke();
+
+      const lastIdx = (_ptIdx - 1 + _pedalTraceLen) % _pedalTraceLen;
+      const lastVal = tr.buf[lastIdx];
+      if (lastVal > 0.02) {
+        const lx = w - 1;
+        const ly = h - lastVal * (h - 2) - 1;
+        ctx.beginPath();
+        ctx.arc(lx, ly, 2.5, 0, Math.PI * 2);
+        ctx.fillStyle = `rgba(${r},${g},${b},0.6)`;
+        ctx.fill();
+      }
+    }
+  }
+
+  // ── Curve-following dot renderer ──
+  // Each dot sits on the response curve at the current pedal input position.
+  // A fading trail of recent positions shows movement along the curve.
+  function _renderCurveDots(ctx, positions, thr, brk, clt) {
+    // Update trails — map pedal values to their corresponding trail arrays
+    const trailMap = [
+      { trail: _thrTrail, val: thr },
+      { trail: _brkTrail, val: brk },
+      { trail: _cltTrail, val: clt },
+    ];
+
+    // Push new positions into trail buffers
+    for (const pos of positions) {
+      let trail;
+      if (pos.rgb[0] === 76) trail = _thrTrail;        // green = throttle
+      else if (pos.rgb[0] === 244) trail = _brkTrail;   // red = brake
+      else trail = _cltTrail;                            // blue = clutch
+
+      trail.push({ x: pos.x, y: pos.y });
+      while (trail.length > _trailLen) trail.shift();
+    }
+
+    // Clear trails for pedals not in positions (below threshold)
+    if (thr <= 0.01) _thrTrail.length = 0;
+    if (brk <= 0.01) _brkTrail.length = 0;
+    if (clt <= 0.01) _cltTrail.length = 0;
+
+    // Draw trails + dots
+    const allTrails = [
+      { trail: _thrTrail, rgb: [76, 175, 80] },
+      { trail: _brkTrail, rgb: [244, 67, 54] },
+      { trail: _cltTrail, rgb: [66, 165, 245] },
+    ];
+
+    for (const { trail, rgb } of allTrails) {
+      if (trail.length < 1) continue;
+      const [r, g, b] = rgb;
+
+      // Draw fading trail line
+      if (trail.length >= 2) {
+        for (let i = 1; i < trail.length; i++) {
+          const alpha = (i / trail.length) * 0.35;
+          ctx.beginPath();
+          ctx.moveTo(trail[i - 1].x, trail[i - 1].y);
+          ctx.lineTo(trail[i].x, trail[i].y);
+          ctx.strokeStyle = `rgba(${r},${g},${b},${alpha})`;
+          ctx.lineWidth = 1.5;
+          ctx.stroke();
+        }
+      }
+
+      // Draw glowing dot at current position
+      const cur = trail[trail.length - 1];
+
+      // Outer glow
+      ctx.beginPath();
+      ctx.arc(cur.x, cur.y, 6, 0, Math.PI * 2);
+      ctx.fillStyle = `rgba(${r},${g},${b},0.15)`;
+      ctx.fill();
+
+      // Inner glow
+      ctx.beginPath();
+      ctx.arc(cur.x, cur.y, 3.5, 0, Math.PI * 2);
+      ctx.fillStyle = `rgba(${r},${g},${b},0.5)`;
+      ctx.fill();
+
+      // Core dot
+      ctx.beginPath();
+      ctx.arc(cur.x, cur.y, 2, 0, Math.PI * 2);
+      ctx.fillStyle = `rgba(${r},${g},${b},0.9)`;
+      ctx.fill();
+    }
+  }
+
+  // ═══ COMMENTARY ═══
+  const col = document.getElementById('commentaryCol');
+  const dash = document.getElementById('dashboard');
+  const inner = document.getElementById('commentaryInner');
+
+  // ── Commentary icon library ──
+  // Each SVG uses currentColor so it inherits the sentiment hue via style.color.
+  // viewBox 0 0 24 24, stroke-based, 1.5px stroke for clarity at 28px render size.
+  const _s = (d, extra) => `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"${extra||''}>${d}</svg>`;
+  const _commentaryIcons = {
+    // ── car_response ──
+    spin_catch:        _s('<path d="M12 2v4"/><path d="M12 18v4"/><path d="M4.93 4.93l2.83 2.83"/><path d="M16.24 16.24l2.83 2.83"/><path d="M2 12h4"/><path d="M18 12h4"/><path d="M4.93 19.07l2.83-2.83"/><path d="M16.24 7.76l2.83-2.83"/><circle cx="12" cy="12" r="3"/><path d="M14.5 9.5l3-3" stroke-dasharray="2 2"/>'),
+    wall_contact:      _s('<rect x="2" y="4" width="4" height="16" rx="1"/><path d="M6 12h5"/><path d="M11 8l4 4-4 4"/><path d="M15 7l2 2-2 2"/><path d="M17 13l2 2-2 2"/><circle cx="19" cy="6" r="1" fill="currentColor" stroke="none"/>'),
+    off_track:         _s('<path d="M3 20L12 4l9 16H3z"/><path d="M12 10v4"/><circle cx="12" cy="17" r="0.5" fill="currentColor"/>'),
+    kerb_hit:          _s('<path d="M3 18h18"/><path d="M3 18l3-3h2l3-3h2l3-3h2l3-3"/><path d="M8 12v6"/><path d="M16 6v12"/><circle cx="12" cy="9" r="2"/>'),
+    high_cornering_load: _s('<circle cx="12" cy="12" r="9"/><path d="M12 12l6-3"/><path d="M12 3v2"/><path d="M12 19v2"/><path d="M3 12h2"/><path d="M19 12h2"/><path d="M5.64 5.64l1.41 1.41"/><path d="M16.95 16.95l1.41 1.41"/>'),
+    heavy_braking:     _s('<circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="4"/><rect x="10" y="6" width="4" height="5" rx="1" fill="currentColor" stroke="none" opacity="0.5"/><path d="M8 12h8"/><path d="M12 8v8"/>'),
+    car_balance_sustained: _s('<path d="M4 16l4-8h8l4 8"/><circle cx="8" cy="16" r="2"/><circle cx="16" cy="16" r="2"/><path d="M12 4v4"/><path d="M10 6h4"/>'),
+    rapid_gear_change: _s('<rect x="5" y="3" width="14" height="18" rx="2"/><path d="M9 7v4h3V7"/><path d="M12 11v4h3v-4"/><path d="M9 15v3"/><circle cx="12" cy="19" r="0.5" fill="currentColor"/>'),
+
+    // ── hardware ──
+    abs_activation:    _s('<rect x="3" y="7" width="18" height="10" rx="2"/><path d="M7 11h2l1-2 1 4 1-4 1 2h2"/>', ' stroke-width="1.8"'),
+    tc_intervention:   _s('<path d="M12 3a9 9 0 1 0 0 18"/><path d="M12 3a9 9 0 0 1 0 18"/><path d="M9 9l6 6"/><path d="M9 9h3v3"/>'),
+    ffb_torque_spike:  _s('<path d="M12 2v20"/><path d="M2 12h20"/><path d="M7 7c2 2 3 5 5 5s3-3 5-5"/><path d="M7 17c2-2 3-5 5-5s3 3 5 5"/>'),
+    brake_bias_change: _s('<circle cx="12" cy="12" r="9"/><path d="M12 3v18"/><path d="M8 8h-1a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h1"/><path d="M16 8h1a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1h-1"/><path d="M8 12h8" stroke-dasharray="2 1"/>'),
+    tc_setting_change: _s('<circle cx="12" cy="12" r="9"/><path d="M8 8h8"/><path d="M12 8v8"/><path d="M9 15l3-3 3 3" stroke-dasharray="2 1"/>'),
+    abs_setting_change: _s('<circle cx="12" cy="12" r="9"/><path d="M7 12h10"/><path d="M7 9h10"/><path d="M7 15h10"/><circle cx="14" cy="12" r="1.5" fill="currentColor" stroke="none"/>'),
+    arb_front_change:  _s('<path d="M4 16h16"/><path d="M6 16V8a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v8"/><path d="M10 12h4" stroke-dasharray="2 1"/><path d="M8 10l2 2-2 2"/>'),
+    arb_rear_change:   _s('<path d="M4 8h16"/><path d="M6 8v8a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V8"/><path d="M10 12h4" stroke-dasharray="2 1"/><path d="M16 10l-2 2 2 2"/>'),
+
+    // ── game_feel ──
+    qualifying_push:   _s('<path d="M13 2L3 14h9l-1 8 10-12h-9l1-8"/>'),
+    drs_active:        _s('<path d="M2 8h20"/><path d="M4 8l2 10h12l2-10"/><path d="M8 8V5a4 4 0 0 1 8 0v3"/><path d="M10 12h4" stroke-dasharray="3 2"/>'),
+    ers_low:           _s('<path d="M2 12h4l2-4 3 8 3-8 2 4h4"/><path d="M18 6l2 2-2 2"/>'),
+    personal_best:     _s('<path d="M12 2l2.4 7.4H22l-6.2 4.5 2.4 7.3L12 16.7l-6.2 4.5 2.4-7.3L2 9.4h7.6z"/>'),
+    long_stint:        _s('<circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/><path d="M16 4l2 2"/><path d="M8 4L6 6"/>'),
+    session_time_low:  _s('<circle cx="12" cy="12" r="9"/><path d="M12 7v5l4 2"/><path d="M3 3l3 3"/><path d="M21 3l-3 3"/>'),
+
+    // ── racing_experience ──
+    close_battle:      _s('<path d="M5 17l3-12h3l2 5 2-5h3l3 12"/><path d="M4 10h16" stroke-dasharray="3 2"/><circle cx="8" cy="17" r="1.5"/><circle cx="16" cy="17" r="1.5"/>'),
+    position_gained:   _s('<path d="M12 19V5"/><path d="M5 12l7-7 7 7"/>'),
+    position_lost:     _s('<path d="M12 5v14"/><path d="M5 12l7 7 7-7"/>'),
+    yellow_flag:       _s('<path d="M5 2v20"/><path d="M5 4h12l-3 4 3 4H5"/>'),
+    debris_on_track:   _s('<path d="M3 20h18"/><path d="M7 17l2-5"/><path d="M12 12l-1-4"/><path d="M15 14l2-6"/><path d="M10 17l1-3"/><circle cx="8" cy="10" r="1" fill="currentColor"/><circle cx="14" cy="7" r="1.5" fill="currentColor"/><circle cx="17" cy="11" r="1" fill="currentColor"/>'),
+    race_start:        _s('<circle cx="8" cy="6" r="2.5"/><circle cx="16" cy="6" r="2.5"/><circle cx="8" cy="12" r="2.5"/><circle cx="16" cy="12" r="2.5"/><circle cx="8" cy="18" r="2.5" fill="currentColor" opacity="0.3"/><circle cx="16" cy="18" r="2.5" fill="currentColor" opacity="0.3"/>'),
+    formation_lap:     _s('<path d="M3 6h18"/><path d="M7 6v12"/><path d="M12 6v12"/><path d="M17 6v12"/><path d="M5 14h14" stroke-dasharray="2 2"/><path d="M3 18h18"/>'),
+    pit_entry:         _s('<path d="M3 12h4l2-3h6l2 3h4"/><path d="M7 12v5a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-5"/><circle cx="9" cy="15" r="1"/><circle cx="15" cy="15" r="1"/><path d="M11 5h2v4h-2z" fill="currentColor" stroke="none"/><path d="M10 5h4"/>'),
+    low_fuel:          _s('<rect x="5" y="4" width="14" height="16" rx="2"/><path d="M9 4V2h6v2"/><path d="M9 12h6"/><path d="M12 12v5"/><path d="M8 18h8" stroke-dasharray="2 1"/>'),
+    wet_track:         _s('<path d="M4 14a4 4 0 0 1 4-4 4 4 0 0 1 4 4 4 4 0 0 0 4-4 4 4 0 0 1 4 4"/><path d="M4 18a4 4 0 0 1 4-4 4 4 0 0 1 4 4 4 4 0 0 0 4-4 4 4 0 0 1 4 4"/><path d="M8 3v3"/><path d="M12 2v4"/><path d="M16 3v3"/>'),
+    track_temp_cold:   _s('<path d="M12 2v14"/><circle cx="12" cy="18" r="4"/><path d="M8 18a4 4 0 0 0 8 0"/><path d="M10 8h4"/><path d="M10 11h4"/><path d="M3 5l2 1"/><path d="M3 9l2-1"/>'),
+    track_temp_hot:    _s('<path d="M12 2v14"/><circle cx="12" cy="18" r="4" fill="currentColor" opacity="0.2"/><path d="M8 18a4 4 0 0 0 8 0"/><path d="M10 8h4"/><path d="M10 11h4"/><path d="M18 3l1 3"/><path d="M20 8l-2 1"/><path d="M19 12l-2-1"/>'),
+    tyre_wear_high:    _s('<circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="4"/><path d="M9 7l6 10" stroke-dasharray="2 2"/><path d="M15 7l-6 10" stroke-dasharray="2 2"/>'),
+    hot_tyres:         _s('<circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="4"/><path d="M12 3v3"/><path d="M12 18v3"/><path d="M3 12h3"/><path d="M18 12h3"/><path d="M10 10l-3-3" stroke-dasharray="1.5 1.5"/><path d="M14 14l3 3" stroke-dasharray="1.5 1.5"/>'),
+    incident_spike:    _s('<path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><path d="M12 9v4"/><circle cx="12" cy="16" r="0.5" fill="currentColor"/>'),
+    black_flag:        _s('<path d="M5 2v20"/><path d="M5 4h14v8H5"/><path d="M5 4h7v4H5" fill="currentColor" opacity="0.4"/><path d="M12 8h7v4h-7" fill="currentColor" opacity="0.4"/>'),
+
+    // strategy engine
+    strategy_call:     _s('<path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/><circle cx="12" cy="12" r="2" fill="currentColor" stroke="none"/>'),
+
+    // fallback
+    _default:          _s('<circle cx="12" cy="12" r="9"/><path d="M12 8v4l3 3"/>')
+  };
+
+  // Title → topicId reverse map (fallback when CommentaryTopicId isn't available)
+  const _titleToTopicId = {
+    'Big Save': 'spin_catch',
+    'Wall / Barrier Contact': 'wall_contact',
+    'Off Track': 'off_track',
+    'Kerb / Curb Hit': 'kerb_hit',
+    'ABS Activation': 'abs_activation',
+    'Traction Control Cut': 'tc_intervention',
+    'Close Racing': 'close_battle',
+    'Position Gained': 'position_gained',
+    'Position Lost': 'position_lost',
+    'Yellow Flag': 'yellow_flag',
+    'Debris on Track': 'debris_on_track',
+    'Race Start': 'race_start',
+    'Formation / Pace Lap': 'formation_lap',
+    'Personal Best Lap': 'personal_best',
+    'Pit Lane Entry': 'pit_entry',
+    'Maximum Cornering Load': 'high_cornering_load',
+    'FFB Torque Spike': 'ffb_torque_spike',
+    'Low Fuel': 'low_fuel',
+    'Wet Conditions': 'wet_track',
+    'Cold Track Conditions': 'track_temp_cold',
+    'High Tyre Wear': 'tyre_wear_high',
+    'Overheating Tyres': 'hot_tyres',
+    'Major Braking Zone': 'heavy_braking',
+    'Hot Qualifying Lap': 'qualifying_push',
+    'iRacing Incident Points': 'incident_spike',
+    'ERS Battery Low': 'ers_low',
+    'High Track Temperature': 'track_temp_hot',
+    'DRS Open': 'drs_active',
+    'Car On The Limit': 'car_balance_sustained',
+    'Black Flag': 'black_flag',
+    'Aggressive Gear Shift': 'rapid_gear_change',
+    'Long Stint Distance': 'long_stint',
+    'Session Time Running Out': 'session_time_low',
+    'Brake Bias Adjustment': 'brake_bias_change',
+    'Traction Control Adjusted': 'tc_setting_change',
+    'ABS Level Adjusted': 'abs_setting_change',
+    'Front ARB Adjusted': 'arb_front_change',
+    'Rear ARB Adjusted': 'arb_rear_change',
+  };
+
+  // Category → icon fallback (when neither topicId nor title match)
+  const _categoryIcons = {
+    car_response:       _commentaryIcons['car_balance_sustained'],
+    hardware:           _commentaryIcons['abs_activation'],
+    game_feel:          _commentaryIcons['qualifying_push'],
+    racing_experience:  _commentaryIcons['close_battle'],
+    strategy:           _s('<path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/><circle cx="12" cy="12" r="2" fill="currentColor" stroke="none"/>'),
+  };
+
+  function _resolveCommentaryIcon(topicId, title, category) {
+    if (topicId && _commentaryIcons[topicId]) return _commentaryIcons[topicId];
+    const idFromTitle = _titleToTopicId[title];
+    if (idFromTitle && _commentaryIcons[idFromTitle]) return _commentaryIcons[idFromTitle];
+    if (category && _categoryIcons[category]) return _categoryIcons[category];
+    return _commentaryIcons['_default'];
+  }
+
+  // Overheating topics → force orange (hue 30) or red (hue 0) based on severity
+  const _heatTopics = { hot_tyres: true, track_temp_hot: true };
+  // Wear / degradation topics → force orange hue
+  const _wearTopics = { tyre_wear_high: true, long_stint: true };
+  // Best / achievement topics → force green color scheme
+  const _bestTopics = { personal_best: true, position_gained: true };
+
+  function showCommentary(hue, title, text, meta, topicId, severity, trackImage) {
+    // Resolve topic early so we can override hue for heat, wear & best topics
+    const resolvedTopic = topicId || _titleToTopicId[title] || '';
+    if (_heatTopics[resolvedTopic]) {
+      hue = (severity >= 3) ? 0 : 30;   // high severity → red, else orange
+    } else if (_wearTopics[resolvedTopic]) {
+      hue = 30;                           // orange for wear/degradation
+    } else if (_bestTopics[resolvedTopic]) {
+      hue = 145;                          // green for achievements
+    }
+
+    col.style.setProperty('--commentary-h', hue);
+    inner.style.background = `hsla(${hue}, 50%, 13%, 0.96)`;
+    inner.style.borderColor = `hsla(${hue}, 50%, 27%, 0.50)`;
+    document.getElementById('commentaryTitle').textContent = title;
+    document.getElementById('commentaryTitle').style.color = `hsl(${hue},55%,65%)`;
+    // Set commentary icon — try topicId, then title lookup, then category, then default
+    const iconEl = document.getElementById('commentaryIcon');
+    const iconColor = `hsl(${hue},55%,65%)`;
+    const svgStr = _resolveCommentaryIcon(topicId, title, meta);
+    iconEl.innerHTML = svgStr;
+    iconEl.style.color = iconColor;
+    const textEl = document.getElementById('commentaryText');
+    const scrollEl = document.getElementById('commentaryScroll');
+    textEl.textContent = text;
+    textEl.classList.remove('scrolling');
+    scrollEl.classList.remove('no-overflow');
+    document.getElementById('commentaryMeta').textContent = meta;
+
+    // Track image — show when URL provided by track-related commentary
+    const imgEl = document.getElementById('commentaryTrackImg');
+    if (trackImage) {
+      imgEl.style.backgroundImage = `url(${trackImage})`;
+      imgEl.innerHTML = '<span class="img-attr">Wikimedia Commons \u00B7 CC</span>';
+      imgEl.classList.add('active');
+    } else {
+      imgEl.classList.remove('active');
+    }
+
+    col.classList.add('visible');
+    dash.style.setProperty('--sentiment-h', hue);
+    dash.style.setProperty('--sentiment-s', '40%');
+    dash.style.setProperty('--sentiment-l', '12%');
+    dash.style.setProperty('--sentiment-alpha', '0.06');
+
+    // Activate data visualization for this topic (hue already overridden for heat)
+    if (window.showCommentaryViz) window.showCommentaryViz(resolvedTopic, hue);
+    // Activate WebGL trail effect on commentary border
+    if (window.setCommentaryTrailGL) window.setCommentaryTrailGL(true, hue);
+
+    // After width transition settles (~600ms), measure overflow for slow scroll
+    setTimeout(() => {
+      const scrollH = scrollEl.clientHeight;
+      const textH = textEl.scrollHeight;
+      if (textH > scrollH + 4) {
+        const overflow = textH - scrollH;
+        textEl.style.setProperty('--scroll-distance', `-${overflow}px`);
+        // Duration: ~40px/s so it reads comfortably
+        const duration = Math.max(6, overflow / 40 * 2 + 4);
+        textEl.style.setProperty('--scroll-duration', `${duration.toFixed(1)}s`);
+        textEl.classList.add('scrolling');
+      } else {
+        scrollEl.classList.add('no-overflow');
+      }
+    }, 620);  // wait for commentary-col max-height transition (0.55s) to finish
+  }
+  function hideCommentary() {
+    col.classList.remove('visible');
+    dash.style.setProperty('--sentiment-alpha', '0');
+    if (window.hideCommentaryViz) window.hideCommentaryViz();
+    if (window.setCommentaryTrailGL) window.setCommentaryTrailGL(false);
+    // Clear track image
+    const imgEl = document.getElementById('commentaryTrackImg');
+    if (imgEl) imgEl.classList.remove('active');
+  }
+
+  // ═══ CYCLING PANELS (rating/position only — fuel/tyres no longer cycle) ═══
+  let ratingActive = true;
+
+  let _hasRatingData = false; // set true when iRating or SR become nonzero
+  // Allow external modules (rating-editor.js) to flag rating data as available
+  window.setHasRatingData = function(val) { _hasRatingData = !!val; };
+  // Expose current cycle state so poll-engine can use asymmetric timing
+  window._isRatingPageActive = function() { return ratingActive; };
+  function cycleRatingPos() {
+    // Don't cycle to rating page if no iRating/SR data is available
+    if (!_hasRatingData) return;
+    const r = document.getElementById('ratingPage');
+    const p = document.getElementById('positionPage');
+    const d1 = document.getElementById('dotRating');
+    const d2 = document.getElementById('dotPos');
+    if (ratingActive) {
+      r.classList.replace('active', 'inactive');
+      p.classList.replace('inactive', 'active');
+      d1.classList.remove('active'); d2.classList.add('active');
+    } else {
+      p.classList.replace('active', 'inactive');
+      r.classList.replace('inactive', 'active');
+      d2.classList.remove('active'); d1.classList.add('active');
+    }
+    ratingActive = !ratingActive;
+  }
+
+  // Force position page visible (used when timer row is showing)
+  function showPositionPage() {
+    const r = document.getElementById('ratingPage');
+    const p = document.getElementById('positionPage');
+    const d1 = document.getElementById('dotRating');
+    const d2 = document.getElementById('dotPos');
+    if (ratingActive) {
+      r.classList.replace('active', 'inactive');
+      p.classList.replace('inactive', 'active');
+      d1.classList.remove('active'); d2.classList.add('active');
+      ratingActive = false;
+    }
+  }
+
+  // Cycling interval — call cycleRatingPos() from SimHub timer or JS setInterval
+  // setInterval(cycleRatingPos, 10000);
+
+  // ═══ iRATING BAR CHART ═══
+  function updateIRBar(iRating) {
+    const maxIR = 5000;
+    const pct = Math.min(100, (iRating / maxIR) * 100);
+    document.getElementById('irBarFill').style.width = pct + '%';
+  }
+  updateIRBar(0); // Will be set from session data
+
+  // ═══ SAFETY RATING PIE CHART ═══
+  function updateSRPie(srValue) {
+    const pct = Math.min(1, srValue / 4.0);
+    const circ = 2 * Math.PI * 15; // ~94.25
+    const offset = circ * (1 - pct);
+    const fill = document.getElementById('srPieFill');
+    fill.setAttribute('stroke-dashoffset', offset);
+    // Color: green if > 3.0, amber if > 2.0, red if lower
+    if (srValue >= 3.0) fill.setAttribute('stroke', 'var(--green)');
+    else if (srValue >= 2.0) fill.setAttribute('stroke', 'var(--amber)');
+    else fill.setAttribute('stroke', 'var(--red)');
+    // text label removed
+  }
+  updateSRPie(0); // Will be set from session data
+
+  // ═══ FLASH SYSTEM ═══
+  function flashElement(el, className) {
+    el.classList.remove(className);
+    void el.offsetWidth;
+    el.classList.add(className);
+    setTimeout(() => el.classList.remove(className), 1500);
+  }
+
+  function flashCtrlBar(id) {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.classList.remove('ctrl-changed', 'ctrl-flash-out');
+    void el.offsetWidth;
+    el.classList.add('ctrl-changed');
+    setTimeout(() => {
+      el.classList.remove('ctrl-changed');
+      el.classList.add('ctrl-flash-out');
+      setTimeout(() => el.classList.remove('ctrl-flash-out'), 1200);
+    }, 300);
+  }
+
+  // ═══ CONTROL VISIBILITY ═══
+  // Hide TC/ABS ctrl-items when the car doesn't have them
+  function setCtrlVisibility(hasBB, hasTC, hasABS) {
+    const bb = document.getElementById('ctrlBB');
+    const tc = document.getElementById('ctrlTC');
+    const abs = document.getElementById('ctrlABS');
+    if (bb) bb.classList.toggle('ctrl-hidden', !hasBB);
+    if (tc) tc.classList.toggle('ctrl-hidden', !hasTC);
+    if (abs) abs.classList.toggle('ctrl-hidden', !hasABS);
+    // Show "No Adjustments" when none are available
+    const panel = bb && bb.closest('.car-controls');
+    if (panel) panel.classList.toggle('no-adj', !hasBB && !hasTC && !hasABS);
+  }
+
+  // ═══ TYRE TEMPERATURE COLORING ═══
+  // Returns CSS class based on tyre temp (°F for iRacing)
+  function getTyreTempClass(tempF) {
+    if (tempF <= 0) return '';
+    if (tempF < 150) return 'cold';       // < 66°C
+    if (tempF < 230) return 'optimal';     // 66-110°C
+    if (tempF < 270) return 'hot';         // 110-132°C
+    return 'danger';                       // > 132°C
+  }
+
+  // Update a single tyre cell: temp value + color class + wear bar.
+  // wearPct is REMAINING life: 100 = brand new, 0 = destroyed, -1 = no data.
+  function updateTyreCell(index, tempF, wearPct) {
+    const cells = document.querySelectorAll('.tyre-cell');
+    const wearFills = document.querySelectorAll('.tyre-wear-fill');
+    if (index >= cells.length) return;
+    const cell = cells[index];
+
+    // No wear data — show empty bar with dim indicator
+    if (wearPct < 0) {
+      if (index < wearFills.length) {
+        wearFills[index].style.width = '0%';
+        wearFills[index].style.background = 'hsla(0,0%,100%,0.1)';
+      }
+      // Still update temp
+      cell.textContent = tempF > 0 ? Math.round(tempF) + '°' : '—';
+      cell.className = 'tyre-cell ' + getTyreTempClass(tempF);
+      return;
+    }
+
+    cell.textContent = tempF > 0 ? Math.round(tempF) + '°' : '—';
+    cell.className = 'tyre-cell ' + getTyreTempClass(tempF);
+    if (index < wearFills.length) {
+      wearFills[index].style.width = Math.max(0, Math.min(100, wearPct)) + '%';
+      // Color by remaining life: > 50% green, > 25% amber, below = red
+      if (wearPct > 50) wearFills[index].style.background = 'var(--green)';
+      else if (wearPct > 25) wearFills[index].style.background = 'var(--amber)';
+      else wearFills[index].style.background = 'var(--red)';
+    }
+  }
+
+  // ═══ FUEL STATE ═══
+  function updateFuelBar(pct, pitLapPct) {
+    const bar = document.querySelector('.fuel-bar-inner');
+    if (!bar) return;
+    bar.style.width = Math.max(0, Math.min(100, pct)) + '%';
+    bar.className = 'fuel-bar-inner';
+    if (pct > 40) bar.classList.add('healthy');
+    else if (pct > 15) bar.classList.add('caution');
+    else bar.classList.add('critical');
+    // Pit marker
+    const marker = document.querySelector('.fuel-bar-pit-marker');
+    if (marker && pitLapPct > 0) {
+      marker.style.left = Math.min(100, pitLapPct) + '%';
+      marker.style.display = '';
+    } else if (marker) {
+      marker.style.display = 'none';
+    }
+  }
+
+  // ═══ TRACK MAP ═══
+  let _mapLastPath = '';
+  let _mapSmoothedX = 0, _mapSmoothedY = 0;
+  let _mapHasInit = false;
+  const _SVG_NS = 'http://www.w3.org/2000/svg';
+  const _MAP_MAX_OPPONENTS = 63; // iRacing max field size
+
+  // G-force animation trail on player dot — ring buffer of recent positions
+  const _MAP_TRAIL_LEN = 24;
+  const _mapTrailX = new Float32Array(_MAP_TRAIL_LEN);
+  const _mapTrailY = new Float32Array(_MAP_TRAIL_LEN);
+  const _mapTrailG = new Float32Array(_MAP_TRAIL_LEN); // total G at each sample
+  let _mapTrailIdx = 0;
+  let _mapTrailCount = 0;
+  let _fullMapTrailEl = null;
+  let _zoomMapTrailEl = null;
+
+  function _ensureTrailElement(parentId, refElId) {
+    const parent = document.getElementById(parentId);
+    if (!parent) return null;
+    let trail = parent.querySelector('.map-gforce-trail');
+    if (trail) return trail;
+    trail = document.createElementNS(_SVG_NS, 'polyline');
+    trail.classList.add('map-gforce-trail');
+    trail.setAttribute('fill', 'none');
+    trail.setAttribute('stroke-linecap', 'round');
+    trail.setAttribute('stroke-linejoin', 'round');
+    // Insert before the player dot (last circle child) so trail draws behind it
+    const refEl = document.getElementById(refElId);
+    if (refEl) parent.insertBefore(trail, refEl);
+    else parent.appendChild(trail);
+    return trail;
+  }
+
+  function _renderMapTrail(trailEl, strokeWidth) {
+    if (!trailEl) return;
+    const count = Math.min(_mapTrailCount, _MAP_TRAIL_LEN);
+    if (count < 2) { trailEl.setAttribute('points', ''); return; }
+
+    // Build points string — newest first (ring buffer)
+    let pts = '';
+    let avgG = 0;
+    for (let i = 0; i < count; i++) {
+      const idx = (_mapTrailIdx - 1 - i + _MAP_TRAIL_LEN) % _MAP_TRAIL_LEN;
+      pts += _mapTrailX[idx].toFixed(1) + ',' + _mapTrailY[idx].toFixed(1) + ' ';
+      avgG += _mapTrailG[idx];
+    }
+    avgG /= count;
+
+    // Color: low G → cyan, high G → orange/red, modulated by intensity
+    const gNorm = Math.min(avgG / 2.5, 1.0);
+    const hue = Math.round(185 - gNorm * 155); // 185 (cyan) → 30 (orange)
+    const sat = Math.round(60 + gNorm * 30);
+    const lum = Math.round(50 + gNorm * 10);
+    const alpha = 0.25 + gNorm * 0.35;
+
+    trailEl.setAttribute('points', pts);
+    trailEl.setAttribute('stroke', 'hsla(' + hue + ',' + sat + '%,' + lum + '%,' + alpha.toFixed(2) + ')');
+    trailEl.setAttribute('stroke-width', String(strokeWidth));
+  }
+
+  // Reset track map — clears recorded data and restarts capture
+  function resetTrackMap() {
+    fetch((window._simhubUrlOverride || SIMHUB_URL) + '?action=resetmap').catch(() => {});
+    _mapLastPath = '';
+    _mapHasInit = false;
+    const fullTrack = document.getElementById('fullMapTrack');
+    const zoomTrack = document.getElementById('zoomMapTrack');
+    if (fullTrack) fullTrack.setAttribute('d', '');
+    if (zoomTrack) zoomTrack.setAttribute('d', '');
+    // Clear opponent dots
+    const fg = document.getElementById('fullMapOpponents');
+    const zg = document.getElementById('zoomMapOpponents');
+    if (fg) fg.innerHTML = '';
+    if (zg) zg.innerHTML = '';
+  }
+
+  // Sector colors: 0=none(transparent), 1=pb(purple), 2=faster(green), 3=slower(red)
+  const _sectorColors = ['transparent', 'hsl(280,60%,55%)', 'hsl(130,60%,50%)', 'hsl(0,65%,50%)'];
+  const _sectorActiveColor = 'hsla(0,0%,100%,0.25)';
+
+  // Split an SVG path string into N sector sub-paths.
+  // boundaryPcts is an array of N-1 boundary percentages (e.g. [0.33, 0.67] for 3 sectors).
+  // Falls back to equal thirds if no boundaries provided.
+  // Track map points are evenly distributed by LapDistPct, so point index ≈ pct * count.
+  function _splitPathIntoSectors(svgPath, boundaryPcts) {
+    const coords = svgPath.match(/[\d.]+[,\s]+[\d.]+/g);
+    if (!coords || coords.length < 6) return [];
+
+    // Determine boundary indices from percentages
+    var pcts = (Array.isArray(boundaryPcts) && boundaryPcts.length >= 1)
+      ? boundaryPcts
+      : [0.333, 0.667]; // default to 3 sectors
+    var indices = pcts.map(function(p) { return Math.round(p * coords.length); });
+
+    // Build N sector sub-paths
+    var result = [];
+    var prevIdx = 0;
+    for (var s = 0; s <= indices.length; s++) {
+      var endIdx = s < indices.length ? indices[s] : coords.length;
+      var pts = coords.slice(prevIdx, endIdx);
+      if (pts.length === 0) { result.push(''); prevIdx = endIdx; continue; }
+      var startPt = prevIdx === 0 ? pts[0] : coords[prevIdx - 1];
+      var d = 'M ' + startPt;
+      for (var j = (prevIdx === 0 ? 1 : 0); j < pts.length; j++) d += ' L ' + pts[j];
+      result.push(d);
+      prevIdx = endIdx;
+    }
+    return result;
+  }
+  window._splitPathIntoSectors = _splitPathIntoSectors;
+
+  // Smoothed zoom radius for the local map
+  let _mapZoomRadius = 15;
+
+  // Smoothed heading for local map rotation
+  let _mapSmoothedHeading = 0;
+
+  function updateTrackMap(svgPath, playerX, playerY, opponentStr, speedMph, headingDeg) {
+    // No track map available — clear outline, hide markers, center dots
+    if (!svgPath && _mapLastPath !== '') {
+      _mapLastPath = '';
+      _mapHasInit = false;
+      const fullTrack = document.getElementById('fullMapTrack');
+      const zoomTrack = document.getElementById('zoomMapTrack');
+      if (fullTrack) fullTrack.setAttribute('d', '');
+      if (zoomTrack) zoomTrack.setAttribute('d', '');
+
+      // Remove sector sub-paths
+      const fullSvg = document.getElementById('fullMapSvg');
+      if (fullSvg) fullSvg.querySelectorAll('.map-sector').forEach(el => el.remove());
+
+      // Hide start/finish markers
+      const fullSF = document.getElementById('fullMapSF');
+      const zoomSF = document.getElementById('zoomMapSF');
+      if (fullSF) fullSF.style.display = 'none';
+      if (zoomSF) zoomSF.style.display = 'none';
+    }
+
+    // Update track outline (only when path changes — new track or first load)
+    if (svgPath && svgPath !== _mapLastPath) {
+      _mapLastPath = svgPath;
+      _mapHasInit = false;
+      const fullTrack = document.getElementById('fullMapTrack');
+      const zoomTrack = document.getElementById('zoomMapTrack');
+      if (fullTrack) fullTrack.setAttribute('d', svgPath);
+      if (zoomTrack) zoomTrack.setAttribute('d', svgPath);
+
+      // Split path into N sector sub-paths using native iRacing boundaries
+      const boundaryPcts = Array.isArray(window._sectorBoundaries) ? window._sectorBoundaries : null;
+      const sectorPaths = _splitPathIntoSectors(svgPath, boundaryPcts);
+      const sectorCount = sectorPaths.length;
+
+      // Dynamically create/update sector path elements in the full map SVG
+      const fullSvg = document.getElementById('fullMapSvg');
+      if (fullSvg) {
+        // Remove old sector paths
+        fullSvg.querySelectorAll('.map-sector').forEach(el => el.remove());
+        // Insert new sector paths before the opponents group
+        const oppGroup = document.getElementById('fullMapOpponents');
+        for (let i = 0; i < sectorCount; i++) {
+          const path = document.createElementNS(_SVG_NS, 'path');
+          path.classList.add('map-sector');
+          path.id = 'mapSector' + (i + 1);
+          path.setAttribute('d', sectorPaths[i]);
+          if (oppGroup) fullSvg.insertBefore(path, oppGroup);
+          else fullSvg.appendChild(path);
+        }
+      }
+
+      // Position start/finish marker at the first point of the path (LapDistPct=0)
+      const sfMatch = svgPath.match(/^M\s*([\d.]+)[,\s]+([\d.]+)/);
+      if (sfMatch) {
+        const sfX = +sfMatch[1], sfY = +sfMatch[2];
+        const fullSF = document.getElementById('fullMapSF');
+        const zoomSF = document.getElementById('zoomMapSF');
+        if (fullSF) {
+          fullSF.setAttribute('transform', 'translate(' + sfX.toFixed(1) + ',' + sfY.toFixed(1) + ')');
+          fullSF.style.display = '';
+        }
+        if (zoomSF) {
+          zoomSF.setAttribute('transform', 'translate(' + sfX.toFixed(1) + ',' + sfY.toFixed(1) + ')');
+          zoomSF.style.display = '';
+        }
+      }
+    }
+
+    // Update sector colors from live performance data (set by poll-engine)
+    if (window._sectorData) {
+      const sd = window._sectorData;
+      for (let i = 1; i <= sd.sectorCount; i++) {
+        const el = document.getElementById('mapSector' + i);
+        if (!el) continue;
+        if (i === sd.curSector) {
+          el.setAttribute('stroke', _sectorActiveColor);
+        } else {
+          el.setAttribute('stroke', _sectorColors[sd.states[i - 1]] || 'transparent');
+        }
+      }
+    }
+
+    // Sanity: clamp coordinates to 0–100 SVG range
+    playerX = Math.max(0, Math.min(100, playerX));
+    playerY = Math.max(0, Math.min(100, playerY));
+
+    // Smoothing: reject large jumps, low-pass filter coordinates
+    if (!_mapHasInit) {
+      _mapSmoothedX = playerX;
+      _mapSmoothedY = playerY;
+      _mapHasInit = true;
+    } else {
+      const dx = playerX - _mapSmoothedX;
+      const dy = playerY - _mapSmoothedY;
+      const jump = Math.sqrt(dx * dx + dy * dy);
+      // If jump is huge (>20 SVG units), blend slowly (glitch recovery)
+      const alpha = jump > 20 ? 0.08 : 0.45;
+      _mapSmoothedX += dx * alpha;
+      _mapSmoothedY += dy * alpha;
+    }
+
+    const sx = _mapSmoothedX;
+    const sy = _mapSmoothedY;
+
+    // Update player dot
+    const fullPlayer = document.getElementById('fullMapPlayer');
+    const zoomPlayer = document.getElementById('zoomMapPlayer');
+    if (fullPlayer) {
+      fullPlayer.setAttribute('cx', sx.toFixed(1));
+      fullPlayer.setAttribute('cy', sy.toFixed(1));
+    }
+    if (zoomPlayer) {
+      zoomPlayer.setAttribute('cx', sx.toFixed(1));
+      zoomPlayer.setAttribute('cy', sy.toFixed(1));
+    }
+
+    // Update track glow effect following player position
+    const glowFullSvg = document.getElementById('fullMapSvg');
+    const glowZoomSvg = document.getElementById('zoomMapSvg');
+    if (glowFullSvg) _updateTrackGlow(glowFullSvg, sx, sy);
+    if (glowZoomSvg) _updateTrackGlow(glowZoomSvg, sx, sy);
+
+    // G-force trail — read current G from datastream globals
+    const latG  = window._ambientLatG  || 0;
+    const longG = window._ambientLongG || 0;
+    const totalG = Math.sqrt(latG * latG + longG * longG);
+
+    // Sample position into ring buffer (every frame)
+    _mapTrailX[_mapTrailIdx] = sx;
+    _mapTrailY[_mapTrailIdx] = sy;
+    _mapTrailG[_mapTrailIdx] = totalG;
+    _mapTrailIdx = (_mapTrailIdx + 1) % _MAP_TRAIL_LEN;
+    _mapTrailCount++;
+
+    // Ensure trail SVG elements exist and render
+    if (!_fullMapTrailEl)  _fullMapTrailEl  = _ensureTrailElement('fullMapSvg', 'fullMapPlayer');
+    if (!_zoomMapTrailEl) _zoomMapTrailEl = _ensureTrailElement('zoomMapSvg', 'zoomMapPlayer');
+    _renderMapTrail(_fullMapTrailEl, 3);
+    _renderMapTrail(_zoomMapTrailEl, 1.8);
+
+    // Update zoom map — player always centered, track rotates so
+    // driving direction always points UP. Zoom out when slow to
+    // reveal nearby opponents; zoom in when fast for detail.
+    const zoomSvg = document.getElementById('zoomMapSvg');
+    if (zoomSvg) {
+      const spd = typeof speedMph === 'number' ? speedMph : 0;
+      // Zoom: slow → wider view (radius 24) to see nearby/oncoming cars,
+      //        fast → still fairly wide (radius 16) so you see oncoming traffic
+      const targetZR = 24 - Math.min(spd / 150, 1.0) * 8;
+      _mapZoomRadius += (targetZR - _mapZoomRadius) * 0.15;
+      const zr = _mapZoomRadius;
+
+      // ViewBox always centered on player — NO clamping, overflow="visible"
+      // handles content outside the 0-100 range. Player is always at center.
+      const vx = sx - zr;
+      const vy = sy - zr;
+      zoomSvg.setAttribute('viewBox', vx.toFixed(1) + ' ' + vy.toFixed(1) + ' ' + (zr * 2).toFixed(1) + ' ' + (zr * 2).toFixed(1));
+
+      // Clear any legacy CSS rotation on the SVG element
+      zoomSvg.style.transform = '';
+      zoomSvg.style.transformOrigin = '';
+
+      // Rotate the inner group around the player's SVG coordinate so
+      // the driving direction always points up. Player dot is outside
+      // the group so it stays upright and visually centered.
+      if (typeof headingDeg === 'number') {
+        let diff = headingDeg - _mapSmoothedHeading;
+        if (diff > 180) diff -= 360;
+        if (diff < -180) diff += 360;
+        // Dead-zone: ignore sub-degree jitter
+        if (Math.abs(diff) < 0.5) diff = 0;
+        _mapSmoothedHeading += diff * 0.15;
+        _mapSmoothedHeading = ((_mapSmoothedHeading % 360) + 360) % 360;
+
+        const rotGrp = document.getElementById('zoomMapRotateGroup');
+        if (rotGrp) {
+          rotGrp.setAttribute('transform',
+            'rotate(' + (-_mapSmoothedHeading).toFixed(2) + ',' + sx.toFixed(1) + ',' + sy.toFixed(1) + ')');
+        }
+      }
+    }
+
+    // Parse and render opponents
+    const fullG = document.getElementById('fullMapOpponents');
+    const zoomG = document.getElementById('zoomMapOpponents');
+    if (!fullG || !zoomG) return;
+
+    // Parse "x,y,pit;x,y,pit;..." format
+    const parts = opponentStr ? opponentStr.split(';') : [];
+    const count = Math.min(parts.length, _MAP_MAX_OPPONENTS);
+
+    // Ensure we have enough circle elements (create/remove as needed)
+    _ensureOpponentDots(fullG, count, 2.5);
+    _ensureOpponentDots(zoomG, count, 1.5);
+
+    // Update positions
+    const fullDots = fullG.children;
+    const zoomDots = zoomG.children;
+    for (let i = 0; i < count; i++) {
+      const seg = parts[i].split(',');
+      if (seg.length < 2) continue;
+      // Clamp opponent coords to 0–100
+      const ox = Math.max(0, Math.min(100, +seg[0]));
+      const oy = Math.max(0, Math.min(100, +seg[1]));
+      const inPit = seg[2] === '1';
+
+      fullDots[i].setAttribute('cx', ox);
+      fullDots[i].setAttribute('cy', oy);
+      fullDots[i].style.display = inPit ? 'none' : '';
+      fullDots[i].classList.toggle('close', _isClose(sx, sy, ox, oy));
+      // Add pulse animation for nearby opponents (~20% track proximity)
+      fullDots[i].classList.toggle('map-opponent-near', _isNear(sx, sy, ox, oy));
+
+      zoomDots[i].setAttribute('cx', ox);
+      zoomDots[i].setAttribute('cy', oy);
+      zoomDots[i].style.display = inPit ? 'none' : '';
+      zoomDots[i].classList.toggle('close', _isClose(sx, sy, ox, oy));
+      // Add pulse animation for nearby opponents (~20% track proximity)
+      zoomDots[i].classList.toggle('map-opponent-near', _isNear(sx, sy, ox, oy));
+    }
+  }
+
+  function _ensureOpponentDots(parent, count, radius) {
+    while (parent.children.length < count) {
+      const c = document.createElementNS(_SVG_NS, 'circle');
+      c.classList.add('map-opponent');
+      c.setAttribute('r', radius);
+      parent.appendChild(c);
+    }
+    while (parent.children.length > count) {
+      parent.removeChild(parent.lastChild);
+    }
+  }
+
+  function _isClose(px, py, ox, oy) {
+    const dx = px - ox, dy = py - oy;
+    return (dx * dx + dy * dy) < 64; // ~8 SVG units
+  }
+
+  function _isNear(px, py, ox, oy) {
+    // Proximity pulse: ~20% of track (distance ~20 SVG units = ~400 units squared)
+    const dx = px - ox, dy = py - oy;
+    return (dx * dx + dy * dy) < 400; // ~20 SVG units
+  }
+
+  function _updateTrackGlow(svgEl, px, py) {
+    // Create or update a radial gradient glow that follows player position
+    let glow = svgEl.getElementById('trackPlayerGlow');
+    let grad = svgEl.getElementById('trackGlowGrad');
+
+    if (!glow) {
+      // Create radial gradient definition once
+      const defs = svgEl.querySelector('defs') || (() => {
+        const d = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
+        svgEl.insertBefore(d, svgEl.firstChild);
+        return d;
+      })();
+
+      grad = document.createElementNS('http://www.w3.org/2000/svg', 'radialGradient');
+      grad.id = 'trackGlowGrad';
+      // Bright white-ish core that fades to brand color at edges
+      const stopCore = document.createElementNS('http://www.w3.org/2000/svg', 'stop');
+      stopCore.setAttribute('offset', '0%');
+      stopCore.setAttribute('stop-color', 'hsl(0,0%,100%)');
+      stopCore.setAttribute('stop-opacity', '0.45');
+      grad.appendChild(stopCore);
+
+      const stopMid = document.createElementNS('http://www.w3.org/2000/svg', 'stop');
+      stopMid.setAttribute('offset', '35%');
+      stopMid.setAttribute('stop-color', 'var(--map-player-color, hsl(185,70%,55%))');
+      stopMid.setAttribute('stop-opacity', '0.25');
+      grad.appendChild(stopMid);
+
+      const stopOuter = document.createElementNS('http://www.w3.org/2000/svg', 'stop');
+      stopOuter.setAttribute('offset', '100%');
+      stopOuter.setAttribute('stop-color', 'var(--map-player-color, hsl(185,70%,55%))');
+      stopOuter.setAttribute('stop-opacity', '0');
+      grad.appendChild(stopOuter);
+
+      defs.appendChild(grad);
+
+      // Create glow circle overlay — tight radius, pulsing via CSS
+      glow = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+      glow.id = 'trackPlayerGlow';
+      glow.setAttribute('r', '10');
+      glow.setAttribute('fill', 'url(#trackGlowGrad)');
+      glow.style.pointerEvents = 'none';
+      glow.style.mixBlendMode = 'screen';
+      glow.style.animation = 'map-glow-pulse 2s ease-in-out infinite';
+
+      // Insert before dots so it's behind them
+      const dotsGroup = svgEl.querySelector('.map-opponent') || svgEl.lastChild;
+      if (dotsGroup && dotsGroup.parentNode) {
+        dotsGroup.parentNode.insertBefore(glow, dotsGroup);
+      } else {
+        svgEl.appendChild(glow);
+      }
+    }
+
+    // Update glow position to follow player
+    glow.setAttribute('cx', px.toFixed(1));
+    glow.setAttribute('cy', py.toFixed(1));
+  }
+
+  // ═══ EXPOSE ALL FUNCTIONS TO WINDOW ═══
+
+
+// ── modules/js/pedal-curves.js ──
+// ═══════════════════════════════════════════════════════════════
+// PEDAL CURVE VISUALIZATION
+// Renders throttle/brake/clutch response curves from the active
+// pedal profile onto the full pedal histogram area.
+// Curve-following dots show current pedal position on each curve.
+// Data flows from C# PedalProfileManager via HTTP bridge
+// as K10Motorsports.Plugin.DS.PedalProfile (JSON object).
+// ═══════════════════════════════════════════════════════════════
+
+(function () {
+  'use strict';
+
+  var _curveCanvas = null;
+  var _curveCtx = null;
+  var _profileLabel = null;
+  var _lastProfileJson = '';
+  var _currentProfile = null;
+  var _hasProfile = false;
+
+  // Colors matching the existing pedal histogram
+  var THROTTLE_COLOR = '#4CAF50';
+  var BRAKE_COLOR    = '#F44336';
+  var CLUTCH_COLOR   = '#42A5F5';
+  var GRID_COLOR     = 'rgba(255, 255, 255, 0.06)';
+  var DIAG_COLOR     = 'rgba(255, 255, 255, 0.04)';
+
+  // ── Init ────────────────────────────────────────────────────
+  document.addEventListener('DOMContentLoaded', function () {
+    _curveCanvas = document.getElementById('pedalCurveCanvas');
+    _profileLabel = document.getElementById('pedalProfileLabel');
+    if (_curveCanvas) {
+      _curveCtx = _curveCanvas.getContext('2d');
+      _resizeCurveCanvas();
+    }
+  });
+
+  function _resizeCurveCanvas() {
+    if (!_curveCanvas || !_curveCtx) return;
+    var rect = _curveCanvas.getBoundingClientRect();
+    var w = Math.round(rect.width) || 240;
+    var h = Math.round(rect.height) || 80;
+    if (_curveCanvas.width !== w || _curveCanvas.height !== h) {
+      _curveCanvas.width = w;
+      _curveCanvas.height = h;
+    }
+  }
+
+  // ── Called each poll frame from poll-engine.js ────────────────
+  // p = full poll data object
+  window.updatePedalCurves = function (p) {
+    if (!_curveCtx) return;
+
+    var pre = p._demo ? 'K10Motorsports.Plugin.Demo.DS.' : 'K10Motorsports.Plugin.DS.';
+    var profileData = p[pre + 'PedalProfile'] || p['K10Motorsports.Plugin.DS.PedalProfile'];
+    if (!profileData || typeof profileData !== 'object') {
+      // No profile data — hide canvases
+      _setProfileVisibility(false);
+      return;
+    }
+
+    // Check if there are actual curves (not just an empty stub)
+    var hasCurves = (profileData.throttleCurve && profileData.throttleCurve.length >= 2)
+                 || (profileData.brakeCurve && profileData.brakeCurve.length >= 2);
+    if (!hasCurves) {
+      _setProfileVisibility(false);
+      return;
+    }
+
+    _setProfileVisibility(true);
+
+    // Only re-render static curves when the profile data changes
+    var json = JSON.stringify(profileData);
+    if (json === _lastProfileJson) return;
+    _lastProfileJson = json;
+    _currentProfile = profileData;
+
+    // Update label
+    if (_profileLabel) {
+      var name = profileData.profileName || '';
+      var source = profileData.source || '';
+      if (source === 'moza') name = '⚡ ' + name;
+      _profileLabel.textContent = name;
+      _profileLabel.title = profileData.carName || '';
+    }
+
+    _resizeCurveCanvas();
+    renderCurves();
+  };
+
+  function _setProfileVisibility(visible) {
+    if (visible === _hasProfile) return;
+    _hasProfile = visible;
+    var curveEl = document.getElementById('pedalCurveCanvas');
+    var traceEl = document.getElementById('pedalTraceCanvas');
+    if (curveEl) curveEl.classList.toggle('no-profile', !visible);
+    if (traceEl) traceEl.classList.toggle('no-profile', !visible);
+    if (!visible) {
+      _currentProfile = null;
+      _lastProfileJson = '';
+      if (_profileLabel) _profileLabel.textContent = '';
+    }
+  }
+
+  // ── Render static curves ────────────────────────────────────
+  function renderCurves() {
+    if (!_curveCtx || !_currentProfile) return;
+
+    var ctx = _curveCtx;
+    var w = _curveCanvas.width;
+    var h = _curveCanvas.height;
+    var pad = 2;
+    var plotW = w - pad * 2;
+    var plotH = h - pad * 2;
+
+    ctx.clearRect(0, 0, w, h);
+
+    // ── Background grid ──────────────────────────────────────
+    ctx.strokeStyle = GRID_COLOR;
+    ctx.lineWidth = 0.5;
+    for (var i = 1; i <= 3; i++) {
+      var gx = pad + (i / 4) * plotW;
+      var gy = pad + (1 - i / 4) * plotH;
+      ctx.beginPath();
+      ctx.moveTo(gx, pad); ctx.lineTo(gx, pad + plotH);
+      ctx.stroke();
+      ctx.beginPath();
+      ctx.moveTo(pad, gy); ctx.lineTo(pad + plotW, gy);
+      ctx.stroke();
+    }
+
+    // Diagonal reference (linear 1:1)
+    ctx.strokeStyle = DIAG_COLOR;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([3, 3]);
+    ctx.beginPath();
+    ctx.moveTo(pad, pad + plotH);
+    ctx.lineTo(pad + plotW, pad);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // ── Draw each curve ──────────────────────────────────────
+    // Throttle: left-to-right (matches throttle histogram direction)
+    // Brake: RIGHT-to-LEFT (matches brake histogram flex-direction: row-reverse)
+    // Clutch: left-to-right
+    var throttleCurve = _currentProfile.throttleCurve;
+    var brakeCurve = _currentProfile.brakeCurve;
+    var clutchCurve = _currentProfile.clutchCurve;
+
+    if (clutchCurve && clutchCurve.length >= 2) {
+      drawCurve(ctx, clutchCurve, CLUTCH_COLOR, 0.35, pad, plotW, plotH, false);
+    }
+    if (brakeCurve && brakeCurve.length >= 2) {
+      drawCurve(ctx, brakeCurve, BRAKE_COLOR, 0.7, pad, plotW, plotH, true);
+    }
+    if (throttleCurve && throttleCurve.length >= 2) {
+      drawCurve(ctx, throttleCurve, THROTTLE_COLOR, 0.85, pad, plotW, plotH, false);
+    }
+
+    // ── Deadzone indicators ──────────────────────────────────
+    var thrDz = _currentProfile.throttleDeadzone || 0;
+    var brkDz = _currentProfile.brakeDeadzone || 0;
+
+    if (thrDz > 0.01) {
+      var dzX = pad + thrDz * plotW;
+      ctx.strokeStyle = THROTTLE_COLOR;
+      ctx.globalAlpha = 0.3;
+      ctx.lineWidth = 1;
+      ctx.setLineDash([2, 2]);
+      ctx.beginPath();
+      ctx.moveTo(dzX, pad); ctx.lineTo(dzX, pad + plotH);
+      ctx.stroke();
+      ctx.setLineDash([]);
+      ctx.globalAlpha = 1;
+    }
+
+    if (brkDz > 0.01) {
+      // Brake deadzone: mirrored (from right edge inward)
+      var dzX2 = pad + plotW - brkDz * plotW;
+      ctx.strokeStyle = BRAKE_COLOR;
+      ctx.globalAlpha = 0.3;
+      ctx.lineWidth = 1;
+      ctx.setLineDash([2, 2]);
+      ctx.beginPath();
+      ctx.moveTo(dzX2, pad); ctx.lineTo(dzX2, pad + plotH);
+      ctx.stroke();
+      ctx.setLineDash([]);
+      ctx.globalAlpha = 1;
+    }
+  }
+
+  /**
+   * Draw a response curve.
+   * @param {boolean} mirror - If true, X axis is mirrored (right-to-left) to match brake histogram.
+   */
+  function drawCurve(ctx, points, color, alpha, pad, plotW, plotH, mirror) {
+    if (!points || points.length < 2) return;
+
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 1.5;
+    ctx.globalAlpha = alpha;
+    ctx.lineJoin = 'round';
+    ctx.lineCap = 'round';
+
+    ctx.beginPath();
+    for (var i = 0; i < points.length; i++) {
+      var rawX = points[i][0];
+      var px = mirror
+        ? pad + (1 - rawX) * plotW   // right-to-left for brake
+        : pad + rawX * plotW;         // left-to-right for throttle/clutch
+      var py = pad + (1 - points[i][1]) * plotH; // Y is inverted (0 at bottom)
+      if (i === 0) ctx.moveTo(px, py);
+      else ctx.lineTo(px, py);
+    }
+    ctx.stroke();
+    ctx.globalAlpha = 1;
+  }
+
+  // ── Curve-following dot positions ───────────────────────────
+  // Called from webgl-helpers _flushPedalFrame to place dots on curves
+  // thr/brk/clt = 0..1 (raw pedal input, not output)
+  window.getCurvePositions = function (thr, brk, clt) {
+    if (!_currentProfile || !_hasProfile || !_curveCanvas) return null;
+
+    var w = _curveCanvas.width;
+    var h = _curveCanvas.height;
+    var pad = 2;
+    var plotW = w - pad * 2;
+    var plotH = h - pad * 2;
+
+    var result = [];
+
+    // Throttle dot
+    var thrCurve = _currentProfile.throttleCurve;
+    if (thrCurve && thrCurve.length >= 2 && thr > 0.01) {
+      var out = interpolateCurve(thrCurve, thr);
+      result.push({
+        x: pad + thr * plotW,
+        y: pad + (1 - out) * plotH,
+        color: THROTTLE_COLOR,
+        rgb: [76, 175, 80],
+        val: thr
+      });
+    }
+
+    // Brake dot (mirrored X)
+    var brkCurve = _currentProfile.brakeCurve;
+    if (brkCurve && brkCurve.length >= 2 && brk > 0.01) {
+      var bOut = interpolateCurve(brkCurve, brk);
+      result.push({
+        x: pad + (1 - brk) * plotW,   // mirrored
+        y: pad + (1 - bOut) * plotH,
+        color: BRAKE_COLOR,
+        rgb: [244, 67, 54],
+        val: brk
+      });
+    }
+
+    // Clutch dot
+    var cltCurve = _currentProfile.clutchCurve;
+    if (cltCurve && cltCurve.length >= 2 && clt > 0.01) {
+      var cOut = interpolateCurve(cltCurve, clt);
+      result.push({
+        x: pad + clt * plotW,
+        y: pad + (1 - cOut) * plotH,
+        color: CLUTCH_COLOR,
+        rgb: [66, 165, 245],
+        val: clt
+      });
+    }
+
+    return result;
+  };
+
+  /**
+   * Interpolate a value along a curve's control points.
+   * points = [[x0,y0], [x1,y1], ...] sorted by x.
+   */
+  function interpolateCurve(points, input) {
+    if (input <= points[0][0]) return points[0][1];
+    if (input >= points[points.length - 1][0]) return points[points.length - 1][1];
+    for (var i = 1; i < points.length; i++) {
+      if (input <= points[i][0]) {
+        var t = (input - points[i-1][0]) / (points[i][0] - points[i-1][0]);
+        return points[i-1][1] + t * (points[i][1] - points[i-1][1]);
+      }
+    }
+    return points[points.length - 1][1];
+  }
+
+  // ── Expose for settings panel ────────────────────────────────
+  window.getCurrentPedalProfile = function () {
+    return _currentProfile;
+  };
+  window.hasPedalProfile = function () {
+    return _hasProfile;
+  };
+})();
+
+// ═══════════════════════════════════════════════════════════════
+// PEDAL SETTINGS PANEL — profile management + curve preview
+// ═══════════════════════════════════════════════════════════════
+
+var _pedalSettingsCanvas = null;
+var _pedalSettingsCtx = null;
+var _pedalProfilesLoaded = false;
+
+function _initPedalSettingsCanvas() {
+  if (_pedalSettingsCanvas) return;
+  _pedalSettingsCanvas = document.getElementById('pedalSettingsCurveCanvas');
+  if (!_pedalSettingsCanvas) return;
+  _pedalSettingsCtx = _pedalSettingsCanvas.getContext('2d');
+  var dpr = window.devicePixelRatio || 1;
+  var w = _pedalSettingsCanvas.offsetWidth || 200;
+  var h = _pedalSettingsCanvas.offsetHeight || 200;
+  _pedalSettingsCanvas.width = w * dpr;
+  _pedalSettingsCanvas.height = h * dpr;
+  _pedalSettingsCtx.scale(dpr, dpr);
+  _pedalSettingsCanvas.style.width = w + 'px';
+  _pedalSettingsCanvas.style.height = h + 'px';
+}
+
+function renderPedalSettingsCurve() {
+  _initPedalSettingsCanvas();
+  var profile = window.getCurrentPedalProfile ? window.getCurrentPedalProfile() : null;
+  if (!profile || !_pedalSettingsCtx) return;
+
+  var ctx = _pedalSettingsCtx;
+  var w = _pedalSettingsCanvas.offsetWidth || 200;
+  var h = _pedalSettingsCanvas.offsetHeight || 200;
+  var pad = 20;
+  var plotW = w - pad * 2;
+  var plotH = h - pad * 2;
+
+  ctx.clearRect(0, 0, w, h);
+
+  // Background
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.4)';
+  ctx.fillRect(0, 0, w, h);
+
+  // Grid
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.08)';
+  ctx.lineWidth = 0.5;
+  for (var i = 0; i <= 4; i++) {
+    var gx = pad + (i / 4) * plotW;
+    var gy = pad + (i / 4) * plotH;
+    ctx.beginPath(); ctx.moveTo(gx, pad); ctx.lineTo(gx, pad + plotH); ctx.stroke();
+    ctx.beginPath(); ctx.moveTo(pad, gy); ctx.lineTo(pad + plotW, gy); ctx.stroke();
+  }
+
+  // Axis labels
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.25)';
+  ctx.font = '9px sans-serif';
+  ctx.textAlign = 'center';
+  ctx.fillText('0%', pad, h - 4);
+  ctx.fillText('50%', pad + plotW / 2, h - 4);
+  ctx.fillText('100%', pad + plotW, h - 4);
+  ctx.textAlign = 'right';
+  ctx.fillText('0%', pad - 4, pad + plotH);
+  ctx.fillText('100%', pad - 4, pad + 3);
+
+  // Diagonal reference
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.06)';
+  ctx.lineWidth = 1;
+  ctx.setLineDash([4, 4]);
+  ctx.beginPath();
+  ctx.moveTo(pad, pad + plotH);
+  ctx.lineTo(pad + plotW, pad);
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  // Draw curves
+  function drawSettingsCurve(points, color) {
+    if (!points || points.length < 2) return;
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 2.5;
+    ctx.lineJoin = 'round';
+    ctx.beginPath();
+    for (var j = 0; j < points.length; j++) {
+      var px = pad + points[j][0] * plotW;
+      var py = pad + (1 - points[j][1]) * plotH;
+      if (j === 0) ctx.moveTo(px, py);
+      else ctx.lineTo(px, py);
+    }
+    ctx.stroke();
+  }
+
+  drawSettingsCurve(profile.clutchCurve, '#42A5F5');
+  drawSettingsCurve(profile.brakeCurve, '#F44336');
+  drawSettingsCurve(profile.throttleCurve, '#4CAF50');
+
+  // Deadzone markers
+  if (profile.throttleDeadzone > 0.01) {
+    var tdx = pad + profile.throttleDeadzone * plotW;
+    ctx.strokeStyle = 'rgba(76, 175, 80, 0.35)';
+    ctx.setLineDash([3, 3]);
+    ctx.beginPath(); ctx.moveTo(tdx, pad); ctx.lineTo(tdx, pad + plotH); ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.fillStyle = 'rgba(76, 175, 80, 0.4)';
+    ctx.fillRect(pad, pad, tdx - pad, plotH);
+  }
+  if (profile.brakeDeadzone > 0.01) {
+    var bdx = pad + profile.brakeDeadzone * plotW;
+    ctx.strokeStyle = 'rgba(244, 67, 54, 0.35)';
+    ctx.setLineDash([3, 3]);
+    ctx.beginPath(); ctx.moveTo(bdx, pad); ctx.lineTo(bdx, pad + plotH); ctx.stroke();
+    ctx.setLineDash([]);
+  }
+}
+
+function loadPedalProfiles() {
+  var url = (window._simhubUrlOverride || SIMHUB_URL) + '?action=listPedalProfiles';
+  fetch(url).then(function (r) { return r.json(); }).then(function (profiles) {
+    var sel = document.getElementById('settingsPedalProfile');
+    if (!sel) return;
+    sel.innerHTML = '';
+    if (!profiles || profiles.length === 0) {
+      var opt = document.createElement('option');
+      opt.value = '';
+      opt.textContent = 'No profiles available';
+      sel.appendChild(opt);
+      _pedalProfilesLoaded = true;
+      return;
+    }
+    profiles.forEach(function (p) {
+      var opt = document.createElement('option');
+      opt.value = p.id;
+      opt.textContent = p.name + (p.carName ? ' (' + p.carName + ')' : '');
+      if (p.isActive) opt.selected = true;
+      sel.appendChild(opt);
+    });
+    _pedalProfilesLoaded = true;
+  }).catch(function (e) {
+    // Plugin may not be running yet
+    var sel = document.getElementById('settingsPedalProfile');
+    if (sel) {
+      sel.innerHTML = '<option value="">Plugin not connected</option>';
+    }
+    _pedalProfilesLoaded = false;
+  });
+}
+
+function switchPedalProfile(profileId) {
+  if (!profileId) return;
+  var url = (window._simhubUrlOverride || SIMHUB_URL) + '?action=setPedalProfile&id=' + encodeURIComponent(profileId);
+  fetch(url).catch(function () {});
+}
+
+function bindPedalProfileToCar() {
+  var sel = document.getElementById('settingsPedalProfile');
+  if (!sel || !sel.value) return;
+  var url = (window._simhubUrlOverride || SIMHUB_URL) + '?action=bindPedalProfile&id=' + encodeURIComponent(sel.value);
+  fetch(url).then(function () {
+    var btn = document.getElementById('pedalBindCarBtn');
+    if (btn) { btn.textContent = 'Bound!'; setTimeout(function () { btn.textContent = 'Bind'; }, 2000); }
+  }).catch(function () {});
+}
+
+function importMozaPedals() {
+  var url = (window._simhubUrlOverride || SIMHUB_URL) + '?action=importMozaPedals';
+  fetch(url).then(function (r) { return r.json(); }).then(function (result) {
+    if (result.ok) {
+      loadPedalProfiles(); // refresh the dropdown
+      var btn = document.getElementById('mozaImportBtn');
+      if (btn) { btn.textContent = 'Imported!'; setTimeout(function () { btn.textContent = 'Import from Moza'; }, 3000); }
+    }
+  }).catch(function () {});
+}
+
+// Detect Moza status and update UI when the Pedals tab loads
+function updatePedalSettingsUI() {
+  var profile = window.getCurrentPedalProfile ? window.getCurrentPedalProfile() : null;
+  var statusLabel = document.getElementById('mozaStatusLabel');
+  var importBtn = document.getElementById('mozaImportBtn');
+
+  if (profile) {
+    if (profile.mozaDetected) {
+      if (statusLabel) statusLabel.textContent = 'Moza Pithouse detected';
+      if (importBtn) importBtn.disabled = false;
+    } else {
+      if (statusLabel) statusLabel.textContent = 'Moza not detected';
+      if (importBtn) importBtn.disabled = true;
+    }
+  } else {
+    if (statusLabel) statusLabel.textContent = 'No profile data from plugin';
+    if (importBtn) importBtn.disabled = true;
+  }
+
+  // Load profile list if not yet loaded
+  if (!_pedalProfilesLoaded) loadPedalProfiles();
+
+  // Render large curve preview
+  renderPedalSettingsCurve();
+
+  // Update debug panel
+  _updateMozaDebug(profile);
+}
+
+function _updateMozaDebug(profile) {
+  var el = function (id) { return document.getElementById(id); };
+
+  if (!profile) {
+    var ids = ['dbgMozaDetected', 'dbgProfileSource', 'dbgProfileName',
+               'dbgCarName', 'dbgThrottlePts', 'dbgBrakePts', 'dbgClutchPts',
+               'dbgThrottleDz', 'dbgBrakeDz'];
+    ids.forEach(function (id) { var e = el(id); if (e) e.textContent = '—'; });
+    var jsonEl = el('dbgRawJson');
+    if (jsonEl) jsonEl.textContent = 'No profile data';
+    return;
+  }
+
+  var set = function (id, val) { var e = el(id); if (e) e.textContent = val; };
+
+  set('dbgMozaDetected', profile.mozaDetected ? 'YES' : 'NO');
+  set('dbgProfileSource', profile.source || '(none)');
+  set('dbgProfileName', profile.profileName || '(unnamed)');
+  set('dbgCarName', profile.carName || '(none)');
+  set('dbgThrottlePts', profile.throttleCurve ? profile.throttleCurve.length + ' pts' : '—');
+  set('dbgBrakePts', profile.brakeCurve ? profile.brakeCurve.length + ' pts' : '—');
+  set('dbgClutchPts', profile.clutchCurve ? profile.clutchCurve.length + ' pts' : '—');
+  set('dbgThrottleDz', profile.throttleDeadzone != null ? (profile.throttleDeadzone * 100).toFixed(1) + '%' : '—');
+  set('dbgBrakeDz', profile.brakeDeadzone != null ? (profile.brakeDeadzone * 100).toFixed(1) + '%' : '—');
+
+  var jsonEl = el('dbgRawJson');
+  if (jsonEl) {
+    try {
+      jsonEl.textContent = JSON.stringify(profile, null, 1);
+    } catch (e) {
+      jsonEl.textContent = '(error)';
+    }
+  }
+}
+
+// Hook into tab switch to refresh pedal settings
+var _origSwitchSettingsTab = typeof switchSettingsTab === 'function' ? switchSettingsTab : null;
+document.addEventListener('DOMContentLoaded', function () {
+  // Override switchSettingsTab to detect when Pedals tab is shown
+  if (_origSwitchSettingsTab) {
+    var orig = switchSettingsTab;
+    window.switchSettingsTab = function (tab) {
+      orig(tab);
+      if (tab.dataset && tab.dataset.tab === 'pedals') updatePedalSettingsUI();
+    };
+  }
+});
+
+
+// ── modules/js/settings.js ──
+// Settings system
+  // _defaultSettings, _settings, _forceFlagState declared in config.js
+
+  // Section class/id → element finder
+  function _findSectionEls(sectionKey) {
+    // Try as ID first, then as class
+    let el = document.getElementById(sectionKey);
+    if (el) return [el];
+    return Array.from(document.querySelectorAll('.' + sectionKey));
+  }
+
+  function applySettings() {
+    const toggles = document.querySelectorAll('.settings-toggle[data-key]');
+    toggles.forEach(t => {
+      const key = t.dataset.key;
+      const on = _settings[key] !== false;
+      t.classList.toggle('on', on);
+
+      const els = _findSectionEls(t.dataset.section);
+      els.forEach(el => el.classList.toggle('section-hidden', !on));
+    });
+
+    // Parent column collapse: hide wrappers when all children hidden
+    _collapseParentColumns();
+
+    // SimHub URL
+    const urlInput = document.getElementById('settingsSimhubUrl');
+    if (urlInput) urlInput.value = _settings.simhubUrl || 'http://localhost:8889/k10mediabroadcaster/';
+    // Restore saved URL override so polling uses the persisted URL
+    if (_settings.simhubUrl && _settings.simhubUrl !== SIMHUB_URL) {
+      window._simhubUrlOverride = _settings.simhubUrl;
+    }
+
+    // Green screen toggle — reflect saved state
+    const gsToggle = document.getElementById('greenScreenToggle');
+    if (gsToggle) gsToggle.classList.toggle('on', _settings.greenScreen === true);
+    // Body class for CSS targeting
+    document.body.classList.toggle('green-screen-mode', _settings.greenScreen === true);
+
+    // WebGL effects toggle
+    const webglOn = _settings.showWebGL !== false;
+    document.querySelectorAll('.gl-overlay').forEach(c => {
+      c.style.display = webglOn ? '' : 'none';
+    });
+
+    // Ambient light mode — migrate legacy boolean to 3-way string
+    if (typeof _settings.showAmbientLight === 'boolean') {
+      _settings.ambientMode = _settings.showAmbientLight ? 'reflective' : 'off';
+      delete _settings.showAmbientLight;
+    }
+    const ambMode = _settings.ambientMode || 'reflective';
+    if (typeof applyAmbientMode === 'function') applyAmbientMode(ambMode);
+    const ambSel = document.getElementById('settingsAmbientMode');
+    if (ambSel) ambSel.value = ambMode;
+    // Restore saved capture region — only send to main process if ambient is ON
+    // (Sending the rect when ambient is off used to auto-start capture via IPC race condition)
+    if (ambMode !== 'off' && typeof window.restoreAmbientCapture === 'function') window.restoreAmbientCapture();
+
+    // Bonkers pit limiter toggle
+    document.body.classList.toggle('bonkers-off', _settings.showBonkers === false);
+
+    // Layout — all behavior is deterministic from position choice
+    applyLayout();
+
+    // Zoom
+    const zoomVal = _settings.zoom || 100;
+    const zoomSlider = document.getElementById('settingsZoom');
+    const zoomLabel = document.getElementById('zoomVal');
+    if (zoomSlider) zoomSlider.value = zoomVal;
+    if (zoomLabel) zoomLabel.textContent = zoomVal + '%';
+    applyZoom(zoomVal);
+
+    // Force flag
+    _forceFlagState = _settings.forceFlag || '';
+    const flagSelect = document.getElementById('settingsForceFlag');
+    if (flagSelect) flagSelect.value = _forceFlagState;
+
+    // Rally mode
+    _rallyModeEnabled = _settings.rallyMode || false;
+    _isRally = isRallyGame() || _rallyModeEnabled;
+
+    // Sync layout rally toggle (will be updated again when Discord state loads)
+    const layoutRallyToggle = document.getElementById('layoutRallyToggle');
+    if (layoutRallyToggle) layoutRallyToggle.classList.toggle('on', _rallyModeEnabled);
+
+    // Drive mode toggle sync
+    const dmToggle = document.getElementById('driveModeToggle');
+    if (dmToggle) dmToggle.classList.toggle('on', _settings.driveMode === true);
+    if (_settings.driveMode && typeof setDriveMode === 'function') setDriveMode(true);
+
+    // Leaderboard settings
+    const lbFocusSelect = document.getElementById('settingsLbFocus');
+    if (lbFocusSelect) lbFocusSelect.value = _settings.lbFocus || 'me';
+    const lbMaxSelect = document.getElementById('settingsLbMaxRows');
+    if (lbMaxSelect) lbMaxSelect.value = String(_settings.lbMaxRows || 5);
+    const lbExpandToggle = document.getElementById('lbExpandToggle');
+    if (lbExpandToggle) lbExpandToggle.classList.toggle('on', _settings.lbExpandToFill === true);
+
+    // Datastream field toggles
+    applyDsFieldToggles();
+
+    // Logo-only startup: apply body class so CSS hides everything except logos
+    if (_settings.logoOnlyStart !== false) {
+      document.body.classList.add('logo-only');
+    }
+  }
+
+  // Called by poll-engine when session goes active (game running + session state > 0).
+  // Removes logo-only mode with a reveal transition.
+  let _logoOnlyRevealed = false;
+  function revealFromLogoOnly() {
+    if (_logoOnlyRevealed) return;
+    _logoOnlyRevealed = true;
+    document.body.classList.add('logo-only-reveal');
+    document.body.classList.remove('logo-only');
+    // Clean up the reveal class after transition completes
+    setTimeout(() => document.body.classList.remove('logo-only-reveal'), 1200);
+  }
+
+  function _collapseParentColumns() {
+    // Fuel + Tyres share fuel-tyres-col
+    const ftCol = document.querySelector('.fuel-tyres-col');
+    if (ftCol) {
+      const fuelHidden = _settings.showFuel === false;
+      const tyresHidden = _settings.showTyres === false;
+      ftCol.classList.toggle('section-hidden', fuelHidden && tyresHidden);
+    }
+    // Controls + Pedals share controls-pedals-block
+    const cpBlock = document.querySelector('.controls-pedals-block');
+    if (cpBlock) {
+      const ctrlHidden = _settings.showControls === false;
+      const pedalsHidden = _settings.showPedals === false;
+      cpBlock.classList.toggle('section-hidden', ctrlHidden && pedalsHidden);
+    }
+    // Logo column: hide if both logos hidden
+    const logoCol = document.querySelector('.logo-col');
+    if (logoCol) {
+      const k10Hidden = _settings.showK10Logo === false;
+      const carHidden = _settings.showCarLogo === false;
+      logoCol.classList.toggle('section-hidden', k10Hidden && carHidden);
+    }
+  }
+
+  function switchSettingsTab(tab) {
+    const tabName = tab.dataset.tab;
+    // Update both sidebar items and legacy tab bar
+    document.querySelectorAll('.settings-sidebar-item').forEach(t => t.classList.toggle('active', t.dataset.tab === tabName));
+    document.querySelectorAll('.settings-tab').forEach(t => t.classList.toggle('active', t.dataset.tab === tabName));
+    document.querySelectorAll('.settings-tab-content').forEach(c => c.classList.toggle('active', c.id === 'settingsTab' + tabName.charAt(0).toUpperCase() + tabName.slice(1)));
+    // Refresh connection status when switching to Connections tab
+    if (tabName === 'connections') updateConnectionsTab();
+  }
+
+  // Subtab switching within a settings tab (e.g. Dashboard → Main HUD / Leaderboard / etc.)
+  function switchSectionSubtab(el) {
+    const subtab = el.dataset.subtab;
+    const container = el.closest('.settings-tab-content');
+    if (!container) return;
+    container.querySelectorAll('.settings-subtab').forEach(t => t.classList.toggle('active', t.dataset.subtab === subtab));
+    container.querySelectorAll('.settings-subtab-page').forEach(p => p.classList.toggle('active', p.dataset.subtabPage === subtab));
+  }
+
+  // ── Leaderboard settings ──
+
+  function updateLbFocus(value) {
+    _settings.lbFocus = value;
+    _lbLastJson = ''; // force re-render
+    saveSettings();
+  }
+
+  function updateLbMaxRows(value) {
+    _settings.lbMaxRows = Math.max(1, Math.min(40, +value || 5));
+    _lbLastJson = '';
+    saveSettings();
+  }
+
+  function toggleLbExpand(el) {
+    const isOn = el.classList.contains('on');
+    el.classList.toggle('on', !isOn);
+    _settings.lbExpandToFill = !isOn;
+    _lbLastJson = '';
+    saveSettings();
+  }
+
+  // ── Datastream field toggles ──
+
+  function toggleDsSetting(el) {
+    const key = el.dataset.key;
+    if (!key) return;
+    const isOn = el.classList.contains('on');
+    _settings[key] = !isOn;
+    el.classList.toggle('on', !isOn);
+    applyDsFieldToggles();
+    saveSettings();
+  }
+
+  function applyDsFieldToggles() {
+    document.querySelectorAll('[data-ds-field]').forEach(el => {
+      const key = el.dataset.dsField;
+      const show = _settings[key] !== false;
+      el.style.display = show ? '' : 'none';
+    });
+  }
+
+  // ── Draggable settings panel ──
+  (function initSettingsDrag() {
+    let _isDragging = false, _dragOffX = 0, _dragOffY = 0;
+    document.addEventListener('DOMContentLoaded', function() {
+      const bar = document.getElementById('settingsTitlebar');
+      const panel = document.getElementById('settingsPanel');
+      if (!bar || !panel) return;
+      bar.addEventListener('mousedown', function(e) {
+        if (e.target.tagName === 'INPUT' || e.target.tagName === 'SELECT') return;
+        _isDragging = true;
+        const rect = panel.getBoundingClientRect();
+        _dragOffX = e.clientX - rect.left;
+        _dragOffY = e.clientY - rect.top;
+        e.preventDefault();
+      });
+      document.addEventListener('mousemove', function(e) {
+        if (!_isDragging) return;
+        var rawLeft = e.clientX - _dragOffX;
+        var rawTop  = e.clientY - _dragOffY;
+        // Clamp aggressively: keep at least half the panel width and the
+        // full titlebar height visible on-screen at all times. The previous
+        // 40px margin was too loose — the panel could be dragged almost
+        // entirely off-screen in all directions.
+        var minVisible = Math.max(200, Math.round(panel.offsetWidth * 0.5));
+        var maxLeft = window.innerWidth  - minVisible;
+        var minLeft = -(panel.offsetWidth - minVisible);
+        var maxTop  = window.innerHeight - 60; // keep titlebar reachable
+        panel.style.position = 'fixed';
+        panel.style.left = Math.max(minLeft, Math.min(maxLeft, rawLeft)) + 'px';
+        panel.style.top  = Math.max(0, Math.min(maxTop, rawTop)) + 'px';
+        panel.style.margin = '0';
+      });
+      document.addEventListener('mouseup', function() { _isDragging = false; });
+    });
+  })();
+
+  // ── Commentary settings (migrated from SimHub plugin) ──
+  // These settings are sent to the plugin via the HTTP bridge.
+  function updateCommentarySetting(key, value) {
+    var url = (window._simhubUrlOverride || SIMHUB_URL) + '?action=setSetting&key=' + encodeURIComponent(key) + '&value=' + encodeURIComponent(value);
+    fetch(url).catch(function() {});
+  }
+  function toggleCommentarySetting(el, key) {
+    var isOn = el.classList.contains('on');
+    el.classList.toggle('on', !isOn);
+    updateCommentarySetting(key, !isOn ? '1' : '0');
+  }
+  function toggleCommentaryCategory(el, category) {
+    var isOn = el.classList.contains('on');
+    el.classList.toggle('on', !isOn);
+    updateCommentarySetting('category_' + category, !isOn ? '1' : '0');
+  }
+
+  // Load K10 logo into settings titlebar + populate version from package.json
+  document.addEventListener('DOMContentLoaded', function() {
+    var logoEl = document.getElementById('settingsTitlebarLogo');
+    if (logoEl) {
+      var img = document.createElement('img');
+      img.src = 'images/branding/logomark.png';
+      img.alt = 'K10';
+      logoEl.appendChild(img);
+    }
+    // Version label — read from Electron app.getVersion() (set by package.json)
+    if (window.k10 && window.k10.getVersion) {
+      window.k10.getVersion().then(function(ver) {
+        var el = document.getElementById('settingsVersionLabel');
+        if (el && ver) el.textContent = 'K10 Motorsports v' + ver + ' \u2014 Media Overlay';
+      });
+    }
+  });
+
+  // ── Popout settings to secondary display ──
+  function popoutSettings() {
+    if (window.k10 && window.k10.openSettingsPopout) {
+      window.k10.openSettingsPopout();
+      // Close the inline settings panel on the main overlay
+      var overlay = document.getElementById('settingsOverlay');
+      if (overlay && overlay.classList.contains('open')) {
+        toggleSettings();
+      }
+    }
+  }
+
+  // ── Popout window initialisation ──
+  // When this page loads with ?settingsPopout=1, switch into popout mode:
+  // hide all dashboard panels, auto-open settings, fill the window.
+  document.addEventListener('DOMContentLoaded', function() {
+    if (window.k10 && window.k10.isSettingsPopout && window.k10.isSettingsPopout()) {
+      document.body.classList.add('settings-popout');
+      // Force settings open (the overlay CSS rules handle the rest)
+      var overlay = document.getElementById('settingsOverlay');
+      if (overlay) overlay.classList.add('open');
+      document.body.classList.add('settings-active');
+    }
+  });
+
+  // ── Cross-window settings sync ──
+  // When the other window changes settings, apply them here.
+  if (window.k10 && window.k10.onSettingsSync) {
+    window.k10.onSettingsSync(function(newSettings) {
+      if (newSettings && typeof newSettings === 'object') {
+        Object.assign(_settings, newSettings);
+        applySettings();
+      }
+    });
+  }
+
+  // When the popout window is closed, re-enable the popout button
+  if (window.k10 && window.k10.onSettingsPopoutClosed) {
+    window.k10.onSettingsPopoutClosed(function() {
+      var btn = document.getElementById('settingsPopoutBtn');
+      if (btn) btn.disabled = false;
+    });
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+
+
+// ── modules/js/qr-code.js ──
+// ═══════════════════════════════════════════════════════════════
+// Minimal QR Code Generator — no dependencies, byte-mode only
+// Generates Version 3 (29x29) QR codes with ECC level M.
+// Draws directly to a <canvas> element.
+// ═══════════════════════════════════════════════════════════════
+
+(function() {
+  'use strict';
+
+  // GF(256) tables for Reed-Solomon ECC
+  var EXP = new Uint8Array(256), LOG = new Uint8Array(256);
+  (function() {
+    var x = 1;
+    for (var i = 0; i < 255; i++) { EXP[i] = x; LOG[x] = i; x = (x << 1) ^ (x >= 128 ? 0x11d : 0); }
+    EXP[255] = EXP[0];
+  })();
+
+  function gfMul(a, b) { return a === 0 || b === 0 ? 0 : EXP[(LOG[a] + LOG[b]) % 255]; }
+
+  function rsEncode(data, eccLen) {
+    // Generator polynomial for eccLen
+    var gen = [1];
+    for (var i = 0; i < eccLen; i++) {
+      var ng = new Array(gen.length + 1);
+      ng[0] = 0;
+      for (var j = 0; j < gen.length; j++) ng[j + 1] = gen[j];
+      for (var j = 0; j < gen.length; j++) {
+        var coeff = gfMul(gen[j], EXP[i]);
+        ng[j] ^= coeff;
+      }
+      gen = ng;
+    }
+    var msg = new Uint8Array(data.length + eccLen);
+    msg.set(data);
+    for (var i = 0; i < data.length; i++) {
+      var coeff = msg[i];
+      if (coeff !== 0) {
+        for (var j = 0; j < gen.length; j++) {
+          msg[i + j] ^= gfMul(gen[j], coeff);
+        }
+      }
+    }
+    return msg.slice(data.length);
+  }
+
+  // QR Version 3, ECC M: 44 data codewords, 26 ECC codewords (1 block)
+  var VERSION = 3, SIZE = 29, DATA_CW = 44, ECC_CW = 26;
+
+  function encodeData(text) {
+    var bytes = [];
+    for (var i = 0; i < text.length; i++) {
+      var c = text.charCodeAt(i);
+      if (c < 128) bytes.push(c);
+      else if (c < 2048) { bytes.push(0xc0 | (c >> 6)); bytes.push(0x80 | (c & 0x3f)); }
+      else { bytes.push(0xe0 | (c >> 12)); bytes.push(0x80 | ((c >> 6) & 0x3f)); bytes.push(0x80 | (c & 0x3f)); }
+    }
+    // Mode indicator (0100 = byte) + char count (8 bits for V1-9)
+    var bits = [];
+    function pushBits(val, len) { for (var i = len - 1; i >= 0; i--) bits.push((val >> i) & 1); }
+    pushBits(4, 4);           // byte mode
+    pushBits(bytes.length, 8); // character count
+    for (var i = 0; i < bytes.length; i++) pushBits(bytes[i], 8);
+    pushBits(0, 4);           // terminator (up to 4 bits)
+    // Pad to byte boundary
+    while (bits.length % 8 !== 0) bits.push(0);
+    // Pad to DATA_CW codewords
+    var codewords = new Uint8Array(DATA_CW);
+    for (var i = 0; i < bits.length / 8 && i < DATA_CW; i++) {
+      var b = 0;
+      for (var j = 0; j < 8; j++) b = (b << 1) | (bits[i * 8 + j] || 0);
+      codewords[i] = b;
+    }
+    var pad = [0xec, 0x11], pi = 0;
+    for (var i = Math.ceil(bits.length / 8); i < DATA_CW; i++) {
+      codewords[i] = pad[pi++ % 2];
+    }
+    return codewords;
+  }
+
+  function createMatrix() {
+    var m = [];
+    for (var i = 0; i < SIZE; i++) { m[i] = new Uint8Array(SIZE); }
+    return m;
+  }
+
+  function isReserved(r, c) {
+    // Finder patterns (7x7 + separators)
+    if (r < 9 && c < 9) return true;
+    if (r < 9 && c >= SIZE - 8) return true;
+    if (r >= SIZE - 8 && c < 9) return true;
+    // Timing patterns
+    if (r === 6 || c === 6) return true;
+    // Format info
+    if (r === 8 && (c < 9 || c >= SIZE - 8)) return true;
+    if (c === 8 && (r < 9 || r >= SIZE - 7)) return true;
+    return false;
+  }
+
+  function placeFinderPattern(m, r, c) {
+    for (var dr = -1; dr <= 7; dr++) {
+      for (var dc = -1; dc <= 7; dc++) {
+        var rr = r + dr, cc = c + dc;
+        if (rr < 0 || rr >= SIZE || cc < 0 || cc >= SIZE) continue;
+        if (dr >= 0 && dr <= 6 && dc >= 0 && dc <= 6) {
+          var ring = Math.max(Math.abs(dr - 3), Math.abs(dc - 3));
+          m[rr][cc] = (ring !== 1 && ring !== 4) ? 1 : 0;
+        } else {
+          m[rr][cc] = 0; // separator
+        }
+      }
+    }
+  }
+
+  function placeTiming(m) {
+    for (var i = 8; i < SIZE - 8; i++) {
+      m[6][i] = (i % 2 === 0) ? 1 : 0;
+      m[i][6] = (i % 2 === 0) ? 1 : 0;
+    }
+  }
+
+  function placeData(m, codewords) {
+    var bitIdx = 0;
+    var totalBits = codewords.length * 8;
+    var col = SIZE - 1;
+    var upward = true;
+
+    while (col > 0) {
+      if (col === 6) col--; // skip timing column
+      for (var row = 0; row < SIZE; row++) {
+        var r = upward ? SIZE - 1 - row : row;
+        for (var dc = 0; dc <= 1; dc++) {
+          var c = col - dc;
+          if (c < 0 || c >= SIZE) continue;
+          if (isReserved(r, c)) continue;
+          if (bitIdx < totalBits) {
+            var byteIdx = Math.floor(bitIdx / 8);
+            var bitPos = 7 - (bitIdx % 8);
+            m[r][c] = (codewords[byteIdx] >> bitPos) & 1;
+            bitIdx++;
+          }
+        }
+      }
+      col -= 2;
+      upward = !upward;
+    }
+  }
+
+  function applyMask(m, maskId) {
+    var maskFn;
+    switch (maskId) {
+      case 0: maskFn = function(r, c) { return (r + c) % 2 === 0; }; break;
+      case 1: maskFn = function(r, c) { return r % 2 === 0; }; break;
+      case 2: maskFn = function(r, c) { return c % 3 === 0; }; break;
+      case 3: maskFn = function(r, c) { return (r + c) % 3 === 0; }; break;
+      case 4: maskFn = function(r, c) { return (Math.floor(r / 2) + Math.floor(c / 3)) % 2 === 0; }; break;
+      case 5: maskFn = function(r, c) { return (r * c) % 2 + (r * c) % 3 === 0; }; break;
+      case 6: maskFn = function(r, c) { return ((r * c) % 2 + (r * c) % 3) % 2 === 0; }; break;
+      default: maskFn = function(r, c) { return ((r * c) % 3 + (r + c) % 2) % 2 === 0; }; break;
+    }
+    for (var r = 0; r < SIZE; r++) {
+      for (var c = 0; c < SIZE; c++) {
+        if (!isReserved(r, c) && maskFn(r, c)) {
+          m[r][c] ^= 1;
+        }
+      }
+    }
+  }
+
+  // Format info bits for ECC M + mask patterns (precomputed)
+  var FORMAT_BITS = [
+    0x5412, 0x5125, 0x5E7C, 0x5B4B, 0x45F9, 0x40CE, 0x4F97, 0x4AA0
+  ];
+
+  function placeFormatInfo(m, maskId) {
+    var bits = FORMAT_BITS[maskId];
+    // Around top-left finder
+    var positions1 = [[8,0],[8,1],[8,2],[8,3],[8,4],[8,5],[8,7],[8,8],[7,8],[5,8],[4,8],[3,8],[2,8],[1,8],[0,8]];
+    for (var i = 0; i < 15; i++) {
+      m[positions1[i][0]][positions1[i][1]] = (bits >> i) & 1;
+    }
+    // Around other finders
+    var positions2 = [[SIZE-1,8],[SIZE-2,8],[SIZE-3,8],[SIZE-4,8],[SIZE-5,8],[SIZE-6,8],[SIZE-7,8],[8,SIZE-8],[8,SIZE-7],[8,SIZE-6],[8,SIZE-5],[8,SIZE-4],[8,SIZE-3],[8,SIZE-2],[8,SIZE-1]];
+    for (var i = 0; i < 15; i++) {
+      m[positions2[i][0]][positions2[i][1]] = (bits >> i) & 1;
+    }
+    // Dark module
+    m[SIZE - 8][8] = 1;
+  }
+
+  function generateQR(text) {
+    if (text.length > 42) {
+      // V3 byte mode max is ~42 chars. For longer URLs, truncate with ellipsis
+      // Actually V3 M allows 44 data codewords = max 42 byte-mode chars
+      // For longer text, we'd need V4+. Keep it simple and truncate.
+    }
+    var data = encodeData(text);
+    var ecc = rsEncode(data, ECC_CW);
+    var allCW = new Uint8Array(DATA_CW + ECC_CW);
+    allCW.set(data);
+    allCW.set(ecc, DATA_CW);
+
+    var m = createMatrix();
+    placeFinderPattern(m, 0, 0);
+    placeFinderPattern(m, 0, SIZE - 7);
+    placeFinderPattern(m, SIZE - 7, 0);
+    placeTiming(m);
+    placeData(m, allCW);
+    applyMask(m, 0); // mask 0
+    placeFormatInfo(m, 0);
+    return m;
+  }
+
+  /**
+   * Render a QR code to a canvas element.
+   * @param {string} canvasId — ID of the <canvas> element
+   * @param {string} text — URL or text to encode
+   */
+  function renderQRCode(canvasId, text) {
+    var canvas = document.getElementById(canvasId);
+    if (!canvas) return;
+    var ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    var size = canvas.width;
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, size, size);
+
+    try {
+      var matrix = generateQR(text);
+      var cellSize = (size - 8) / SIZE; // 4px quiet zone each side
+      var offset = 4;
+
+      ctx.fillStyle = '#000000';
+      for (var r = 0; r < SIZE; r++) {
+        for (var c = 0; c < SIZE; c++) {
+          if (matrix[r][c]) {
+            ctx.fillRect(
+              Math.floor(offset + c * cellSize),
+              Math.floor(offset + r * cellSize),
+              Math.ceil(cellSize),
+              Math.ceil(cellSize)
+            );
+          }
+        }
+      }
+    } catch (e) {
+      // Fallback text
+      ctx.fillStyle = '#ffffff';
+      ctx.fillRect(0, 0, size, size);
+      ctx.fillStyle = '#333333';
+      ctx.font = 'bold 11px system-ui, sans-serif';
+      ctx.textAlign = 'center';
+      ctx.fillText('Open URL', size / 2, size / 2 - 6);
+      ctx.fillText('on iPad', size / 2, size / 2 + 10);
+    }
+  }
+
+  // Expose globally
+  window.renderQRCode = renderQRCode;
+})();
+
+
+// ── modules/js/connections.js ──
+// Connections tab
+
+  // ═══════════════════════════════════════════════════════════════
+  //  CONNECTIONS TAB — SimHub & Discord status
+  // ═══════════════════════════════════════════════════════════════
+
+  const DISCORD_GUILD_INVITE = 'https://discord.gg/k10mediabroadcaster';
+  // _discordUser declared in config.js
+  let _discordConnecting = false;
+
+  function updateConnectionsTab() {
+    updateSimhubConnectionCard();
+    updateDiscordConnectionCard();
+  }
+
+  // ── SimHub connection card ──
+  function updateSimhubConnectionCard() {
+    const dot = document.getElementById('connSimhubDot');
+    const text = document.getElementById('connSimhubText');
+    const urlEl = document.getElementById('connSimhubUrl');
+    const urlInput = document.getElementById('settingsSimhubUrl');
+    const currentUrl = window._simhubUrlOverride || SIMHUB_URL;
+
+    if (urlEl) urlEl.textContent = currentUrl;
+    if (urlInput) urlInput.value = currentUrl;
+
+    // Derive state from the existing connection status
+    const connEl = document.getElementById('connStatus');
+    const state = connEl ? (connEl.classList.contains('connected') ? 'connected' :
+                            connEl.classList.contains('disconnected') ? 'disconnected' : 'connecting') : 'connecting';
+
+    if (dot) {
+      dot.className = 'conn-dot ' + (state === 'connected' ? 'green' : state === 'disconnected' ? 'red' : 'orange');
+    }
+    if (text) {
+      if (state === 'connected') text.innerHTML = '<strong>Connected</strong> — receiving telemetry';
+      else if (state === 'disconnected') text.innerHTML = '<strong>Disconnected</strong> — check SimHub is running';
+      else text.innerHTML = 'Connecting...';
+    }
+  }
+
+  // ── Discord connection card ──
+  function updateDiscordConnectionCard() {
+    const notConn = document.getElementById('discordNotConnected');
+    const conn = document.getElementById('discordConnected');
+    if (!notConn || !conn) return;
+
+    if (_discordUser) {
+      notConn.style.display = 'none';
+      conn.style.display = '';
+      const nameEl = document.getElementById('discordDisplayName');
+      const idEl = document.getElementById('discordUserId');
+      const avatarEl = document.getElementById('discordAvatar');
+      if (nameEl) nameEl.textContent = _discordUser.globalName || _discordUser.username;
+      if (idEl) idEl.textContent = _discordUser.id;
+      if (avatarEl && _discordUser.avatar) {
+        avatarEl.src = `https://cdn.discordapp.com/avatars/${_discordUser.id}/${_discordUser.avatar}.png?size=64`;
+        avatarEl.alt = _discordUser.globalName || _discordUser.username;
+      }
+    } else {
+      notConn.style.display = '';
+      conn.style.display = 'none';
+    }
+
+    // Show game features card when Discord is connected
+    const gameCard = document.getElementById('gameFeatureCard');
+    if (gameCard) gameCard.style.display = _discordUser ? '' : 'none';
+
+    // Update layout section rally toggle
+    updateLayoutRallyToggle();
+    syncRallyToggles();
+
+    // Remote dashboard — visible when Discord connected
+    updateRemoteDashVisibility();
+
+    // iRacing tab — enabled when Discord connected
+    if (typeof updateIRacingTabState === 'function') updateIRacingTabState();
+  }
+
+  async function connectDiscord() {
+    if (_discordConnecting) return;
+    if (!window.k10 || !window.k10.discordConnect) {
+      // Fallback: open invite link directly in browser
+      openDiscordInvite();
+      return;
+    }
+
+    _discordConnecting = true;
+    const btn = document.getElementById('discordConnectBtn');
+    if (btn) { btn.disabled = true; btn.textContent = 'Connecting...'; }
+
+    try {
+      const result = await window.k10.discordConnect();
+      if (result && result.success && result.user) {
+        _discordUser = result.user;
+        _settings.discordUser = result.user;
+        saveSettings();
+        updateDiscordConnectionCard();
+      } else {
+        const errMsg = result?.error || 'Connection failed';
+        console.warn('[K10] Discord connect failed:', errMsg);
+        const text = document.getElementById('connDiscordText');
+        if (text) text.innerHTML = '<strong style="color:hsl(0,75%,60%)">Failed</strong> — ' + errMsg;
+        // Reset after 3s
+        setTimeout(() => {
+          if (text) text.innerHTML = 'Not connected';
+        }, 3000);
+      }
+    } catch (err) {
+      console.error('[K10] Discord connect error:', err);
+    } finally {
+      _discordConnecting = false;
+      if (btn) { btn.disabled = false; btn.innerHTML = '<svg viewBox="0 0 24 24" fill="currentColor" style="width:12px;height:12px;vertical-align:-1px;margin-right:4px"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.947 2.418-2.157 2.418z"/></svg> Connect Discord'; }
+    }
+  }
+
+  async function disconnectDiscord() {
+    if (window.k10 && window.k10.discordDisconnect) {
+      await window.k10.discordDisconnect();
+    }
+    _discordUser = null;
+    delete _settings.discordUser;
+    saveSettings();
+    updateDiscordConnectionCard();
+  }
+
+  function openDiscordInvite() {
+    if (window.k10 && window.k10.openExternal) {
+      window.k10.openExternal(DISCORD_GUILD_INVITE);
+    } else {
+      window.open(DISCORD_GUILD_INVITE, '_blank');
+    }
+  }
+
+  function toggleRallyMode(el) {
+    const isOn = el.classList.contains('on');
+    el.classList.toggle('on', !isOn);
+    _rallyModeEnabled = !isOn;
+    _settings.rallyMode = _rallyModeEnabled;
+    _isRally = isRallyGame() || _rallyModeEnabled;
+    applyGameMode();
+    saveSettings();
+    // Sync the layout section toggle
+    syncRallyToggles();
+  }
+
+  function toggleLayoutRally(el) {
+    // Ignore clicks when disabled (no Discord connection)
+    if (el.classList.contains('disabled')) return;
+    const isOn = el.classList.contains('on');
+    el.classList.toggle('on', !isOn);
+    _rallyModeEnabled = !isOn;
+    _settings.rallyMode = _rallyModeEnabled;
+    _isRally = isRallyGame() || _rallyModeEnabled;
+    applyGameMode();
+    saveSettings();
+    // Sync the connections tab toggle
+    syncRallyToggles();
+  }
+
+  /** Keep both rally toggles (layout + connections) in sync */
+  function syncRallyToggles() {
+    const layoutToggle = document.getElementById('layoutRallyToggle');
+    const connToggle = document.querySelector('.settings-toggle[data-key="rallyMode"]:not(#layoutRallyToggle)');
+    if (layoutToggle) layoutToggle.classList.toggle('on', _rallyModeEnabled);
+    if (connToggle) connToggle.classList.toggle('on', _rallyModeEnabled);
+  }
+
+  /** Enable/disable the layout rally toggle based on Discord state */
+  function updateLayoutRallyToggle() {
+    const el = document.getElementById('layoutRallyToggle');
+    const hint = document.getElementById('layoutRallyHint');
+    if (!el) return;
+    if (_discordUser) {
+      el.classList.remove('disabled');
+      if (hint) hint.style.display = 'none';
+    } else {
+      el.classList.add('disabled');
+      el.classList.remove('on');
+      if (hint) hint.style.display = '';
+      // Force rally off when Discord disconnects
+      _rallyModeEnabled = false;
+      _settings.rallyMode = false;
+      _isRally = isRallyGame();
+    }
+  }
+
+  // ── Remote Dashboard (LAN streaming via remote-server.js) ──
+
+  async function toggleRemoteDash(el) {
+    if (!window.k10) return;
+    const isOn = el.classList.contains('on');
+    const newVal = !isOn;
+    el.classList.toggle('on', newVal);
+
+    if (newVal) {
+      const result = await window.k10.startRemoteServer();
+      if (result && result.success) {
+        _showRemoteDashDocs(result);
+      } else {
+        el.classList.remove('on');
+        console.error('[K10] Remote server start failed:', result?.error);
+      }
+    } else {
+      await window.k10.stopRemoteServer();
+      document.getElementById('remoteDashDocs').style.display = 'none';
+    }
+  }
+
+  function _showRemoteDashDocs(info) {
+    const docs = document.getElementById('remoteDashDocs');
+    const urlEl = document.getElementById('remoteServerUrl');
+    if (!docs) return;
+    docs.style.display = '';
+    if (urlEl && info.url) urlEl.textContent = info.url;
+    if (info.url) _renderQR('remoteServerQR', info.url);
+  }
+
+  function updateRemoteDashVisibility() {
+    const section = document.getElementById('remoteDashSection');
+    if (!section) return;
+    if (window._k10RemoteMode) { section.style.display = 'none'; return; }
+    section.style.display = _discordUser ? '' : 'none';
+  }
+
+  async function initRemoteDashState() {
+    if (window._k10RemoteMode) return;
+    updateRemoteDashVisibility();
+    if (!window.k10 || !window.k10.getRemoteServerInfo) return;
+    try {
+      const info = await window.k10.getRemoteServerInfo();
+      if (info && info.running) {
+        const toggle = document.getElementById('remoteDashToggle');
+        if (toggle) toggle.classList.add('on');
+        _showRemoteDashDocs(info);
+      }
+    } catch (e) { /* ok */ }
+    updateRemoteDashVisibility();
+  }
+
+  // QR code rendering — uses the local qr-code.js module (no external API)
+  function _renderQR(canvasId, text) {
+    if (window.renderQRCode) window.renderQRCode(canvasId, text);
+  }
+
+  // Load Discord user on startup
+  async function initDiscordState() {
+    // Try loading from Electron's persisted file first
+    if (window.k10 && window.k10.getDiscordUser) {
+      try {
+        const user = await window.k10.getDiscordUser();
+        if (user && user.id) {
+          _discordUser = user;
+          updateDiscordConnectionCard();
+          return;
+        }
+      } catch (e) { /* ok */ }
+    }
+    // Fallback: check settings
+    if (_settings.discordUser && _settings.discordUser.id) {
+      _discordUser = _settings.discordUser;
+      updateDiscordConnectionCard();
+    }
+  }
+
+  function toggleSetting(el) {
+    const key = el.dataset.key;
+    const isOn = el.classList.contains('on');
+    _settings[key] = !isOn;
+    el.classList.toggle('on', !isOn);
+
+    const els = _findSectionEls(el.dataset.section);
+    els.forEach(e => e.classList.toggle('section-hidden', isOn));
+
+    _collapseParentColumns();
+
+    // Re-run layout so dynamically positioned panels (pitbox) reflow
+    applyLayout();
+
+    saveSettings();
+  }
+
+  function toggleWebGL(el) {
+    const isOn = el.classList.contains('on');
+    const newVal = !isOn;
+    el.classList.toggle('on', newVal);
+    _settings.showWebGL = newVal;
+    // Show/hide all WebGL overlay canvases
+    document.querySelectorAll('.gl-overlay').forEach(c => {
+      c.style.display = newVal ? '' : 'none';
+    });
+    saveSettings();
+  }
+
+  function updateAmbientMode(mode) {
+    _settings.ambientMode = mode;
+    // Migrate legacy boolean → new mode
+    delete _settings.showAmbientLight;
+    applyAmbientMode(mode);
+    saveSettings();
+  }
+
+  function applyAmbientMode(mode) {
+    const body = document.body;
+    body.classList.remove('ambient-off', 'ambient-matte', 'ambient-plastic');
+    if (mode === 'off') {
+      body.classList.add('ambient-off');
+      if (typeof window.stopAmbientLight === 'function') window.stopAmbientLight();
+    } else {
+      if (mode === 'matte') body.classList.add('ambient-matte');
+      if (mode === 'plastic') body.classList.add('ambient-plastic');
+      if (typeof window.startAmbientLight === 'function') window.startAmbientLight();
+    }
+    // Expose mode for WebGL shader: 0=off, 1=matte, 2=reflective
+    // Plastic uses CSS-only glow — tell WebGL ambient is OFF so it skips
+    // the expensive ambientGlow() + glassReflection() shader passes,
+    // freeing GPU time for g-force vignette, RPM redline, and panel glow.
+    window._ambientModeInt = (mode === 'off' || mode === 'plastic') ? 0
+                           : mode === 'matte' ? 1 : 2;
+  }
+
+  function toggleBonkers(el) {
+    const isOn = el.classList.contains('on');
+    const newVal = !isOn;
+    el.classList.toggle('on', newVal);
+    _settings.showBonkers = newVal;
+    document.body.classList.toggle('bonkers-off', !newVal);
+    saveSettings();
+  }
+
+  function updateSimhubUrl(url) {
+    _settings.simhubUrl = url;
+    // Update the polling constant (for standalone mode)
+    if (typeof SIMHUB_URL !== 'undefined') {
+      // Can't reassign const, but we can update the fetch function
+      window._simhubUrlOverride = url;
+    }
+    saveSettings();
+  }
+
+  // ─── Game Logo toggle ───
+  function toggleGameLogo(el) {
+    const isOn = el.classList.contains('on');
+    _settings.showGameLogo = !isOn;
+    el.classList.toggle('on', !isOn);
+    saveSettings();
+    // Immediately update the logo visibility
+    if (window.updateGameLogo) window.updateGameLogo(window._currentGameId || 'iracing', !isOn);
+  }
+
+  // ─── Green screen mode ───
+  async function toggleGreenScreen(el) {
+    const isOn = el.classList.contains('on');
+    const newValue = !isOn;
+    el.classList.toggle('on', newValue);
+    _settings.greenScreen = newValue;
+    document.getElementById('greenScreenHint').style.display = 'block';
+    await saveSettings();
+    // Electron's transparent property can't change at runtime — restart required
+    if (window.k10 && window.k10.restartApp) {
+      const hint = document.getElementById('greenScreenHint');
+      hint.textContent = newValue
+        ? 'Restarting into green-screen mode…'
+        : 'Restarting into transparent overlay mode…';
+      setTimeout(() => window.k10.restartApp(), 400);
+    }
+  }
+
+  // ─── Layout management ───
+
+  /* ── Layout Position Map ──
+     5 positions: 4 user-selectable corners + 1 programmatic (absolute-center).
+     All behavior is deterministic from the position:
+       Right → RTL flow        Left → LTR flow
+       Bottom → column-reverse + vswap (automatic)
+       Absolute-center → pre-race/podium, ~500px from top */
+  const _layoutPositionMap = {
+    'top-right': 'layout-tr', 'top-left': 'layout-tl',
+    'bottom-right': 'layout-br', 'bottom-left': 'layout-bl',
+    'absolute-center': 'layout-ac'
+  };
+  const _allLayoutClasses = Object.values(_layoutPositionMap);
+
+  function applyLayout() {
+    const dash = document.getElementById('dashboard');
+    const pos = _settings.layoutPosition || 'top-right';
+
+    // ── 1. Dashboard position ──
+    _allLayoutClasses.forEach(c => dash.classList.remove(c));
+    dash.classList.add(_layoutPositionMap[pos] || 'layout-tr');
+
+    // Derived properties — deterministic from corner choice
+    const isBottom = pos.includes('bottom');
+    const isRight  = pos.includes('right');
+    const isLeft   = pos.includes('left');
+    const isCenter = (pos === 'absolute-center');
+
+    // ── 2. Commentary: diagonally opposite corner ──
+    const cmtCol = document.getElementById('commentaryCol');
+    if (cmtCol) {
+      cmtCol.classList.remove('cmt-tl', 'cmt-tr', 'cmt-bl', 'cmt-br');
+      if (!isCenter) {
+        const cmtV = isBottom ? 't' : 'b';
+        const cmtH = isRight  ? 'l' : 'r';
+        cmtCol.classList.add('cmt-' + cmtV + cmtH);
+      } else {
+        // Absolute-center: commentary goes bottom-left
+        cmtCol.classList.add('cmt-bl');
+      }
+    }
+
+    // ── 3. Sync settings dropdown ──
+    const posSelect = document.getElementById('settingsPosition');
+    if (posSelect && posSelect.value !== pos) posSelect.value = pos;
+
+    // ── 4. Secondary panels (leaderboard, datastream, pitbox) ──
+    // Opposite vertical edge, same horizontal edge as main HUD.
+    // Two rows: main HUD + incidents on one edge, sec panels + commentary on the other.
+    const secVert  = isCenter ? 'bottom' : (isBottom ? 'top'    : 'bottom');
+    const secHoriz = isCenter ? 'right'  : (isRight  ? 'right'  : 'left');
+
+    const sec = document.getElementById('secContainer');
+    if (sec) {
+      sec.classList.remove('sec-top', 'sec-bottom', 'sec-left', 'sec-right');
+      sec.classList.add('sec-' + secVert);
+      sec.classList.add('sec-' + secHoriz);
+      sec.style.marginTop = '';
+      sec.style.marginBottom = '';
+    }
+
+    // Individual panel class bookkeeping (for CSS styling hooks)
+    const lb = document.getElementById('leaderboardPanel');
+    if (lb) {
+      lb.classList.remove('lb-top', 'lb-bottom', 'lb-left', 'lb-right');
+      lb.classList.add('lb-' + secVert, 'lb-' + secHoriz);
+    }
+    const ds = document.getElementById('datastreamPanel');
+    if (ds) {
+      ds.classList.remove('ds-top', 'ds-bottom', 'ds-left', 'ds-right');
+      ds.classList.add('ds-' + secVert, 'ds-' + secHoriz);
+    }
+    const pb = document.getElementById('pitBoxPanel');
+    if (pb) {
+      pb.classList.remove('pb-top', 'pb-bottom', 'pb-left', 'pb-right');
+      pb.classList.add('pb-' + secVert, 'pb-' + secHoriz);
+    }
+
+    // ── 5. Incidents: same vertical edge as sec-container, always opposite
+    //       horizontal edge from it (diagonal from main HUD) ──
+    const incVert  = secVert;
+    const incHoriz = secHoriz === 'right' ? 'left' : 'right';
+
+    const inc = document.getElementById('incidentsPanel');
+    if (inc) {
+      inc.classList.remove('inc-top', 'inc-bottom', 'inc-left', 'inc-right');
+      inc.classList.add('inc-' + incVert);
+      inc.classList.add('inc-' + incHoriz);
+      // Explicit inline resets — CEF/Electron can hold stale values after
+      // class removal; force every position property so nothing lingers.
+      inc.style.top    = incVert  === 'top'   ? '' : 'auto';
+      inc.style.bottom = incVert  === 'bottom'? '' : 'auto';
+      inc.style.left   = incHoriz === 'left'  ? '' : 'auto';
+      inc.style.right  = incHoriz === 'right' ? '' : 'auto';
+      inc.style.marginTop = '';
+      inc.style.marginBottom = '';
+      console.log('[layout] incidents → ' + incVert + '-' + incHoriz +
+        ' (sec=' + secVert + '-' + secHoriz + ', pos=' + pos + ')');
+    }
+
+    // ── 6. Spotter: co-located with race control at top center ──
+    // Positioning is handled entirely by CSS (top: 8px, left: 50%, transform).
+    // No layout-dependent positioning needed.
+  }
+
+  function updateLayoutPosition(value) {
+    _settings.layoutPosition = value;
+    applyLayout();
+    saveSettings();
+  }
+
+  // Layout helper functions removed — all behavior is now deterministic
+  // from the 4-corner position choice. No flow/vswap/oppose/offset toggles needed.
+
+  function previewZoom(val) {
+    // Live preview: apply zoom to all modules while dragging, but NOT the settings panel
+    val = Math.max(100, Math.min(200, +val));
+    document.getElementById('zoomVal').textContent = val + '%';
+    applyZoom(val, true);  // skipSettings = true
+  }
+  function updateZoom(val) {
+    val = Math.max(100, Math.min(200, +val));
+    _settings.zoom = val;
+    document.getElementById('zoomVal').textContent = val + '%';
+    applyZoom(val, false);  // apply to everything including settings
+    saveSettings();
+  }
+  function applyZoom(val, skipSettings) {
+    const scale = (val || 100) / 100;
+    document.documentElement.style.setProperty('--dash-zoom', scale);
+
+    // Scale --edge so zoomed fixed elements keep consistent visual margins.
+    // At zoom 1.65, a 10px edge in CSS gives only ~6px visual gap.
+    // Compensate: --edge-z = base-edge / zoom (so CSS 6px * 1.65 zoom = 10px visual).
+    const baseEdge = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--edge')) || 10;
+    document.documentElement.style.setProperty('--edge-z', (baseEdge / scale) + 'px');
+
+    // Zoomed fixed elements: dashboard, incidents, spotter, commentary, race control
+    document.getElementById('dashboard').style.zoom = scale;
+    const inc = document.getElementById('incidentsPanel');
+    if (inc) inc.style.zoom = scale;
+    const sp = document.getElementById('spotterPanel');
+    if (sp) sp.style.zoom = scale;
+    const cmtCol = document.getElementById('commentaryCol');
+    if (cmtCol) cmtCol.style.zoom = scale;
+    const rc = document.getElementById('rcBanner');
+    if (rc) rc.style.zoom = scale;
+
+    // Secondary container: zoom the container, not individual panels.
+    // Container is position:fixed — its --edge offset needs compensating too.
+    const sec = document.getElementById('secContainer');
+    if (sec) sec.style.zoom = scale;
+
+    // Scale the settings panel itself on release (not during drag)
+    if (!skipSettings) {
+      const settingsOverlay = document.getElementById('settingsOverlay');
+      if (settingsOverlay) settingsOverlay.style.zoom = scale;
+    }
+  }
+
+  function updateForceFlag(val) {
+    _forceFlagState = val;
+    _settings.forceFlag = val;
+    saveSettings();
+  }
+
+  function toggleSettings() {
+    const overlay = document.getElementById('settingsOverlay');
+    const isOpen = overlay.classList.contains('open');
+    if (isOpen) {
+      // Closing — also exit settings mode via Electron
+      overlay.classList.remove('open');
+      document.body.classList.remove('settings-active');
+      document.body.classList.remove('settings-drag');
+      if (window.k10?.releaseInteractive) window.k10.releaseInteractive();
+      // Stop ambient preview when settings close
+      if (typeof window.stopAmbientPreview === 'function') window.stopAmbientPreview();
+    } else {
+      // Opening — also enter settings mode
+      overlay.classList.add('open');
+      document.body.classList.add('settings-active');
+      if (window.k10?.requestInteractive) window.k10.requestInteractive();
+      // Start ambient preview when settings open
+      if (typeof window.startAmbientPreview === 'function') window.startAmbientPreview();
+    }
+  }
+
+  // ─── Persistence ───
+  async function loadSettings() {
+    let saved = null;
+    // Try Electron IPC first
+    if (window.k10 && window.k10.getSettings) {
+      saved = await window.k10.getSettings();
+    }
+    // Fallback to localStorage
+    if (!saved) {
+      try { saved = JSON.parse(localStorage.getItem('k10-broadcast-settings')); } catch(e) {}
+    }
+    if (saved) _settings = Object.assign({}, _defaultSettings, saved);
+    applySettings();
+  }
+
+  async function saveSettings() {
+    // Try Electron IPC first
+    if (window.k10 && window.k10.saveSettings) {
+      await window.k10.saveSettings(_settings);
+    }
+    // Broadcast to the other window (overlay ↔ popout) via main process relay
+    if (window.k10 && window.k10.notifySettingsChanged) {
+      window.k10.notifySettingsChanged(_settings);
+    }
+    // Also save to localStorage
+    try { localStorage.setItem('k10-broadcast-settings', JSON.stringify(_settings)); } catch(e) {}
+  }
+
+  // ─── Electron settings mode listener ───
+  // Ctrl+Shift+S directly opens/closes the settings modal.
+  // Closing the modal also exits settings mode.
+  if (window.k10 && window.k10.onSettingsMode) {
+    window.k10.onSettingsMode((active) => {
+      const overlay = document.getElementById('settingsOverlay');
+      if (active) {
+        // Open the settings modal
+        overlay.classList.add('open');
+        document.body.classList.add('settings-active');
+      } else {
+        // Close the settings modal
+        overlay.classList.remove('open');
+        document.body.classList.remove('settings-active');
+      }
+    });
+  }
+
+  // Load settings on startup
+  loadSettings();
+  initDiscordState();
+  initRemoteDashState();
+
+  // ═══════════════════════════════════════════════════════════════
+
+
+// ── modules/js/leaderboard.js ──
+// Leaderboard renderer
+
+  // ═══════════════════════════════════════════════════════════════
+  //  LEADERBOARD RENDERER
+  // ═══════════════════════════════════════════════════════════════
+
+  // Sparkline history: keyed by driver name, stores last N lap times
+  const _sparkHistory = {};
+  const SPARK_MAX = 12;
+  let _lbLastJson = '';
+
+  function updateLeaderboard(p) {
+    const lbPanel = document.getElementById('leaderboardPanel');
+    if (!lbPanel || lbPanel.classList.contains('section-hidden')) return;
+    // Leaderboard comes as raw JSON array from the plugin
+    let raw = p['K10Motorsports.Plugin.Leaderboard'];
+    // If plugin sends leaderboard as a JSON string, parse it
+    if (typeof raw === 'string') {
+      try { raw = JSON.parse(raw); } catch(e) { console.warn('[K10 LB] Failed to parse leaderboard string:', e); return; }
+    }
+    if (_pollFrame > 0 && _pollFrame <= 3) console.log('[K10 LB] raw type:', typeof raw, 'isArray:', Array.isArray(raw), 'length:', raw ? raw.length : 0, 'sample:', raw ? JSON.stringify(raw).slice(0, 200) : 'null');
+    if (!raw || !Array.isArray(raw) || raw.length === 0) return;
+
+    // Dedupe: skip render if data hasn't changed (+ settings version)
+    const expandToFill = _settings.lbExpandToFill === true; // Ensure boolean with default false
+    const settingsKey = (_settings.lbFocus || 'me') + '|' + (_settings.lbMaxRows || 5) + '|' + (expandToFill ? '1' : '0') + '|' + (window.innerHeight || 0);
+    const json = JSON.stringify(raw) + '|' + settingsKey;
+    if (json === _lbLastJson) return;
+    _lbLastJson = json;
+
+    const container = document.getElementById('lbRows');
+    if (!container) return;
+
+    // ── Focus + row limit logic ──
+    const focusMode = _settings.lbFocus || 'me';
+    let maxRows = _settings.lbMaxRows || 5;
+
+    // Expand to fill: calculate max rows that fit on screen
+    if (expandToFill) {
+      const lbPanel = document.getElementById('leaderboardPanel');
+      const sec = document.getElementById('secContainer');
+      const zoom = parseFloat(sec ? sec.style.zoom : 1) || 1;
+      const rowH = 22; // approximate row height in px (in panel coordinates)
+      // Measure available height from the sec-container position
+      // getBoundingClientRect() returns viewport pixels; divide by zoom to get panel-space pixels
+      const vpH = window.innerHeight || 600;
+      let availH;
+      if (sec && sec.offsetHeight > 0) {
+        const secRect = sec.getBoundingClientRect();
+        const isTop = sec.classList.contains('sec-top');
+        // Available height: from the container's edge toward the opposite viewport edge
+        availH = isTop ? (vpH - secRect.top) / zoom : secRect.bottom / zoom;
+        // Fallback if getBoundingClientRect returned 0 (not laid out yet)
+        if (availH <= 0) {
+          availH = vpH / zoom;
+        }
+      } else if (lbPanel && lbPanel.offsetHeight > 0) {
+        // Fallback: use lbPanel's own height if available
+        availH = lbPanel.offsetHeight / zoom;
+      } else {
+        // Last resort: use viewport height
+        availH = vpH / zoom;
+      }
+      // Reserve space for lb-header, timeline strip, padding, and a safety margin
+      const headerH = 36; // header + timeline + top/bottom padding
+      const marginH = 16; // breathing room at the edge
+      const calculatedMaxRows = Math.max(3, Math.min(raw.length, Math.floor((availH - headerH - marginH) / rowH)));
+      // Warn if calculated maxRows is suspiciously small when expand-to-fill is enabled
+      if (calculatedMaxRows < 6 && raw.length >= 6) {
+        if (_pollFrame > 0 && _pollFrame % 20 === 0) {
+          console.warn('[K10 LB] expand-to-fill calculated suspiciously small maxRows:', calculatedMaxRows, 'availH:', availH, 'lbPanel.offsetHeight:', lbPanel ? lbPanel.offsetHeight : 'N/A', 'sec.offsetHeight:', sec ? sec.offsetHeight : 'N/A');
+        }
+      }
+      maxRows = calculatedMaxRows;
+    }
+
+    // Entry format: [pos, name, irating, bestLap, lastLap, gapToPlayer, inPit, isPlayer]
+    // Find player index and session best
+    let playerIdx = -1;
+    let sessionBest = Infinity;
+    for (let i = 0; i < raw.length; i++) {
+      if (raw[i][7]) playerIdx = i;
+      const b = +raw[i][3];
+      if (b > 0 && b < sessionBest) sessionBest = b;
+    }
+    if (sessionBest === Infinity) sessionBest = 0;
+    // Expose session best for other modules (best lap coloring)
+    window._sessionBestLap = sessionBest;
+
+    // Slice visible entries based on focus mode
+    let visible;
+    if (focusMode === 'lead') {
+      // Show from P1, up to maxRows
+      visible = raw.slice(0, maxRows);
+    } else {
+      // Center on player
+      if (playerIdx < 0) {
+        visible = raw.slice(0, maxRows);
+      } else {
+        const half = Math.floor(maxRows / 2);
+        let start = Math.max(0, playerIdx - half);
+        let end = start + maxRows;
+        if (end > raw.length) { end = raw.length; start = Math.max(0, end - maxRows); }
+        visible = raw.slice(start, end);
+      }
+    }
+
+    let html = '';
+    for (const entry of visible) {
+      const [pos, name, ir, best, last, gap, pit, isPlayer] = entry;
+      const classes = ['lb-row'];
+      if (isPlayer) {
+        classes.push('lb-player');
+        if (pos === 1) classes.push('lb-p1');
+        else if (_startPosition > 0 && pos < _startPosition) classes.push('lb-ahead');
+        else if (_startPosition > 0 && pos > _startPosition) classes.push('lb-behind');
+        else classes.push('lb-same');
+      }
+      // Mark the starting position row when player has moved away from it
+      if (!isPlayer && _startPosition > 0 && pos === _startPosition && _lastPosition !== _startPosition) {
+        classes.push('lb-start-pos');
+      }
+      if (pit) classes.push('lb-pit');
+
+      // Gap display
+      let gapStr = '', gapClass = 'gap-player';
+      if (isPlayer) {
+        gapStr = '';
+      } else if (gap < 0) {
+        gapStr = '-' + Math.abs(gap).toFixed(1) + 's';
+        gapClass = 'gap-ahead';
+      } else if (gap > 0) {
+        gapStr = '+' + gap.toFixed(1) + 's';
+        gapClass = 'gap-behind';
+      } else {
+        gapStr = '';
+      }
+
+      // iRating shorthand
+      const irStr = ir > 0 ? (ir >= 1000 ? (ir / 1000).toFixed(1) + 'k' : '' + ir) : '';
+
+      // Update sparkline history (coerce to number, skip 0/NaN)
+      const lastNum = +last;
+      if (lastNum > 0) {
+        if (!_sparkHistory[name]) _sparkHistory[name] = [];
+        const h = _sparkHistory[name];
+        if (h.length === 0 || h[h.length - 1] !== lastNum) {
+          h.push(lastNum);
+          if (h.length > SPARK_MAX) h.shift();
+        }
+      }
+
+      // Build sparkline SVG inline (mini polyline)
+      let sparkSvg = '';
+      // Filter out any stale 0s that may have entered the history
+      const hist = _sparkHistory[name] ? _sparkHistory[name].filter(v => v > 0) : null;
+      // During rolling/formation starts, draw a flat baseline when no lap data exists
+      if ((!hist || hist.length < 2) && window._isRollingStart) {
+        const w = 44, h2 = 14;
+        const midY = (h2 / 2).toFixed(1);
+        const col = isPlayer ? 'hsla(210,75%,55%,0.5)' : 'hsla(0,0%,100%,0.15)';
+        sparkSvg = '<svg class="lb-spark" viewBox="0 0 ' + w + ' ' + h2 + '" preserveAspectRatio="none">'
+          + '<line x1="0" y1="' + midY + '" x2="' + w + '" y2="' + midY + '" stroke="' + col + '" stroke-width="1" stroke-dasharray="3,2"/>'
+          + '</svg>';
+      } else if (hist && hist.length >= 2) {
+        const mn = Math.min(...hist), mx = Math.max(...hist);
+        const range = mx - mn || 1;
+        const w = 44, h2 = 14;
+        let pts = '';
+        for (let i = 0; i < hist.length; i++) {
+          const x = (i / (hist.length - 1)) * w;
+          const y = ((hist[i] - mn) / range) * h2;
+          if (i === 0) {
+            pts += x.toFixed(1) + ',' + y.toFixed(1);
+          } else {
+            // Step: horizontal to new x at old y, then vertical to new y
+            const prevY = ((hist[i - 1] - mn) / range) * h2;
+            pts += ' ' + x.toFixed(1) + ',' + prevY.toFixed(1);
+            pts += ' ' + x.toFixed(1) + ',' + y.toFixed(1);
+          }
+        }
+        const lastY = ((hist[hist.length - 1] - mn) / range) * h2;
+        let col = 'hsla(0,0%,100%,0.3)';
+        if (isPlayer) {
+          if (pos === 1) col = 'hsla(42,80%,55%,1)';
+          else if (_startPosition > 0 && pos < _startPosition) col = 'hsla(145,75%,50%,1)';
+          else if (_startPosition > 0 && pos > _startPosition) col = 'hsla(0,75%,50%,1)';
+          else col = 'hsla(210,75%,55%,1)';
+        }
+        sparkSvg = '<svg class="lb-spark" viewBox="0 0 ' + w + ' ' + h2 + '" preserveAspectRatio="none"><polyline points="' + pts + '" fill="none" stroke="' + col + '" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="' + (w).toFixed(1) + '" cy="' + lastY.toFixed(1) + '" r="1.5" fill="' + col + '"/></svg>';
+      }
+
+      // Lap time display with color coding
+      // Purple: session best (one only), Green: driver personal best, Yellow: off-pace
+      let lapStr = '', lapClass = '';
+      if (last > 0) {
+        const m = Math.floor(last / 60), s = last - m * 60;
+        lapStr = m + ':' + (s < 10 ? '0' : '') + s.toFixed(1);
+        if (sessionBest > 0 && Math.abs(last - sessionBest) < 0.05) {
+          lapClass = 'lap-pb';                             // session best lap
+        } else if (best > 0 && Math.abs(last - best) < 0.05) {
+          lapClass = 'lap-fast';                           // driver personal best
+        } else {
+          lapClass = 'lap-slow';                           // off-pace
+        }
+      }
+
+      html += '<div class="' + classes.join(' ') + '">'
+        + '<div class="lb-pos">' + pos + '</div>'
+        + '<div class="lb-name">' + escHtml(isPlayer ? _driverDisplayName : name) + '</div>'
+        + '<div class="lb-lap ' + lapClass + '">' + lapStr + '</div>'
+        + '<div class="lb-ir">' + irStr + '</div>'
+        + '<div class="lb-gap ' + gapClass + '">' + gapStr + '</div>'
+        + sparkSvg
+        + '</div>';
+    }
+    container.innerHTML = html;
+    // Update WebGL highlight position after DOM update
+    requestAnimationFrame(function() {
+      if (window.updateLBPlayerPos) window.updateLBPlayerPos();
+    });
+  }
+
+  function escHtml(s) { return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'); }
+
+
+// ── modules/js/datastream.js ──
+// Datastream renderer
+
+  // ═══════════════════════════════════════════════════════════════
+  //  DATASTREAM RENDERER  (optimised)
+  // ═══════════════════════════════════════════════════════════════
+
+  const _dsCanvas = document.getElementById('dsGforceCanvas');
+  const _dsCtx = _dsCanvas ? _dsCanvas.getContext('2d') : null;
+  let _dsPeakG = 0;
+  const _dsTrailLen = 40;
+  const _dsTrailLat = new Float32Array(_dsTrailLen);
+  const _dsTrailLong = new Float32Array(_dsTrailLen);
+  let _dsTrailIdx = 0;
+  let _dsTrailCount = 0;
+  let _dsAbsFlash = 0;
+
+  // Yaw trail — ring buffer of recent yaw rate samples for waveform display
+  const _yawTrailLen = 80;
+  const _yawTrail = new Float32Array(_yawTrailLen);
+  let _yawTrailIdx = 0;
+  let _yawTrailCount = 0;
+  const _yawTrailCanvas = document.getElementById('dsYawTrail');
+  const _yawTrailCtx = _yawTrailCanvas ? _yawTrailCanvas.getContext('2d') : null;
+
+  // ── Cached DOM refs (avoid per-frame getElementById) ──
+  const _elLatG       = document.getElementById('dsLatG');
+  const _elLongG      = document.getElementById('dsLongG');
+  const _elPeakG      = document.getElementById('dsPeakG');
+  const _elYawRate    = document.getElementById('dsYawRate');
+  const _elYawFill    = document.getElementById('dsYawFill');
+  const _elSteerTorque = document.getElementById('dsSteerTorque');
+  const _elDelta      = document.getElementById('dsDelta');
+  const _elTrackTemp  = document.getElementById('dsTrackTemp');
+  const _elCtrlABS    = document.getElementById('ctrlABS');
+  const _elCtrlTC     = document.getElementById('ctrlTC');
+
+  // ── Cached gradients for yaw trail (reused when canvas size unchanged) ──
+  let _yawCacheW = 0, _yawCacheH = 0, _yawCacheHue = -1;
+  let _yawFillGrad = null, _yawStrokeGrad = null;
+
+  // ── DPR-aware G-force canvas init (set once, not every frame) ──
+  let _dsCanvasReady = false;
+  const _dsCssW = 64, _dsCssH = 64;
+
+  function _ensureGforceCanvas() {
+    if (_dsCanvasReady || !_dsCanvas) return;
+    const dpr = window.devicePixelRatio || 1;
+    _dsCanvas.width  = _dsCssW * dpr;
+    _dsCanvas.height = _dsCssH * dpr;
+    _dsCanvasReady = true;
+  }
+
+  function renderYawTrail(yawRate) {
+    // Store sample
+    _yawTrail[_yawTrailIdx] = yawRate;
+    _yawTrailIdx = (_yawTrailIdx + 1) % _yawTrailLen;
+    _yawTrailCount++;
+
+    if (!_yawTrailCtx) return;
+    const c = _yawTrailCanvas;
+    const w = c.width, h = c.height;
+    const ctx = _yawTrailCtx;
+    ctx.clearRect(0, 0, w, h);
+
+    const count = Math.min(_yawTrailCount, _yawTrailLen);
+    if (count < 2) return;
+
+    const maxYaw = 1.5; // max expected yaw rate
+    const mid = h / 2;
+    const absYaw = Math.abs(yawRate);
+    const hue = Math.max(0, 210 - absYaw * 120) | 0;
+
+    // Rebuild gradients only when canvas size or hue changes
+    const hueI = hue;
+    if (w !== _yawCacheW || h !== _yawCacheH || hueI !== _yawCacheHue) {
+      _yawCacheW = w; _yawCacheH = h; _yawCacheHue = hueI;
+      _yawFillGrad = ctx.createLinearGradient(0, 0, w, 0);
+      _yawFillGrad.addColorStop(0,   `hsla(${hue}, 60%, 50%, 0.02)`);
+      _yawFillGrad.addColorStop(0.7, `hsla(${hue}, 65%, 50%, 0.15)`);
+      _yawFillGrad.addColorStop(1,   `hsla(${hue}, 70%, 55%, 0.35)`);
+      _yawStrokeGrad = ctx.createLinearGradient(0, 0, w, 0);
+      _yawStrokeGrad.addColorStop(0,   `hsla(${hue}, 60%, 55%, 0.05)`);
+      _yawStrokeGrad.addColorStop(0.8, `hsla(${hue}, 70%, 55%, 0.3)`);
+      _yawStrokeGrad.addColorStop(1,   `hsla(${hue}, 75%, 60%, 0.6)`);
+    }
+
+    // Draw filled waveform — left=oldest, right=newest
+    ctx.beginPath();
+    ctx.moveTo(0, mid);
+    for (let i = 0; i < count; i++) {
+      const idx = (_yawTrailIdx - count + i + _yawTrailLen) % _yawTrailLen;
+      const x = (i / (count - 1)) * w;
+      const val = _yawTrail[idx];
+      const y = mid - (val / maxYaw) * (mid - 2);
+      ctx.lineTo(x, y);
+    }
+    // Close to baseline on right, sweep back along baseline
+    ctx.lineTo(w, mid);
+    ctx.closePath();
+    ctx.fillStyle = _yawFillGrad;
+    ctx.fill();
+
+    // Stroke the waveform line
+    ctx.beginPath();
+    for (let i = 0; i < count; i++) {
+      const idx = (_yawTrailIdx - count + i + _yawTrailLen) % _yawTrailLen;
+      const x = (i / (count - 1)) * w;
+      const val = _yawTrail[idx];
+      const y = mid - (val / maxYaw) * (mid - 2);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.strokeStyle = _yawStrokeGrad;
+    ctx.lineWidth = 1.2;
+    ctx.stroke();
+
+    // Center line (zero yaw reference)
+    ctx.beginPath();
+    ctx.moveTo(0, mid);
+    ctx.lineTo(w, mid);
+    ctx.strokeStyle = 'hsla(0, 0%, 100%, 0.06)';
+    ctx.lineWidth = 0.5;
+    ctx.stroke();
+  }
+  let _dsTcFlash = 0;
+  let _dsPrevTrackTemp = 0;
+  let _dsPrevIncidents = -1;
+  let _dsPrevDeltaSign = 0;  // -1, 0, 1
+
+  // ── Flash via Web Animations API (no forced reflow) ──
+  function dsFlash(el) {
+    if (!el || !el.animate) return;
+    el.animate([
+      { opacity: 1, filter: 'brightness(2)' },
+      { opacity: 1, filter: 'brightness(1)' }
+    ], { duration: 300, easing: 'ease-out' });
+  }
+
+  function drawGforceDiamond(latG, longG) {
+    if (!_dsCtx) return;
+    _ensureGforceCanvas();
+    const c = _dsCanvas;
+    const dpr = window.devicePixelRatio || 1;
+    const ctx = _dsCtx;
+    // Clear without resetting canvas dimensions (preserves state)
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, _dsCssW, _dsCssH);
+
+    const cx = _dsCssW / 2, cy = _dsCssH / 2;
+    const maxG = 3.0;  // full scale
+    const r = 28;       // diamond radius in px
+
+    // Diamond outline (rotated square)
+    ctx.strokeStyle = 'hsla(0,0%,100%,0.08)';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(cx, cy - r);
+    ctx.lineTo(cx + r, cy);
+    ctx.lineTo(cx, cy + r);
+    ctx.lineTo(cx - r, cy);
+    ctx.closePath();
+    ctx.stroke();
+
+    // Inner grid lines (crosshair)
+    ctx.strokeStyle = 'hsla(0,0%,100%,0.04)';
+    ctx.beginPath();
+    ctx.moveTo(cx - r, cy); ctx.lineTo(cx + r, cy);
+    ctx.moveTo(cx, cy - r); ctx.lineTo(cx, cy + r);
+    ctx.stroke();
+
+    // Half-diamond
+    ctx.strokeStyle = 'hsla(0,0%,100%,0.03)';
+    ctx.beginPath();
+    ctx.moveTo(cx, cy - r/2);
+    ctx.lineTo(cx + r/2, cy);
+    ctx.lineTo(cx, cy + r/2);
+    ctx.lineTo(cx - r/2, cy);
+    ctx.closePath();
+    ctx.stroke();
+
+    // G-force trail
+    if (_dsTrailCount > 1) {
+      ctx.beginPath();
+      ctx.strokeStyle = 'hsla(210,60%,55%,0.15)';
+      ctx.lineWidth = 1;
+      for (let i = 0; i < Math.min(_dsTrailCount, _dsTrailLen); i++) {
+        const idx = (_dsTrailIdx - 1 - i + _dsTrailLen) % _dsTrailLen;
+        const px = cx + (_dsTrailLat[idx] / maxG) * r;
+        const py = cy - (_dsTrailLong[idx] / maxG) * r;
+        if (i === 0) ctx.moveTo(px, py);
+        else ctx.lineTo(px, py);
+      }
+      ctx.stroke();
+    }
+
+    // Store trail
+    _dsTrailLat[_dsTrailIdx] = latG;
+    _dsTrailLong[_dsTrailIdx] = longG;
+    _dsTrailIdx = (_dsTrailIdx + 1) % _dsTrailLen;
+    _dsTrailCount++;
+
+    // Current G dot
+    let dotX = cx + (latG / maxG) * r;
+    let dotY = cy - (longG / maxG) * r;
+    const totalG = Math.sqrt(latG * latG + longG * longG);
+
+    // Check if dot is within diamond boundary
+    // Diamond boundary: |dotX - cx|/r + |dotY - cy|/r <= 1
+    const dx = Math.abs(dotX - cx);
+    const dy = Math.abs(dotY - cy);
+    const distanceFactor = dx / r + dy / r;
+    let isClamped = false;
+    let clampRatio = 0;
+
+    if (distanceFactor > 1) {
+      isClamped = true;
+      clampRatio = Math.min((distanceFactor - 1) / (distanceFactor - 1), 1);
+
+      // Project to nearest point on diamond edge
+      const signX = dotX >= cx ? 1 : -1;
+      const signY = dotY >= cy ? 1 : -1;
+      dotX = cx + signX * (r * Math.abs(dotX - cx)) / (dx + dy);
+      dotY = cy - signY * (r * Math.abs(dotY - cy)) / (dx + dy);
+
+      const newDx = Math.abs(dotX - cx);
+      const newDy = Math.abs(dotY - cy);
+      const scale = 1 / ((newDx + newDy) / r);
+      if (scale < 1) {
+        dotX = cx + (dotX - cx) * scale;
+        dotY = cy + (dotY - cy) * scale;
+      }
+    }
+
+    // Dot color: blue at low G, shifts toward red/orange at high G
+    const hue = Math.max(0, 210 - totalG * 50);
+    let lum = 55 + totalG * 5;
+    if (isClamped) lum = Math.min(lum + 20, 95);
+
+    ctx.fillStyle = `hsl(${hue},70%,${lum}%)`;
+    ctx.beginPath();
+    let dotRadius = 2.5;
+    if (isClamped) dotRadius = 2.5 + (5.0 - 2.5) * clampRatio;
+    ctx.arc(dotX, dotY, dotRadius, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Glow
+    ctx.fillStyle = `hsla(${hue},70%,${lum}%,0.25)`;
+    ctx.beginPath();
+    ctx.arc(dotX, dotY, 5, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  // ── Visibility gate: skip rendering when datastream panel is hidden ──
+  const _dsPanel = document.getElementById('datastreamArea') || ((_dsCanvas) ? _dsCanvas.closest('.panel') : null);
+
+  function updateDatastream(p, isDemo) {
+    // Skip entirely if panel is not visible
+    if (_dsPanel && _dsPanel.offsetParent === null) return;
+
+    const pre = isDemo ? 'K10Motorsports.Plugin.Demo.DS.' : 'K10Motorsports.Plugin.DS.';
+    const vd = (key) => +p[pre + key] || 0;
+
+    const latG = vd('LatG');
+    const longG = vd('LongG');
+    const yawRate = vd('YawRate');
+    const steerTorque = vd('SteerTorque');
+    const trackTemp = vd('TrackTemp');
+    const incidentCount = vd('IncidentCount');
+    const absActive = vd('AbsActive') > 0;
+    const tcActive = vd('TcActive') > 0;
+    const lapDelta = vd('LapDelta');
+
+    // Expose G-force values for map trail animation
+    window._ambientLatG = latG;
+    window._ambientLongG = longG;
+
+    // G-force diamond
+    drawGforceDiamond(latG, longG);
+
+    // Lat/Long G values
+    if (_elLatG) _elLatG.textContent = Math.abs(latG).toFixed(2) + 'g';
+    if (_elLongG) _elLongG.textContent = Math.abs(longG).toFixed(2) + 'g';
+
+    // Peak G tracking
+    const totalG = Math.sqrt(latG * latG + longG * longG);
+    const wasNewPeak = totalG > _dsPeakG && _dsPeakG > 0;
+    if (totalG > _dsPeakG) _dsPeakG = totalG;
+    if (_elPeakG) { _elPeakG.textContent = _dsPeakG.toFixed(2) + 'g'; if (wasNewPeak) dsFlash(_elPeakG); }
+
+    // Yaw rate
+    if (_elYawRate) _elYawRate.textContent = Math.abs(yawRate).toFixed(2) + ' r/s';
+
+    // Yaw bar (centered, extends left for negative, right for positive)
+    if (_elYawFill) {
+      const maxYaw = 1.5;
+      const pct = Math.min(Math.abs(yawRate) / maxYaw, 1.0) * 50;
+      const yawHue = Math.max(0, 210 - Math.abs(yawRate) * 120);
+      if (yawRate >= 0) {
+        _elYawFill.style.cssText = `left:50%;width:${pct}%;background:hsla(${yawHue},70%,55%,0.7)`;
+      } else {
+        _elYawFill.style.cssText = `left:${50 - pct}%;width:${pct}%;background:hsla(${yawHue},70%,55%,0.7)`;
+      }
+    }
+
+    // Yaw trail waveform
+    renderYawTrail(yawRate);
+
+    // Steering torque
+    if (_elSteerTorque) _elSteerTorque.textContent = steerTorque.toFixed(1) + ' Nm';
+
+    // Lap delta
+    if (_elDelta) {
+      const sign = lapDelta >= 0 ? '+' : '';
+      _elDelta.textContent = sign + lapDelta.toFixed(3);
+      _elDelta.classList.remove('ds-positive', 'ds-negative', 'ds-neutral');
+      if (lapDelta > 0.05) _elDelta.classList.add('ds-positive');
+      else if (lapDelta < -0.05) _elDelta.classList.add('ds-negative');
+      else _elDelta.classList.add('ds-neutral');
+      // Flash on sign change
+      const curSign = lapDelta > 0.05 ? 1 : lapDelta < -0.05 ? -1 : 0;
+      if (_dsPrevDeltaSign !== 0 && curSign !== 0 && curSign !== _dsPrevDeltaSign) dsFlash(_elDelta);
+      if (curSign !== 0) _dsPrevDeltaSign = curSign;
+    }
+
+    // Track temp
+    if (_elTrackTemp) {
+      _elTrackTemp.textContent = trackTemp > 0 ? trackTemp.toFixed(1) + '°C' : '—°C';
+      if (_dsPrevTrackTemp > 0 && Math.abs(trackTemp - _dsPrevTrackTemp) > 0.3) dsFlash(_elTrackTemp);
+      _dsPrevTrackTemp = trackTemp;
+    }
+
+    // ABS/TC activity → glow on adjustments module bars
+    if (absActive) _dsAbsFlash = 8;
+    if (tcActive) _dsTcFlash = 8;
+    if (_elCtrlABS) {
+      _elCtrlABS.classList.toggle('ctrl-active', _dsAbsFlash > 0);
+      if (_dsAbsFlash > 0) _dsAbsFlash--;
+    }
+    if (_elCtrlTC) {
+      _elCtrlTC.classList.toggle('ctrl-active', _dsTcFlash > 0);
+      if (_dsTcFlash > 0) _dsTcFlash--;
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+
+
+// ── modules/js/pitbox.js ──
+// ═══════════════════════════════════════════════════════════════
+//  PIT BOX — Tabbed driver panel: tyres, fuel, weather,
+//  in-car adjustments, camera/FFB.
+//  All data read-only from telemetry. Respects iRacing DisplayUnits.
+// ═══════════════════════════════════════════════════════════════
+
+(function initPitBox() {
+  'use strict';
+
+  // ── DOM cache (populated on first update) ──
+  let _els = null;
+  let _lastIsIRacing = null;
+
+  // ── Previous values for change detection ──
+  const _prev = {};
+  let _initialized = false;
+
+  // ── Wheel button input counters ──
+  // The plugin increments these each time the corresponding SimHub action fires.
+  // We detect changes per-frame and dispatch the appropriate UI action.
+  let _lastTabCycle = -1;
+  let _lastTabCycleBack = -1;
+  let _lastNext = -1;
+  let _lastPrev = -1;
+  let _lastIncrement = -1;
+  let _lastDecrement = -1;
+  let _lastToggle = -1;
+  var _tabOrder = ['tyres', 'fuel', 'weather', 'adj', 'camera'];
+  var _pbHidden = false;  // "off" state — pitbox dismissed via tab cycling past the edges
+
+  function cacheElements() {
+    var $ = function(id) { return document.getElementById(id); };
+    _els = {
+      panel:       $('pitBoxPanel'),
+      noData:      $('pbNoData'),
+      content:     $('pbContent'),
+      // Tyres tab — pit selections
+      tireLF:      $('pbTireLF'),   tireRF:      $('pbTireRF'),
+      tireLR:      $('pbTireLR'),   tireRR:      $('pbTireRR'),
+      pressLF:     $('pbPressLF'),  pressRF:     $('pbPressRF'),
+      pressLR:     $('pbPressLR'),  pressRR:     $('pbPressRR'),
+      // Tyres tab — wear bars
+      wearLF:      $('pbWearLF'),   wearLFVal:   $('pbWearLFVal'),
+      wearRF:      $('pbWearRF'),   wearRFVal:   $('pbWearRFVal'),
+      wearLR:      $('pbWearLR'),   wearLRVal:   $('pbWearLRVal'),
+      wearRR:      $('pbWearRR'),   wearRRVal:   $('pbWearRRVal'),
+      // Tyres tab — temps
+      tempLF:      $('pbTempLF'),   tempRF:      $('pbTempRF'),
+      tempLR:      $('pbTempLR'),   tempRR:      $('pbTempRR'),
+      // Fuel tab
+      fuelBar:     $('pbFuelBar'),
+      fuelLevel:   $('pbFuelLevel'),
+      fuelUnit:    $('pbFuelUnit'),
+      fuelPerLap:  $('pbFuelPerLap'),
+      fuelLaps:    $('pbFuelLaps'),
+      fuelVal:     $('pbFuelVal'),
+      fastRepair:  $('pbFastRepair'),
+      windshield:  $('pbWindshield'),
+      // Weather tab
+      weatherIcon: $('pbWeatherIcon'),
+      airTemp:     $('pbAirTemp'),
+      trackTemp:   $('pbTrackTemp'),
+      conditions:  $('pbConditions'),
+      // Adjustments tab
+      adjBB:    $('pbAdjBB'),    adjTC:    $('pbAdjTC'),
+      adjABS:   $('pbAdjABS'),   adjARBF:  $('pbAdjARBF'),
+      adjARBR:  $('pbAdjARBR'),  adjEng:   $('pbAdjEng'),
+      adjFuel:  $('pbAdjFuel'),  adjWJL:   $('pbAdjWJL'),
+      adjWJR:   $('pbAdjWJR'),   adjWingF: $('pbAdjWingF'),
+      adjWingR: $('pbAdjWingR'),
+      rowTC:    $('pbRowTC'),    rowABS:   $('pbRowABS'),
+      rowARBF:  $('pbRowARBF'),  rowARBR:  $('pbRowARBR'),
+      rowEng:   $('pbRowEng'),   rowFuel:  $('pbRowFuel'),
+      rowWJL:   $('pbRowWJL'),   rowWJR:   $('pbRowWJR'),
+      rowWingF: $('pbRowWingF'), rowWingR: $('pbRowWingR'),
+      // Camera tab
+      ffbMax:   $('pbFFBMax'),
+      mirror:   $('pbMirror'),
+    };
+  }
+
+  // ── Tab switching ──
+  window.switchPbTab = function(el) {
+    var tab = el.dataset.pbTab;
+    if (!tab) return;
+    // Deactivate all tabs and pages
+    var tabs = document.querySelectorAll('.pb-tab');
+    var pages = document.querySelectorAll('.pb-page');
+    for (var i = 0; i < tabs.length; i++) tabs[i].classList.remove('active');
+    for (var i = 0; i < pages.length; i++) pages[i].classList.remove('active');
+    // Activate selected
+    el.classList.add('active');
+    var page = document.querySelector('[data-pb-page="' + tab + '"]');
+    if (page) page.classList.add('active');
+  };
+
+  // ── Flash animation ──
+  function flash(el) {
+    if (!el || !_initialized) return;
+    el.classList.remove('pb-flash');
+    void el.offsetWidth;
+    el.classList.add('pb-flash');
+    setTimeout(function() { el.classList.remove('pb-flash'); }, 1400);
+  }
+
+  function checkAndFlash(key, newVal, el) {
+    if (_prev[key] !== undefined && _prev[key] !== newVal) flash(el);
+    _prev[key] = newVal;
+  }
+
+  function setRowVisible(rowEl, visible) {
+    if (!rowEl) return;
+    rowEl.classList.toggle('hidden', !visible);
+  }
+
+  // ── Wear bar helpers ──
+  // Parse tyre wear with null-awareness and raw telemetry fallback.
+  // Returns null when no data available, otherwise 0-1 (1=new, 0=worn).
+  function _parseTyreWear(gameDataVal, rawL, rawM, rawR) {
+    // Try GameData value first
+    if (gameDataVal != null && gameDataVal !== '') {
+      var v = parseFloat(gameDataVal);
+      if (!isNaN(v)) return v;
+    }
+    // Fallback: raw telemetry wear points (average of inner/mid/outer)
+    var l = parseFloat(rawL), m = parseFloat(rawM), r = parseFloat(rawR);
+    if (!isNaN(l) && !isNaN(m) && !isNaN(r) && (l + m + r) > 0) {
+      return (l + m + r) / 3;
+    }
+    return null; // No data available yet
+  }
+
+  function updateWearBar(fillEl, valEl, wear) {
+    if (!fillEl || !valEl) return;
+    if (wear === null || wear === undefined) {
+      // No data — show placeholder instead of fake 100%
+      fillEl.style.width = '0%';
+      fillEl.className = 'pb-tire-bar-fill';
+      valEl.textContent = '—';
+      return;
+    }
+    var pct = Math.max(0, Math.min(100, (1 - wear) * 100));
+    var remaining = Math.round(pct);
+    fillEl.style.width = remaining + '%';
+    fillEl.className = 'pb-tire-bar-fill' +
+      (remaining < 20 ? ' crit' : remaining < 40 ? ' warn' : '');
+    valEl.textContent = remaining + '%';
+  }
+
+  // ── Temperature formatting — respects DisplayUnits ──
+  function formatTemp(celsius, units) {
+    if (!celsius && celsius !== 0) return '—';
+    var c = parseFloat(celsius) || 0;
+    if (c === 0) return '—';
+    // units: 0=imperial(°F), 1=metric(°C)
+    if (units === 0) return Math.round(c * 9 / 5 + 32) + '°F';
+    return Math.round(c) + '°C';
+  }
+
+  // ── Main update handler ──
+  window.updatePitBox = function(d) {
+    if (!_els) cacheElements();
+    if (!_els || !_els.panel) return;
+
+    // Show/hide based on game detection
+    var isIRacing = typeof _isIRacing !== 'undefined' ? _isIRacing : false;
+    if (isIRacing !== _lastIsIRacing) {
+      _lastIsIRacing = isIRacing;
+      if (_els.noData) _els.noData.style.display = isIRacing ? 'none' : '';
+      if (_els.content) _els.content.style.display = isIRacing ? '' : 'none';
+    }
+    if (!isIRacing) return;
+
+    var pb = function(key) { return d['K10Motorsports.Plugin.PitBox.' + key]; };
+    var dc = function(key) { return d['DataCorePlugin.GameRawData.Telemetry.' + key]; };
+    var ds = function(key) { return d['K10Motorsports.Plugin.DS.' + key]; };
+    var gd = function(key) { return d['DataCorePlugin.GameData.' + key]; };
+
+    // 0=imperial, 1=metric. Cannot use `|| 1` fallback here because 0 is a
+    // valid value (imperial) — `0 || 1` would incorrectly evaluate to metric.
+    var rawUnits = ds('DisplayUnits');
+    var units = (rawUnits !== '' && rawUnits !== null && rawUnits !== undefined)
+      ? parseInt(rawUnits) : 1;
+
+    // ════════════════════════════════════════
+    //  TYRES TAB
+    // ════════════════════════════════════════
+
+    // Pit selections
+    updateTire('LF', _els.tireLF, _els.pressLF, pb('TireLF'), pb('PressureLF'));
+    updateTire('RF', _els.tireRF, _els.pressRF, pb('TireRF'), pb('PressureRF'));
+    updateTire('LR', _els.tireLR, _els.pressLR, pb('TireLR'), pb('PressureLR'));
+    updateTire('RR', _els.tireRR, _els.pressRR, pb('TireRR'), pb('PressureRR'));
+
+    // Wear bars — iRacing sends 0-1 where 1=new, 0=worn.
+    // Use null-aware parsing: null/undefined means "no data yet" (show —),
+    // whereas 0 means "fully worn" (show 0%).
+    // Fall back to raw telemetry average if GameData returns null (first lap).
+    var wearFL = _parseTyreWear(gd('TyreWearFrontLeft'), dc('LFwearL'), dc('LFwearM'), dc('LFwearR'));
+    var wearFR = _parseTyreWear(gd('TyreWearFrontRight'), dc('RFwearL'), dc('RFwearM'), dc('RFwearR'));
+    var wearRL = _parseTyreWear(gd('TyreWearRearLeft'), dc('LRwearL'), dc('LRwearM'), dc('LRwearR'));
+    var wearRR = _parseTyreWear(gd('TyreWearRearRight'), dc('RRwearL'), dc('RRwearM'), dc('RRwearR'));
+    updateWearBar(_els.wearLF, _els.wearLFVal, wearFL);
+    updateWearBar(_els.wearRF, _els.wearRFVal, wearFR);
+    updateWearBar(_els.wearLR, _els.wearLRVal, wearRL);
+    updateWearBar(_els.wearRR, _els.wearRRVal, wearRR);
+
+    // Tyre temps
+    if (_els.tempLF) _els.tempLF.textContent = formatTemp(gd('TyreTempFrontLeft'), units);
+    if (_els.tempRF) _els.tempRF.textContent = formatTemp(gd('TyreTempFrontRight'), units);
+    if (_els.tempLR) _els.tempLR.textContent = formatTemp(gd('TyreTempRearLeft'), units);
+    if (_els.tempRR) _els.tempRR.textContent = formatTemp(gd('TyreTempRearRight'), units);
+
+    // ════════════════════════════════════════
+    //  FUEL TAB
+    // ════════════════════════════════════════
+
+    var fuelPct = parseFloat(ds('FuelPct')) || 0;
+    var fuelFormatted = ds('FuelFormatted') || '—';
+    var fuelPerLap = ds('FuelPerLapFormatted') || '—';
+    var fuelLaps = parseFloat(ds('FuelLapsRemaining')) || 0;
+    var fuelDisplay = pb('FuelDisplay') || '—';
+    var fuelRequested = pb('FuelRequested');
+    var unitLabel = units === 0 ? 'gallons' : 'liters';
+
+    // Fuel gauge bar
+    if (_els.fuelBar) {
+      _els.fuelBar.style.width = Math.min(100, fuelPct) + '%';
+      _els.fuelBar.className = 'pb-fuel-bar-fill' +
+        (fuelPct < 10 ? ' crit' : fuelPct < 25 ? ' warn' : '');
+    }
+    if (_els.fuelLevel) _els.fuelLevel.textContent = fuelFormatted;
+    if (_els.fuelUnit) _els.fuelUnit.textContent = unitLabel;
+    if (_els.fuelPerLap) _els.fuelPerLap.textContent = fuelPerLap;
+    if (_els.fuelLaps) {
+      _els.fuelLaps.textContent = fuelLaps > 0 && fuelLaps < 99
+        ? fuelLaps.toFixed(1) : '—';
+    }
+    // Pit fuel add
+    if (_els.fuelVal) {
+      _els.fuelVal.textContent = fuelRequested ? fuelDisplay : 'OFF';
+      _els.fuelVal.className = 'pb-value ' + (fuelRequested ? 'active' : 'inactive');
+      checkAndFlash('fuel', fuelDisplay + '|' + fuelRequested, _els.fuelVal.parentElement);
+    }
+
+    // Services
+    updateToggle('fastRepair', _els.fastRepair, pb('FastRepairRequested'));
+    updateToggle('windshield', _els.windshield, pb('WindshieldRequested'));
+
+    // ════════════════════════════════════════
+    //  WEATHER TAB
+    // ════════════════════════════════════════
+
+    var airTemp = parseFloat(ds('AirTemp')) || 0;
+    var trackTempVal = parseFloat(ds('TrackTemp')) || 0;
+    var isWet = parseInt(ds('WeatherWet')) === 1;
+
+    if (_els.weatherIcon) _els.weatherIcon.textContent = isWet ? '🌧' : '☀';
+    if (_els.airTemp) _els.airTemp.textContent = formatTemp(airTemp, units);
+    if (_els.trackTemp) _els.trackTemp.textContent = formatTemp(trackTempVal, units);
+    if (_els.conditions) {
+      _els.conditions.textContent = isWet ? 'Wet' : 'Dry';
+      _els.conditions.className = 'pb-value' + (isWet ? ' on' : '');
+    }
+
+    // ════════════════════════════════════════
+    //  ADJUSTMENTS TAB
+    // ════════════════════════════════════════
+
+    setRowVisible(_els.rowTC,    pb('HasTC'));
+    setRowVisible(_els.rowABS,   pb('HasABS'));
+    setRowVisible(_els.rowARBF,  pb('HasARBFront'));
+    setRowVisible(_els.rowARBR,  pb('HasARBRear'));
+    setRowVisible(_els.rowEng,   pb('HasEnginePower'));
+    setRowVisible(_els.rowFuel,  pb('HasFuelMixture'));
+    setRowVisible(_els.rowWJL,   pb('HasWeightJackerL'));
+    setRowVisible(_els.rowWJR,   pb('HasWeightJackerR'));
+    setRowVisible(_els.rowWingF, pb('HasWingFront'));
+    setRowVisible(_els.rowWingR, pb('HasWingRear'));
+
+    updateAdj('bb',    _els.adjBB,    dc('dcBrakeBias'),         '%', 1);
+    updateAdj('tc',    _els.adjTC,    dc('dcTractionControl'),   '',  0);
+    updateAdj('abs',   _els.adjABS,   dc('dcABS'),               '',  0);
+    updateAdj('arbf',  _els.adjARBF,  dc('dcAntiRollFront'),     '',  0);
+    updateAdj('arbr',  _els.adjARBR,  dc('dcAntiRollRear'),      '',  0);
+    updateAdj('eng',   _els.adjEng,   dc('dcEnginePower'),       '',  0);
+    updateAdj('fmix',  _els.adjFuel,  dc('dcFuelMixture'),       '',  0);
+    updateAdj('wjl',   _els.adjWJL,   dc('dcWeightJackerLeft'),  '',  0);
+    updateAdj('wjr',   _els.adjWJR,   dc('dcWeightJackerRight'), '',  0);
+    updateAdj('wingf', _els.adjWingF, dc('dcWingFront'),         '',  0);
+    updateAdj('wingr', _els.adjWingR, dc('dcWingRear'),          '',  0);
+
+    // ════════════════════════════════════════
+    //  CAMERA / FFB TAB
+    // ════════════════════════════════════════
+
+    // dcFFBMaxForce is not currently exposed in telemetry —
+    // show "—" until we wire it. Mirrors are in-sim only.
+    if (_els.ffbMax) _els.ffbMax.textContent = '—';
+    if (_els.mirror) _els.mirror.textContent = '—';
+
+    // ════════════════════════════════════════
+    //  WHEEL BUTTON INPUTS
+    // ════════════════════════════════════════
+
+    var tabCycle     = parseInt(ds('PitboxTabCycle')) || 0;
+    var tabCycleBack = parseInt(ds('PitboxTabCycleBack')) || 0;
+    var pbNext       = parseInt(ds('PitboxNext')) || 0;
+    var pbPrev       = parseInt(ds('PitboxPrev')) || 0;
+    var pbInc        = parseInt(ds('PitboxIncrement')) || 0;
+    var pbDec        = parseInt(ds('PitboxDecrement')) || 0;
+    var pbTog        = parseInt(ds('PitboxToggle')) || 0;
+
+    if (_lastTabCycle === -1) {
+      // First frame — capture baselines, don't fire anything
+      _lastTabCycle = tabCycle; _lastTabCycleBack = tabCycleBack;
+      _lastNext = pbNext; _lastPrev = pbPrev;
+      _lastIncrement = pbInc; _lastDecrement = pbDec;
+      _lastToggle = pbTog;
+    } else {
+      // Tab cycling
+      var tabDir = 0;
+      if (tabCycle !== _lastTabCycle)         { _lastTabCycle = tabCycle; tabDir = 1; }
+      if (tabCycleBack !== _lastTabCycleBack) { _lastTabCycleBack = tabCycleBack; tabDir = -1; }
+      if (tabDir !== 0) {
+        var panel = document.getElementById('pitBoxPanel');
+        if (_pbHidden) {
+          // Re-show: next → first tab, prev → last tab
+          _pbHidden = false;
+          if (panel) panel.classList.remove('pb-dismissed');
+          var revealIdx = tabDir === 1 ? 0 : _tabOrder.length - 1;
+          var revealTab = document.querySelector('.pb-tab[data-pb-tab="' + _tabOrder[revealIdx] + '"]');
+          if (revealTab) switchPbTab(revealTab);
+        } else {
+          var activeTab = document.querySelector('.pb-tab.active');
+          var currentKey = activeTab ? activeTab.dataset.pbTab : _tabOrder[0];
+          var idx = _tabOrder.indexOf(currentKey);
+          // Check if cycling past an edge → dismiss
+          var atEnd   = (tabDir === 1  && idx === _tabOrder.length - 1);
+          var atStart = (tabDir === -1 && idx === 0);
+          if (atEnd || atStart) {
+            _pbHidden = true;
+            if (panel) panel.classList.add('pb-dismissed');
+          } else {
+            var nextIdx = idx + tabDir;
+            var nextTab = document.querySelector('.pb-tab[data-pb-tab="' + _tabOrder[nextIdx] + '"]');
+            if (nextTab) switchPbTab(nextTab);
+          }
+        }
+      }
+
+      // Element navigation / value adjustment — actions stubbed for future mapping
+      if (pbNext !== _lastNext)  { _lastNext = pbNext;  /* TODO: move focus to next element */ }
+      if (pbPrev !== _lastPrev)  { _lastPrev = pbPrev;  /* TODO: move focus to prev element */ }
+      if (pbInc !== _lastIncrement)  { _lastIncrement = pbInc;  /* TODO: increment focused value */ }
+      if (pbDec !== _lastDecrement)  { _lastDecrement = pbDec;  /* TODO: decrement focused value */ }
+      if (pbTog !== _lastToggle) { _lastToggle = pbTog; /* TODO: toggle focused element on/off */ }
+    }
+
+    // Enable flash detection after first full frame
+    if (!_initialized) _initialized = true;
+  };
+
+  // ── Tire update helper ──
+  function updateTire(pos, statusEl, pressEl, isChanging, pressStr) {
+    if (statusEl) {
+      statusEl.textContent = isChanging ? 'CHANGE' : 'KEEP';
+      statusEl.className = 'pb-tire-status ' + (isChanging ? 'changing' : 'keeping');
+    }
+    if (pressEl) {
+      var p = pressStr || '—';
+      pressEl.textContent = isChanging ? p : '—';
+      pressEl.style.opacity = isChanging ? '1' : '0.3';
+    }
+    var key = 'tire' + pos;
+    var val = (isChanging ? 1 : 0) + '|' + pressStr;
+    checkAndFlash(key, val, statusEl ? statusEl.parentElement : null);
+  }
+
+  function updateToggle(key, el, isOn) {
+    if (!el) return;
+    el.textContent = isOn ? 'YES' : 'NO';
+    el.className = 'pb-value ' + (isOn ? 'on' : 'off');
+    checkAndFlash(key, isOn ? 1 : 0, el.parentElement);
+  }
+
+  function updateAdj(key, el, val, suffix, decimals) {
+    if (!el) return;
+    var v = parseFloat(val) || 0;
+    if (v === 0) {
+      el.textContent = '—';
+      el.className = 'pb-adj-val zero';
+    } else {
+      el.textContent = v.toFixed(decimals) + suffix;
+      el.className = 'pb-adj-val';
+    }
+    checkAndFlash('adj_' + key, v.toFixed(decimals), el.parentElement);
+  }
+
+})();
+
+
+// ── modules/js/race-control.js ──
+// Race control message banner
+
+  // ═══════════════════════════════════════════════════════════════
+  //  RACE CONTROL MESSAGE BANNER
+  // ═══════════════════════════════════════════════════════════════
+
+  // Only critical session-altering events get the Race Control banner.
+  // Blue, white, green, debris are handled by the flag overlay on the gaps block.
+  const RC_MESSAGES = {
+    yellow:    { title: 'CAUTION',          detail: 'Full course yellow — hold position' },
+    red:       { title: 'RED FLAG',         detail: 'Session stopped — return to pits' },
+    checkered: { title: 'CHECKERED FLAG',   detail: 'Race complete — cool down lap' },
+    black:     { title: 'BLACK FLAG',       detail: 'Penalty — report to pit lane immediately' },
+    meatball:  { title: 'MEATBALL FLAG',    detail: 'Mechanical issue — pit for required repairs' },
+  };
+
+  // Duration each race control message stays visible (ms)
+  const RC_DISPLAY_MS = 8000;
+
+  function showRaceControl(flagType) {
+    const banner = document.getElementById('rcBanner');
+    if (!banner) return;
+    const msg = RC_MESSAGES[flagType];
+    if (!msg) return;
+
+    const titleEl = document.getElementById('rcTitle');
+    const detailEl = document.getElementById('rcDetail');
+    if (titleEl) titleEl.textContent = msg.title;
+    if (detailEl) detailEl.textContent = msg.detail;
+
+    // Remove previous flag classes
+    banner.className = banner.className.replace(/\brc-flag-\S+/g, '').trim();
+    banner.classList.add('rc-flag-' + flagType);
+    banner.classList.add('rc-visible');
+    _rcVisible = true;
+
+    // Dim HUD elements
+    document.body.classList.add('rc-active');
+
+    // Auto-hide after duration
+    if (_rcTimeout) clearTimeout(_rcTimeout);
+    _rcTimeout = setTimeout(() => {
+      hideRaceControl();
+    }, RC_DISPLAY_MS);
+  }
+
+  function hideRaceControl() {
+    const banner = document.getElementById('rcBanner');
+    if (!banner) return;
+    banner.classList.remove('rc-visible');
+    _rcVisible = false;
+    if (_rcTimeout) { clearTimeout(_rcTimeout); _rcTimeout = null; }
+
+    // Restore HUD elements
+    document.body.classList.remove('rc-active');
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+
+
+// ── modules/js/race-timeline.js ──
+// Race timeline position strip
+
+  // ═══════════════════════════════════════════════════════════════
+  //  RACE TIMELINE — position state color strip
+  // ═══════════════════════════════════════════════════════════════
+
+  // History stores objects: { delta: N, p1: bool, checkered: bool, event: string|null }
+  // delta = positions gained/lost vs start (negative = gained, positive = lost from start)
+  // event: null, 'pit', 'offtrack', 'damage' — drawn as markers on the timeline
+  const RT_MAX_SAMPLES = 310;
+  const _rtHistory = [];
+  let _rtStartPos = 0;
+  let _rtLastLap = 0;
+  let _rtLastPos = 0;
+  let _rtLastDelta = null;
+  let _rtFinished = false;
+  let _rtLastIncident = 0;
+  let _rtWasInPit = false;
+
+  // Heat-mapped color: intensity scales with number of positions gained/lost
+  // delta 0 = neutral blue, negative = green (gained), positive = red (lost)
+  // Clamp heat at ±5 positions for a sane max
+  function rtColor(sample) {
+    if (sample.checkered) return null; // handled separately
+    if (sample.p1) {
+      const heat = Math.min(Math.abs(sample.delta), 5);
+      const lit  = 58 + heat * 4;
+      return 'hsla(42, 72%, ' + lit + '%, 0.8)';
+    }
+    const d = sample.delta;
+    if (d === 0) return 'hsla(210, 42%, 54%, 0.8)';
+    if (d < 0) {
+      const heat = Math.min(Math.abs(d), 5);
+      const sat  = 38 + heat * 8;
+      const lit  = 46 + heat * 5;
+      return 'hsla(145, ' + sat + '%, ' + lit + '%, 0.8)';
+    }
+    const heat = Math.min(d, 5);
+    const sat  = 38 + heat * 8;
+    const lit  = 48 + heat * 5;
+    return 'hsla(0, ' + sat + '%, ' + lit + '%, 0.8)';
+  }
+
+  function updateRaceTimeline(position, currentLap, flagState, incidentCount, isInPit) {
+    if (!position || position <= 0) return;
+    if (_rtStartPos <= 0 && position > 0) _rtStartPos = position;
+
+    const delta = position - _rtStartPos;  // negative = gained positions, positive = lost positions
+
+    // Detect events
+    let event = null;
+    if (isInPit && !_rtWasInPit) {
+      event = 'pit';
+    } else if (incidentCount > _rtLastIncident && _rtLastIncident > 0) {
+      // Incident count jumped — either off-track or contact/damage
+      const inc = incidentCount - _rtLastIncident;
+      event = inc >= 4 ? 'damage' : 'offtrack';  // 4+ points typically = heavy contact/damage
+    }
+    _rtWasInPit = !!isInPit;
+    if (incidentCount > 0) _rtLastIncident = incidentCount;
+
+    const sample = {
+      delta: delta,
+      p1: position === 1,
+      checkered: flagState === 'checkered',
+      event: event,
+      newLap: currentLap > 0 && currentLap !== _rtLastLap,
+    };
+    if (sample.checkered) _rtFinished = true;
+
+    const lapChanged = currentLap > 0 && currentLap !== _rtLastLap;
+    const posChanged = position !== _rtLastPos && _rtLastPos > 0;
+    const hasEvent = event !== null;
+    if (lapChanged || posChanged || hasEvent) {
+      _rtHistory.push(sample);
+      _rtLastLap = currentLap;
+      _rtLastDelta = delta;
+    } else if (_rtHistory.length === 0) {
+      _rtHistory.push(sample);
+      _rtLastDelta = delta;
+    }
+    _rtLastPos = position;
+    if (_rtHistory.length > RT_MAX_SAMPLES) _rtHistory.shift();
+
+    renderTimeline();
+  }
+
+  // Event marker colors
+  const RT_EVENT_COLORS = {
+    pit:     'hsla(210, 80%, 65%, 0.9)',   // blue — pit stop
+    offtrack: 'hsla(35, 90%, 55%, 0.9)',    // orange — off track / minor incident
+    damage:  'hsla(0, 85%, 55%, 0.9)',      // red — heavy contact / damage
+  };
+
+  function renderTimeline() {
+    const canvas = document.getElementById('rtCanvas');
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    const w = canvas.width;
+    const h = canvas.height;
+    ctx.clearRect(0, 0, w, h);
+
+    const len = _rtHistory.length;
+    if (len === 0) return;
+
+    const sliceW = Math.max(1, w / len);
+
+    // First pass: draw position colors
+    for (let i = 0; i < len; i++) {
+      const sample = _rtHistory[i];
+      const x = Math.floor(i * sliceW);
+      const nextX = Math.floor((i + 1) * sliceW);
+      const sw = nextX - x;
+
+      if (sample.checkered) {
+        const sqSize = 2;
+        for (let cy = 0; cy < h; cy += sqSize) {
+          for (let cx = x; cx < x + sw; cx += sqSize) {
+            const row = Math.floor(cy / sqSize);
+            const col = Math.floor((cx - x) / sqSize);
+            ctx.fillStyle = (row + col) % 2 === 0 ? 'hsla(0,0%,100%,0.35)' : 'hsla(0,0%,0%,0.4)';
+            ctx.fillRect(cx, cy, Math.min(sqSize, x + sw - cx), Math.min(sqSize, h - cy));
+          }
+        }
+      } else {
+        ctx.fillStyle = rtColor(sample);
+        ctx.fillRect(x, 0, sw, h);
+      }
+    }
+
+    // Second pass: draw event markers (small triangles/diamonds on top)
+    for (let i = 0; i < len; i++) {
+      const sample = _rtHistory[i];
+      if (!sample.event) continue;
+      const x = Math.floor(i * sliceW + sliceW / 2);
+      const color = RT_EVENT_COLORS[sample.event] || 'hsla(0,0%,100%,0.5)';
+
+      // Draw a small downward-pointing triangle at top of timeline
+      ctx.fillStyle = color;
+      ctx.beginPath();
+      ctx.moveTo(x - 3, 0);
+      ctx.lineTo(x + 3, 0);
+      ctx.lineTo(x, 5);
+      ctx.closePath();
+      ctx.fill();
+
+      // Vertical tick line
+      ctx.strokeStyle = color.replace(/[\d.]+\)$/, '0.6)');
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(x, 5);
+      ctx.lineTo(x, h);
+      ctx.stroke();
+    }
+
+    // Third pass: draw white lap boundary lines
+    for (let i = 0; i < len; i++) {
+      const sample = _rtHistory[i];
+      if (!sample.newLap) continue;
+      const x = Math.floor(i * sliceW);
+      ctx.strokeStyle = 'hsla(0,0%,100%,0.4)';
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, h);
+      ctx.stroke();
+    }
+  }
+
+  function resetTimeline() {
+    _rtHistory.length = 0;
+    _rtStartPos = 0;
+    _rtLastLap = 0;
+    _rtLastPos = 0;
+    _rtLastDelta = null;
+    _rtFinished = false;
+    const canvas = document.getElementById('rtCanvas');
+    if (canvas) canvas.getContext('2d').clearRect(0, 0, canvas.width, canvas.height);
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+
+
+// ── modules/js/incidents.js ──
+// Incidents module renderer
+
+  // ═══════════════════════════════════════════════════════════════
+  //  INCIDENTS MODULE RENDERER
+  // ═══════════════════════════════════════════════════════════════
+  function updateIncidents(p, isDemo) {
+    const panel = document.getElementById('incidentsPanel');
+    if (!panel || panel.classList.contains('section-hidden')) return;
+    const pre = isDemo ? 'K10Motorsports.Plugin.Demo.DS.' : 'K10Motorsports.Plugin.DS.';
+    const incidentCount = +(p[pre + 'IncidentCount']) || 0;
+
+    const countEl = document.getElementById('incCount');
+    if (!countEl) return;
+    countEl.textContent = incidentCount;
+
+    // Flash on increment
+    if (_dsPrevIncidents >= 0 && incidentCount > _dsPrevIncidents) {
+      countEl.classList.remove('inc-flash');
+      void countEl.offsetWidth;
+      countEl.classList.add('inc-flash');
+    }
+    _dsPrevIncidents = incidentCount;
+
+    // Progressive color level: 0=green, 5=red
+    // 0x=0, 1-2x=1, 3-4x=2, 5-6x=3, 7-9x=4, 10+=5
+    let level;
+    if (incidentCount === 0) level = 0;
+    else if (incidentCount <= 2) level = 1;
+    else if (incidentCount <= 4) level = 2;
+    else if (incidentCount <= 6) level = 3;
+    else if (incidentCount <= 9) level = 4;
+    else level = 5;
+
+    for (let i = 0; i <= 5; i++) panel.classList.toggle('inc-level-' + i, i === level);
+
+    // Threshold counters — remaining incidents to penalty / DQ
+    // Read from the iRacing SDK via the plugin (parsed from session YAML WeekendOptions).
+    // Plugin sends IncidentLimitDQ (from SDK IncidentLimit) and IncidentLimitPenalty
+    // (calculated at ~68% of DQ only when DQ >= 20, otherwise 0).
+    //
+    // Three display modes:
+    //   1. Both penalty + DQ limits exist  → show penalty row, DQ row, both markers
+    //   2. DQ only (penalty = 0)           → hide penalty row + marker, show DQ only
+    //   3. No limits (both = 0)            → hide thresholds + progress bar entirely
+    const sdkPen = +(p[pre + 'IncidentLimitPenalty']) || 0;
+    const sdkDQ  = +(p[pre + 'IncidentLimitDQ']) || 0;
+
+    // Check if we're in a non-race session (practice, qualifying, test, warmup)
+    const isNonRaceSession = !!(+(p[pre + 'IsNonRaceSession']) || 0);
+
+    // Determine effective limits: 0 means "no limit for this threshold"
+    let penLimit, dqLimit;
+    if (isNonRaceSession) {
+      penLimit = 0;
+      dqLimit = 0;
+    } else {
+      penLimit = sdkPen;
+      dqLimit  = sdkDQ;
+    }
+
+    const hasPenalty = penLimit > 0;
+    const hasDQ     = dqLimit > 0;
+    const hasAnyLimit = hasPenalty || hasDQ;
+
+    const toPen = hasPenalty ? Math.max(0, penLimit - incidentCount) : -1;
+    const toDQ  = hasDQ     ? Math.max(0, dqLimit  - incidentCount) : -1;
+
+    // ── Threshold rows visibility ──
+    const thresholds = document.querySelector('#incidentsPanel .inc-thresholds');
+    const progressEl = document.getElementById('incProgress');
+    const penRow = document.getElementById('incToPen')?.closest('.inc-thresh-row');
+    const dqRow  = document.getElementById('incToDQ')?.closest('.inc-thresh-row');
+
+    if (thresholds) thresholds.style.display = hasAnyLimit ? '' : 'none';
+    if (progressEl) progressEl.style.display = hasAnyLimit ? '' : 'none';
+    if (penRow) penRow.style.display = hasPenalty ? '' : 'none';
+
+    const penEl = document.getElementById('incToPen');
+    const dqEl  = document.getElementById('incToDQ');
+    if (penEl && hasPenalty) {
+      penEl.textContent = toPen > 0 ? toPen : 'PENALTY';
+      penEl.className = 'inc-thresh-val' + (toPen === 0 ? ' thresh-hit' : toPen <= 3 ? ' thresh-crit' : toPen <= 6 ? ' thresh-near' : '');
+    }
+    if (dqEl) {
+      if (!hasDQ) {
+        dqEl.textContent = '\u221E';
+        dqEl.className = 'inc-thresh-val';
+      } else {
+        dqEl.textContent = toDQ > 0 ? toDQ : 'DQ';
+        dqEl.className = 'inc-thresh-val' + (toDQ === 0 ? ' thresh-hit' : toDQ <= 3 ? ' thresh-crit' : toDQ <= 6 ? ' thresh-near' : '');
+      }
+    }
+
+    // ── Progress bar: accrued fill + penalty / DQ markers ──
+    const barFill = document.getElementById('incBarFill');
+    const markerPen = document.getElementById('incMarkerPen');
+    const markerDQ = document.getElementById('incMarkerDQ');
+    if (barFill && markerPen && markerDQ) {
+      if (!hasDQ) {
+        // No DQ limit — hide the bar entirely
+        barFill.style.width = '0%';
+        markerPen.style.display = 'none';
+        markerDQ.style.display = 'none';
+      } else {
+        // Bar represents 0 → dqLimit, fill shows accrued
+        const fillPct = Math.min(100, (incidentCount / dqLimit) * 100);
+        barFill.style.width = fillPct + '%';
+
+        // Penalty marker — only if penalty threshold exists
+        if (hasPenalty) {
+          const penPct = Math.min(100, (penLimit / dqLimit) * 100);
+          markerPen.style.left = penPct + '%';
+          markerPen.style.display = 'block';
+          markerPen.style.opacity = incidentCount >= penLimit ? '0.3' : '0.7';
+        } else {
+          markerPen.style.display = 'none';
+        }
+
+        // DQ marker is always at the end
+        markerDQ.style.left = '100%';
+        markerDQ.style.display = 'block';
+      }
+    }
+
+    // ── WebGL fire effect at thresholds ──
+    if (window.setIncidentsGL) {
+      if (hasDQ && toDQ === 0) {
+        window.setIncidentsGL('dq');
+      } else if (hasPenalty && toPen === 0) {
+        window.setIncidentsGL('penalty');
+      } else {
+        window.setIncidentsGL('');
+      }
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+
+
+// ── modules/js/pit-limiter.js ──
+// Pit limiter module
+
+  // ═══════════════════════════════════════════════════════════════
+  //  PIT LIMITER
+  // ═══════════════════════════════════════════════════════════════
+  let _wasInPit = false;
+  let _bonkersActive = false;
+  let _sparkTimer = null;
+  // Bonkers holdover: when entering pit at speed, lock bonkers for 3s
+  // so the animation is visible even after the auto-limiter slows the car
+  let _bonkersHoldUntil = 0;
+
+  function updatePitLimiter(p, isDemo) {
+    const pre = isDemo ? 'K10Motorsports.Plugin.Demo.DS.' : 'K10Motorsports.Plugin.DS.';
+    // Fallback to SimHub's built-in DataCore if plugin property is not set
+    const inPitLane = +(p[pre + 'IsInPitLane']) > 0 || +(p['DataCorePlugin.GameData.IsInPitLane']) > 0;
+    const speedKmh = +(p[pre + 'SpeedKmh']) || +(p['DataCorePlugin.GameData.SpeedKph']) || 0;
+    const pitLimiterOn = +(p[pre + 'PitLimiterOn']) > 0 || +(p['DataCorePlugin.GameData.PitLimiterEnabled']) > 0;
+    const pitLimitKmh = +(p[pre + 'PitSpeedLimitKmh']) || +(p['DataCorePlugin.GameData.PitSpeedLimitKmh']) || 0;
+
+    const banner = document.getElementById('pitBanner');
+    const speedEl = document.getElementById('pitSpeed');
+    const limitEl = document.getElementById('pitLimit');
+    const labelEl = banner ? banner.querySelector('.pit-label') : null;
+    if (!banner) return;
+
+    // Pit limiter blue glow on tacho module
+    const tacho = document.querySelector('.tacho-block');
+    if (tacho) tacho.classList.toggle('pit-limiter-engaged', inPitLane && pitLimiterOn);
+
+    // Detect pit entry while speeding — lock bonkers for 3s so it's visible
+    // even after the car's auto-limiter kicks in and drops speed
+    const now = Date.now();
+    const isSpeeding = +(p[pre + 'IsPitSpeeding']) > 0 || (pitLimitKmh > 0 && speedKmh > pitLimitKmh) || +(p['DataCorePlugin.GameData.IsSpeedingOnPitRoad']) > 0;
+    if (!_wasInPit && inPitLane && isSpeeding) {
+      _bonkersHoldUntil = now + 3000;
+    }
+    const bonkersHeld = now < _bonkersHoldUntil;
+
+    if (inPitLane) {
+      banner.classList.add('pit-visible');
+      document.body.classList.add('pit-mode');
+
+      // Show speed — prefer server-computed DS.SpeedMph
+      if (speedEl) {
+        const mph = Math.round(+(p[pre + 'SpeedMph']) || +(p['DataCorePlugin.GameData.SpeedMph']) || speedKmh * 0.621371);
+        speedEl.textContent = mph > 0 ? mph + ' mph' : '';
+      }
+      // Show pit speed limit — prefer server-computed DS.PitSpeedLimitMph
+      if (limitEl) {
+        if (pitLimitKmh > 0) {
+          const limitMph = Math.round(+(p[pre + 'PitSpeedLimitMph']) || +(p['DataCorePlugin.GameData.PitSpeedLimitMph']) || pitLimitKmh * 0.621371);
+          limitEl.textContent = '/ ' + limitMph + ' limit';
+        } else {
+          limitEl.textContent = '';
+        }
+      }
+
+      // ── State priority: BONKERS > WARNING > NORMAL ──
+      if (isSpeeding || bonkersHeld) {
+        // BONKERS — over the speed limit, or held from entry
+        banner.classList.add('pit-bonkers');
+        banner.classList.remove('pit-warning');
+        if (labelEl) labelEl.textContent = 'SPEEDING';
+        if (_settings.showBonkers !== false) {
+          if (!_bonkersActive) _startBonkersSparks(banner);
+          if (window.setBonkersGL) window.setBonkersGL(true);
+        }
+      } else if (!pitLimiterOn) {
+        // WARNING — limiter off but not yet over limit
+        banner.classList.add('pit-warning');
+        banner.classList.remove('pit-bonkers');
+        if (labelEl) labelEl.textContent = 'PIT LIMITER OFF';
+        if (_bonkersActive) _stopBonkersSparks(banner);
+        if (window.setBonkersGL) window.setBonkersGL(false);
+      } else {
+        // NORMAL — limiter on, all good
+        banner.classList.remove('pit-warning', 'pit-bonkers');
+        if (labelEl) labelEl.textContent = 'Pit Limiter';
+        if (_bonkersActive) _stopBonkersSparks(banner);
+        if (window.setBonkersGL) window.setBonkersGL(false);
+      }
+    } else {
+      // Not in pit lane — but if approaching pit at speed, show early warning
+      if (pitLimitKmh > 0 && speedKmh > pitLimitKmh && bonkersHeld) {
+        // Holdover from entering pit — keep bonkers visible during transition
+        banner.classList.add('pit-visible', 'pit-bonkers');
+        banner.classList.remove('pit-warning');
+        if (labelEl) labelEl.textContent = 'SPEEDING';
+        if (speedEl) {
+          const mph = Math.round(+(p[pre + 'SpeedMph']) || +(p['DataCorePlugin.GameData.SpeedMph']) || speedKmh * 0.621371);
+          speedEl.textContent = mph > 0 ? mph + ' mph' : '';
+        }
+      } else {
+        banner.classList.remove('pit-visible', 'pit-warning', 'pit-bonkers');
+        document.body.classList.remove('pit-mode');
+        if (labelEl) labelEl.textContent = 'Pit Limiter';
+        if (_bonkersActive) _stopBonkersSparks(banner);
+        if (window.setBonkersGL) window.setBonkersGL(false);
+      }
+    }
+    _wasInPit = inPitLane;
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //  BONKERS SPARK PARTICLE SYSTEM
+  //  Reusable — call _startBonkersSparks(container) on any element
+  // ═══════════════════════════════════════════════════════════════
+
+  function _startBonkersSparks(container) {
+    if (_bonkersActive) return;
+    _bonkersActive = true;
+    const inner = container.querySelector('.pit-inner');
+    if (!inner) return;
+    _sparkTimer = setInterval(() => {
+      if (!_bonkersActive) return;
+      // Burst of 3-5 sparks per tick
+      const count = 3 + Math.floor(Math.random() * 3);
+      for (let i = 0; i < count; i++) _spawnSpark(inner);
+    }, 40);
+  }
+
+  function _stopBonkersSparks(container) {
+    _bonkersActive = false;
+    if (_sparkTimer) { clearInterval(_sparkTimer); _sparkTimer = null; }
+    // Remove lingering sparks
+    const inner = container.querySelector('.pit-inner');
+    if (inner) inner.querySelectorAll('.pit-spark').forEach(s => s.remove());
+  }
+
+  function _spawnSpark(parent) {
+    const spark = document.createElement('div');
+    spark.className = 'pit-spark';
+
+    // Random direction — bias upward and outward
+    const angle = -Math.PI * 0.1 + Math.random() * -Math.PI * 0.8; // mostly upward arc
+    const speed = 40 + Math.random() * 80;
+    const dx = Math.cos(angle) * speed * (Math.random() > 0.5 ? 1 : -1);
+    const dy = Math.sin(angle) * speed;
+    const size = 1.5 + Math.random() * 2.5;
+    const hue = Math.random() * 55;               // 0 (red) → 55 (yellow)
+    const life = 300 + Math.random() * 400;        // 300-700ms
+    const brightness = 55 + Math.random() * 15;
+
+    spark.style.cssText =
+      'position:absolute;border-radius:50%;pointer-events:none;z-index:10;' +
+      'width:' + size + 'px;height:' + size + 'px;' +
+      'background:hsl(' + hue + ',100%,' + brightness + '%);' +
+      'box-shadow:0 0 ' + (size * 3) + 'px hsl(' + hue + ',100%,50%),' +
+                 '0 0 ' + (size * 6) + 'px hsla(' + hue + ',100%,50%,0.4);' +
+      'left:' + (50 + (Math.random() - 0.5) * 60) + '%;' +
+      'top:50%;' +
+      '--spark-dx:' + dx + 'px;--spark-dy:' + dy + 'px;' +
+      'animation:pit-spark-fly ' + life + 'ms ease-out forwards;';
+
+    parent.appendChild(spark);
+    setTimeout(() => { if (spark.parentNode) spark.remove(); }, life + 50);
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+
+
+// ── modules/js/race-end.js ──
+// Race end screen
+
+  // ═══════════════════════════════════════════════════════════════
+  //  RACE END SCREEN
+  // ═══════════════════════════════════════════════════════════════
+
+  function _fmtLapTime(seconds) {
+    if (!seconds || seconds <= 0 || !isFinite(seconds)) return '—';
+    const m = Math.floor(seconds / 60);
+    const s = seconds - m * 60;
+    return m + ':' + (s < 10 ? '0' : '') + s.toFixed(3);
+  }
+  function _fmtIR(ir) {
+    if (!ir || ir <= 0) return '—';
+    return ir >= 1000 ? (ir / 1000).toFixed(1) + 'k' : String(ir);
+  }
+
+  function showRaceEnd(p, isDemo) {
+    const screen = document.getElementById('raceEndScreen');
+    if (!screen || _raceEndVisible) return;
+
+    // Gather data
+    const pre = isDemo ? 'K10Motorsports.Plugin.Demo.' : '';
+    const pos = isDemo ? +(p['K10Motorsports.Plugin.Demo.Position']) || 0 : +(p['DataCorePlugin.GameData.Position']) || 0;
+    const dsPre = isDemo ? 'K10Motorsports.Plugin.Demo.DS.' : 'K10Motorsports.Plugin.DS.';
+    const incidents = +(p[dsPre + 'IncidentCount']) || 0;
+    const completedLaps = +(p[dsPre + 'CompletedLaps']) || 0;
+    const totalLaps = isDemo ? +(p['K10Motorsports.Plugin.Demo.TotalLaps']) || 0 : +(p['DataCorePlugin.GameData.TotalLaps']) || 0;
+    const bestLap = isDemo ? +(p['K10Motorsports.Plugin.Demo.BestLapTime']) || 0 : +(p['DataCorePlugin.GameData.BestLapTime']) || 0;
+    const iRating = isDemo ? +(p['K10Motorsports.Plugin.Demo.IRating']) || 0 : +(p['IRacingExtraProperties.iRacing_DriverInfo_IRating']) || 0;
+
+    // DNF detection
+    const isDNF = pos === 0 || (completedLaps > 0 && totalLaps > 0 && completedLaps < Math.max(1, Math.floor(totalLaps * 0.5)));
+
+    // Finish type
+    let finishType;
+    if (isDNF) finishType = 'dnf';
+    else if (pos >= 1 && pos <= 3) finishType = 'podium';
+    else if (pos >= 4 && pos <= 10) finishType = 'strong';
+    else finishType = 'midpack';
+
+    // Title / subtitle / tint
+    let title, subtitle = null, tint;
+    if (isDNF) {
+      title = 'TOUGH BREAK'; subtitle = 'Every lap is a lesson. Regroup and go again.'; tint = 'purple';
+    } else if (finishType === 'podium') {
+      title = pos === 1 ? 'VICTORY!' : 'PODIUM FINISH!';
+      tint = pos === 1 ? 'gold' : pos === 2 ? 'silver' : 'bronze';
+    } else if (finishType === 'strong') {
+      title = 'STRONG FINISH'; tint = 'green';
+    } else {
+      title = 'RACE COMPLETE'; tint = 'neutral';
+    }
+
+    // Position the race end screen over the HUD bounds
+    const dash = document.getElementById('dashboard');
+    if (dash) {
+      const r = dash.getBoundingClientRect();
+      screen.style.top = Math.max(0, r.top - 12) + 'px';
+      screen.style.left = Math.max(0, r.left - 12) + 'px';
+      screen.style.width = (r.width + 24) + 'px';
+      screen.style.height = (r.height + 24) + 'px';
+    } else {
+      screen.style.top = '10px'; screen.style.right = '10px';
+      screen.style.width = '500px'; screen.style.height = '260px';
+    }
+
+    // Remove old tint classes
+    screen.className = 'race-end-screen re-visible re-tint-' + tint;
+
+    // Populate content
+    const posEl = document.getElementById('rePosition');
+    const titleEl = document.getElementById('reTitle');
+    const subEl = document.getElementById('reSubtitle');
+    const cleanEl = document.getElementById('reCleanBadge');
+    const statPos = document.getElementById('reStatPos');
+    const statInc = document.getElementById('reStatInc');
+    const statLap = document.getElementById('reStatLap');
+    const statIR = document.getElementById('reStatIR');
+
+    if (posEl) posEl.textContent = !isDNF && pos > 0 ? 'P' + pos : '—';
+    if (titleEl) titleEl.textContent = title;
+    if (subEl) { subEl.textContent = subtitle || ''; subEl.style.display = subtitle ? '' : 'none'; }
+    if (cleanEl) cleanEl.style.display = incidents <= 4 ? '' : 'none';
+    if (statPos) statPos.textContent = !isDNF && pos > 0 ? 'P' + pos : 'DNF';
+    if (statInc) statInc.textContent = incidents;
+    if (statLap) statLap.textContent = _fmtLapTime(bestLap);
+    if (statIR) statIR.textContent = _fmtIR(iRating);
+
+    // Confetti for podium
+    const confetti = document.getElementById('reConfetti');
+    if (confetti) {
+      confetti.innerHTML = '';
+      if (finishType === 'podium') {
+        for (let i = 0; i < 14; i++) {
+          const dot = document.createElement('div');
+          dot.className = 're-confetti-dot';
+          dot.style.left = (5 + i * 6.8) + '%';
+          dot.style.animationDelay = (i * 0.12) + 's';
+          dot.style.animationDuration = (2.5 + Math.random() * 2) + 's';
+          confetti.appendChild(dot);
+        }
+      }
+    }
+
+    _raceEndVisible = true;
+
+    // Auto-hide after 30s
+    if (_raceEndTimer) clearTimeout(_raceEndTimer);
+    _raceEndTimer = setTimeout(hideRaceEnd, 30000);
+  }
+
+  function hideRaceEnd() {
+    const screen = document.getElementById('raceEndScreen');
+    if (screen) screen.classList.remove('re-visible');
+    _raceEndVisible = false;
+    if (_raceEndTimer) { clearTimeout(_raceEndTimer); _raceEndTimer = null; }
+  }
+
+  // ══════════════════════════════════════════════════════════════════
+
+
+// ── modules/js/formation.js ──
+// Formation lap / grid start
+
+  // ══════════════════════════════════════════════════════════════════
+  //  FORMATION LAP / GRID START
+  // ══════════════════════════════════════════════════════════════════
+
+  // Country flag colors — loaded from images/flags/flags.json
+  let _countryFlags = {};
+  async function loadCountryFlags() {
+    try {
+      const resp = await fetch('images/flags/flags.json');
+      if (resp.ok) _countryFlags = await resp.json();
+    } catch (e) { console.warn('Failed to load country flags:', e); }
+  }
+
+  // Simulated green light holdover — when plugin doesn't send LightsPhase,
+  // we generate a synthetic sequence and hold it for 3 seconds
+  let _simLightsPhase = 0;
+  let _simLightsTimer = null;
+
+  function updateGrid(p, isDemo) {
+    const pre = isDemo ? 'K10Motorsports.Plugin.Demo.Grid.' : 'K10Motorsports.Plugin.Grid.';
+    const sessionState = +(p[pre + 'SessionState']) || 0;
+    const griddedCars  = +(p[pre + 'GriddedCars']) || 0;
+    const totalCars    = +(p[pre + 'TotalCars']) || 0;
+    const paceMode     = +(p[pre + 'PaceMode']) || 0;
+    let lightsPhase    = +(p[pre + 'LightsPhase']) || 0;
+    const startType    = (p[pre + 'StartType'] || 'rolling').toLowerCase();
+    const isRolling    = startType === 'rolling';
+
+    const mod  = document.getElementById('gridModule');
+    const info = document.getElementById('gridInfo');
+    const lights = document.getElementById('startLights');
+    if (!mod || !info || !lights) return;
+
+    // Detect transition from ParadeLaps (3) to Racing (4): this is when lights should show.
+    // If plugin doesn't send LightsPhase, we generate a synthetic green sequence
+    // and hold it for 3 seconds so it's actually visible.
+    const transitioningToRace = _gridPrevSessionState >= 1 && _gridPrevSessionState <= 3 && sessionState === 4;
+    if (transitioningToRace && lightsPhase === 0 && _simLightsPhase === 0) {
+      _simLightsPhase = 7;
+      clearTimeout(_simLightsTimer);
+      _simLightsTimer = setTimeout(() => { _simLightsPhase = 0; }, 3000);
+    }
+    // Use synthetic phase when plugin isn't sending one
+    if (lightsPhase === 0 && _simLightsPhase > 0) lightsPhase = _simLightsPhase;
+
+    // SessionState 3 = ParadeLaps (formation), or lights sequence active
+    // Phase 8 = post-green holdover — keep module visible while it fades naturally
+    const isFormation = sessionState === 3 || sessionState === 2 || sessionState === 1;
+    const isLightsActive = lightsPhase >= 1 && lightsPhase <= 8;
+    const shouldShow = isFormation || isLightsActive;
+
+    // Detect transition: was showing → no longer showing → start fadeout
+    // But extend the fade window if we just transitioned to Racing (lights sequence might still play)
+    if (!shouldShow && _gridActive) {
+      mod.classList.remove('grid-visible');
+      mod.classList.add('grid-fadeout');
+      document.body.classList.remove('grid-active');
+      _gridActive = false;
+      if (window.setGridFlagGL) window.setGridFlagGL(false);
+      clearTimeout(_gridFadeTimer);
+      // Extend fade timer from 4s to 6s to allow lights to fully display during race start transition
+      const fadeDelay = transitioningToRace ? 6000 : 4000;
+      _gridFadeTimer = setTimeout(() => {
+        mod.classList.remove('grid-fadeout');
+        // Reset lights
+        resetLightBulbs();
+        const flagElReset = document.getElementById('gridFlag');
+        if (flagElReset) flagElReset.classList.remove('flag-active');
+      }, fadeDelay);
+      return;
+    }
+
+    if (!shouldShow) return;
+
+    // Show the module
+    if (!_gridActive) {
+      clearTimeout(_gridFadeTimer);
+      mod.classList.remove('grid-fadeout');
+      mod.classList.add('grid-visible');
+      // Rolling starts: don't dim the dashboard during formation — driver needs instruments.
+      // Only dim for standing starts or when the lights sequence is actively playing.
+      if (!isRolling || isLightsActive) {
+        document.body.classList.add('grid-active');
+      }
+      _gridActive = true;
+      if (window.setGridFlagGL) window.setGridFlagGL(true);
+    }
+    // If we're in a rolling formation and lights just started, apply dim now
+    if (isRolling && isLightsActive) {
+      document.body.classList.add('grid-active');
+    }
+    // If rolling formation without lights, ensure dashboard stays at 100%
+    if (isRolling && !isLightsActive && isFormation) {
+      document.body.classList.remove('grid-active');
+    }
+
+    // Toggle between info card and lights
+    if (isLightsActive) {
+      info.classList.add('info-hidden');
+      lights.classList.add('lights-active');
+      updateStartLights(lightsPhase);
+      // Hide flag during lights
+      const flagElLights = document.getElementById('gridFlag');
+      if (flagElLights) flagElLights.classList.remove('flag-active');
+    } else {
+      info.classList.remove('info-hidden');
+      lights.classList.remove('lights-active');
+      resetLightBulbs();
+
+      // Update info card
+      document.getElementById('gridCarsGridded').textContent = griddedCars;
+      document.getElementById('gridCarsTotal').textContent = totalCars;
+
+      // Mini grid strip — one dot per car, player highlighted in blue
+      const playerPos = isDemo
+        ? (+(p['K10Motorsports.Plugin.Demo.Position']) || 0)
+        : (+(p['DataCorePlugin.GameData.Position']) || 0);
+      _renderGridStrip(totalCars, griddedCars, playerPos);
+
+      const stEl = document.getElementById('gridStartType');
+      stEl.textContent = startType === 'standing' ? 'Standing Start' : 'Rolling Start';
+      stEl.className = 'grid-start-type ' + startType;
+
+      // Country flag background + WebGL glow colors
+      const countryCode = (p[pre + 'TrackCountry'] || '').toUpperCase();
+      const flagEl = document.getElementById('gridFlag');
+      const flagColors = _countryFlags[countryCode];
+      if (flagEl && flagColors) {
+        document.getElementById('flagStripe1').style.background = flagColors[0];
+        document.getElementById('flagStripe2').style.background = flagColors[1];
+        document.getElementById('flagStripe3').style.background = flagColors[2];
+        flagEl.classList.add('flag-active');
+        if (window.setGridFlagColors) {
+          window.setGridFlagColors(flagColors[0], flagColors[1], flagColors[2]);
+        }
+      } else if (flagEl) {
+        flagEl.classList.remove('flag-active');
+      }
+
+      // Countdown: display time to green or pace mode
+      const countdownEl = document.getElementById('gridCountdown');
+      const timeToGreen = isDemo
+        ? +(p['K10Motorsports.Plugin.Demo.Grid.TimeToGreen']) || 0
+        : +(p['K10Motorsports.Plugin.Grid.TimeToGreen']) || 0;
+
+      // During lights sequence (paceMode 1-3), show pace mode status
+      // Otherwise, show countdown timer if available
+      if (paceMode === 1) {
+        countdownEl.textContent = 'GRID';
+      } else if (paceMode === 2) {
+        countdownEl.textContent = 'PACE';
+      } else if (paceMode === 3) {
+        countdownEl.textContent = 'READY';
+      } else if (timeToGreen > 0) {
+        // Show MM:SS countdown
+        const minutes = Math.floor(timeToGreen / 60);
+        const seconds = Math.floor(timeToGreen % 60);
+        countdownEl.textContent = minutes + ':' + (seconds < 10 ? '0' : '') + seconds;
+      } else if (sessionState === 1) {
+        countdownEl.textContent = 'PIT';
+      } else if (sessionState === 2) {
+        countdownEl.textContent = 'WARM';
+      } else {
+        countdownEl.textContent = 'FORM';
+      }
+
+      // Title reflects state
+      const titleEl = mod.querySelector('.grid-title');
+      if (sessionState === 1) titleEl.textContent = 'Get In Car';
+      else if (sessionState === 2) titleEl.textContent = 'Warm Up';
+      else titleEl.textContent = 'Formation Lap';
+    }
+
+    _gridPrevSessionState = sessionState;
+    _gridLightsPhase = lightsPhase;
+  }
+
+  // ── Mini grid strip: one dot per grid slot, player highlighted ──
+  let _gridStripLastHtml = '';
+  function _renderGridStrip(total, gridded, playerPos) {
+    const container = document.getElementById('gridStrip');
+    if (!container) return;
+    if (total <= 0) { container.innerHTML = ''; _gridStripLastHtml = ''; return; }
+
+    // Build dots — only rebuild DOM when content changes
+    let html = '';
+    for (let i = 1; i <= total; i++) {
+      const isPlayer = (i === playerPos);
+      const isGridded = (i <= gridded);
+      let cls = 'grid-dot';
+      if (isPlayer) cls += ' player';
+      else if (isGridded) cls += ' gridded';
+      html += '<div class="' + cls + '"></div>';
+    }
+    if (html !== _gridStripLastHtml) {
+      container.innerHTML = html;
+      _gridStripLastHtml = html;
+    }
+  }
+
+  function updateStartLights(phase) {
+    // phase: 1-5 = red lights building (one column per phase)
+    //         6  = all red (hold)
+    //         7  = green (GO!)
+    const cols = [
+      ['light1t', 'light1b'],
+      ['light2t', 'light2b'],
+      ['light3t', 'light3b'],
+      ['light4t', 'light4b'],
+      ['light5t', 'light5b']
+    ];
+
+    if (phase >= 1 && phase <= 5) {
+      // Light columns 1..phase are red
+      for (let i = 0; i < 5; i++) {
+        const cls = i < phase ? 'lit-red' : '';
+        cols[i].forEach(id => {
+          const el = document.getElementById(id);
+          if (el) { el.className = 'light-bulb' + (cls ? ' ' + cls : ''); }
+        });
+      }
+      document.getElementById('lightsGo').classList.remove('go-visible');
+    } else if (phase === 6) {
+      // All red
+      cols.forEach(col => col.forEach(id => {
+        const el = document.getElementById(id);
+        if (el) el.className = 'light-bulb lit-red';
+      }));
+      document.getElementById('lightsGo').classList.remove('go-visible');
+    } else if (phase === 7) {
+      // All green — GO!
+      cols.forEach(col => col.forEach(id => {
+        const el = document.getElementById(id);
+        if (el) el.className = 'light-bulb lit-green';
+      }));
+      document.getElementById('lightsGo').classList.add('go-visible');
+    }
+  }
+
+  function resetLightBulbs() {
+    for (let i = 1; i <= 5; i++) {
+      ['t', 'b'].forEach(s => {
+        const el = document.getElementById('light' + i + s);
+        if (el) el.className = 'light-bulb';
+      });
+    }
+    const go = document.getElementById('lightsGo');
+    if (go) go.classList.remove('go-visible');
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+
+
+// ── modules/js/spotter.js ──
+// Spotter messages — stacking system
+
+  // ═══════════════════════════════════════════════════════════════
+  //  SPOTTER MESSAGES (stacking: new messages push old ones)
+  // ═══════════════════════════════════════════════════════════════
+  let _spotterLastGapA = 0;        // previous gap ahead (seconds)
+  let _spotterLastGapB = 0;        // previous gap behind (seconds)
+  let _spotterLastMsg = '';         // legacy — kept for announceAdjustment bypass
+  let _spotterLastPosA = 0;        // previous position of car ahead
+  let _spotterLastPosB = 0;        // previous position of car behind
+
+  // Stack management — max 3 messages visible at once
+  const _spotterMaxStack = 3;
+  const _spotterMsgDuration = 5000;  // ms per message
+
+  // SVG icons per severity (viewBox 0 0 24 24, stroke-based)
+  const _spotterIcons = {
+    default: '<path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/>',
+    'sp-warn': '<path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><path d="M12 9v4"/><circle cx="12" cy="16" r="1" fill="currentColor" stroke="none"/>',
+    'sp-danger': '<circle cx="12" cy="12" r="10"/><path d="M12 8v4"/><circle cx="12" cy="16" r="1" fill="currentColor" stroke="none"/>',
+    'sp-clear': '<path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="M22 4L12 14.01l-3-3"/>',
+    'sp-bb':  '<circle cx="12" cy="12" r="9"/><path d="M12 3v18"/><path d="M8 8h8"/><path d="M6 12h12"/>',
+    'sp-tc':  '<path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10"/><path d="M12 8v8"/><path d="M8 12h8"/>',
+    'sp-abs': '<rect x="3" y="3" width="18" height="18" rx="3"/><path d="M12 8v8"/><path d="M8 12h8"/>',
+    'sp-lap': '<circle cx="12" cy="13" r="8"/><path d="M12 9v4l2 2"/><path d="M10 2h4"/><path d="M12 2v3"/>'
+  };
+
+  function _createSpotterCard(msg, severity, headerText, iconOverride, adjType) {
+    const card = document.createElement('div');
+    card.className = 'sp-inner ' + severity;
+
+    const iconPath = _spotterIcons[iconOverride || severity] || _spotterIcons.default;
+    const iconAttr = adjType ? ` data-adj="${adjType}"` : '';
+    card.innerHTML =
+      `<svg class="sp-icon"${iconAttr} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">` +
+        iconPath +
+      '</svg>' +
+      '<div class="sp-content">' +
+        '<div class="sp-header"></div>' +
+        '<div class="sp-message"></div>' +
+      '</div>';
+
+    card.querySelector('.sp-header').textContent = headerText || 'Spotter';
+    card.querySelector('.sp-message').textContent = msg;
+
+    if (adjType) {
+      card.setAttribute('data-adj-type', adjType);
+    }
+
+    return card;
+  }
+
+  function _pushSpotterMsg(msg, severity, headerOverride, iconOverride, adjType) {
+    const stack = document.getElementById('spotterStack');
+    if (!stack || !msg) return;
+
+    // Create and insert the new card
+    const card = _createSpotterCard(msg, severity, headerOverride, iconOverride, adjType);
+    stack.prepend(card);
+
+    // Trigger WebGL glow for the newest message
+    if (window.setSpotterGlow) {
+      const glowMap = { 'sp-warn': 'warn', 'sp-danger': 'danger', 'sp-clear': 'clear' };
+      window.setSpotterGlow(glowMap[severity] || 'warn');
+    }
+
+    // Animate in on next frame
+    requestAnimationFrame(() => {
+      card.classList.add('sp-active');
+    });
+
+    // Enforce max stack size — fade out oldest if over limit
+    const cards = stack.querySelectorAll('.sp-inner:not(.sp-fading)');
+    if (cards.length > _spotterMaxStack) {
+      const oldest = cards[cards.length - 1];
+      _fadeOutCard(oldest);
+    }
+
+    // Auto-remove after duration
+    const timer = setTimeout(() => {
+      _fadeOutCard(card);
+    }, _spotterMsgDuration);
+
+    // Store timer on element for cleanup
+    card._spotterTimer = timer;
+  }
+
+  function _fadeOutCard(card) {
+    if (!card || card.classList.contains('sp-fading')) return;
+    card.classList.remove('sp-active');
+    card.classList.add('sp-fading');
+    setTimeout(() => {
+      card.remove();
+      // Turn off glow if stack is now empty
+      const stack = document.getElementById('spotterStack');
+      if (stack && stack.children.length === 0 && window.setSpotterGlow) {
+        window.setSpotterGlow('off');
+      }
+    }, 500); // matches CSS transition duration
+    if (card._spotterTimer) {
+      clearTimeout(card._spotterTimer);
+      card._spotterTimer = null;
+    }
+  }
+
+  // Extract the message "shape" — strip trailing numeric gap so
+  // "Car behind — 2.1s" and "Car behind — 2.0s" both become "Car behind —"
+  function _spotterMsgPattern(msg) {
+    return msg.replace(/[\d.]+s$/, '').trim();
+  }
+
+  // Recent-message memo: pattern → expiry timestamp
+  // Prevents any message of the same pattern from repeating within the cooldown
+  const _spotterMemo = new Map();
+  const _spotterMemoCooldown = 4000;  // ms — suppress same pattern for 4s (was 8s, too aggressive)
+
+  function _showSpotterMsg(msg, severity, headerOverride) {
+    if (!msg) return;
+    const pattern = _spotterMsgPattern(msg);
+    const now = Date.now();
+
+    // Check memo — suppress if same pattern fired recently
+    const expiry = _spotterMemo.get(pattern);
+    if (expiry && now < expiry) {
+      console.debug('[K10 Spotter] Suppressed by pattern memo (in cooldown):', pattern, 'expires in', Math.round((expiry - now) / 100) / 10, 's');
+      return;
+    }
+
+    // Also suppress exact duplicate text within a shorter window
+    const exactExpiry = _spotterMemo.get(msg);
+    if (exactExpiry && now < exactExpiry) {
+      console.debug('[K10 Spotter] Suppressed by exact match memo (in cooldown):', msg, 'expires in', Math.round((exactExpiry - now) / 100) / 10, 's');
+      return;
+    }
+
+    // Record both pattern and exact text
+    _spotterMemo.set(pattern, now + _spotterMemoCooldown);
+    _spotterMemo.set(msg, now + _spotterMemoCooldown);
+
+    // Prune old entries periodically (keep map from growing)
+    if (_spotterMemo.size > 30) {
+      for (const [k, v] of _spotterMemo) {
+        if (now >= v) _spotterMemo.delete(k);
+      }
+    }
+
+    console.debug('[K10 Spotter] Showing message:', msg, 'severity:', severity);
+    _pushSpotterMsg(msg, severity, headerOverride);
+  }
+
+  function updateSpotter(p, isDemo) {
+    const stack = document.getElementById('spotterStack');
+    if (!stack) return;
+
+    // ═══════════════════════════════════════════════════════════
+    //  RACE SESSIONS: gap-based proximity spotter
+    // ═══════════════════════════════════════════════════════════
+    const gAhead  = isDemo ? (+p['K10Motorsports.Plugin.Demo.GapAhead'] || 0)  : (+p['IRacingExtraProperties.iRacing_Opponent_Ahead_Gap'] || 0);
+    const gBehind = isDemo ? (+p['K10Motorsports.Plugin.Demo.GapBehind'] || 0) : (+p['IRacingExtraProperties.iRacing_Opponent_Behind_Gap'] || 0);
+
+    // Compute gap deltas (negative = gap shrinking = closing)
+    const deltaA = _spotterLastGapA > 0 && gAhead > 0 ? gAhead - _spotterLastGapA : 0;
+    const deltaB = _spotterLastGapB > 0 && gBehind > 0 ? gBehind - _spotterLastGapB : 0;
+
+    let msg = '';
+    let severity = '';
+
+    // ═ FIRST READING: when we first detect a car nearby (previous was 0, now > 0) ═
+    // Show basic proximity alert without requiring delta change
+    const isFirstReadingAhead = _spotterLastGapA === 0 && gAhead > 0 && gAhead <= 4.0;
+    const isFirstReadingBehind = _spotterLastGapB === 0 && gBehind > 0 && gBehind <= 4.0;
+
+    if (isFirstReadingAhead && !msg) {
+      if (gAhead <= 0.8) {
+        msg = 'Car right there — ' + gAhead.toFixed(1) + 's';
+        severity = 'sp-danger';
+      } else if (gAhead <= 2.0) {
+        msg = 'Car ahead — ' + gAhead.toFixed(1) + 's';
+        severity = 'sp-clear';
+      } else {
+        msg = 'Car ahead — ' + gAhead.toFixed(1) + 's';
+        severity = 'sp-warn';
+      }
+    }
+
+    if (isFirstReadingBehind && !msg) {
+      if (gBehind <= 0.8) {
+        msg = 'Car alongside — ' + gBehind.toFixed(1) + 's';
+        severity = 'sp-danger';
+      } else if (gBehind <= 2.0) {
+        msg = 'Car behind — ' + gBehind.toFixed(1) + 's';
+        severity = 'sp-warn';
+      } else {
+        msg = 'Car behind — ' + gBehind.toFixed(1) + 's';
+        severity = 'sp-warn';
+      }
+    }
+
+    // ═ Threat behind — car closing on us ═
+    if (!msg && gBehind > 0 && gBehind <= 0.8) {
+      msg = 'Car alongside — ' + gBehind.toFixed(1) + 's';
+      severity = 'sp-danger';
+    } else if (!msg && gBehind > 0 && gBehind <= 2.0) {
+      if (deltaB < -0.03) {
+        msg = 'Car closing — ' + gBehind.toFixed(1) + 's';
+        severity = 'sp-warn';
+      } else if (_spotterLastGapB > 0) {  // Only show "car behind" if we've seen the gap before
+        msg = 'Car behind — ' + gBehind.toFixed(1) + 's';
+        severity = 'sp-warn';
+      }
+    } else if (!msg && gBehind > 0 && gBehind <= 4.0 && deltaB < -0.03) {
+      msg = 'Car reeling in — ' + gBehind.toFixed(1) + 's';
+      severity = 'sp-warn';
+    }
+
+    // ═ Opportunity ahead — we're closing on the car ahead ═
+    if (!msg && gAhead > 0 && gAhead <= 0.8) {
+      msg = 'Car right there — ' + gAhead.toFixed(1) + 's';
+      severity = 'sp-danger';
+    } else if (!msg && gAhead > 0 && gAhead <= 2.0) {
+      if (deltaA < -0.03) {
+        msg = 'Closing on car ahead — ' + gAhead.toFixed(1) + 's';
+        severity = 'sp-clear';
+      } else if (deltaA > 0.03) {
+        msg = 'Car ahead pulling away — ' + gAhead.toFixed(1) + 's';
+        severity = 'sp-warn';
+      } else if (_spotterLastGapA > 0) {  // Only show "car ahead" if we've seen the gap before
+        msg = 'Car ahead — ' + gAhead.toFixed(1) + 's';
+        severity = 'sp-clear';
+      }
+    } else if (!msg && gAhead > 0 && gAhead <= 4.0 && deltaA < -0.03) {
+      msg = 'Gaining on car ahead — ' + gAhead.toFixed(1) + 's';
+      severity = 'sp-clear';
+    }
+
+    // ═ Pass events — position swaps ═
+    if (!msg && _spotterLastGapA > 0 && _spotterLastGapA < 3.0 && gAhead > _spotterLastGapA + 2.0 && gBehind > 0 && gBehind < 3.0) {
+      msg = 'Clear — position gained';
+      severity = 'sp-clear';
+    }
+    if (!msg && _spotterLastGapB > 0 && _spotterLastGapB < 3.0 && gBehind > _spotterLastGapB + 2.0 && gAhead > 0 && gAhead < 3.0) {
+      msg = 'Position lost';
+      severity = 'sp-danger';
+    }
+
+    _spotterLastGapA = gAhead;
+    _spotterLastGapB = gBehind;
+
+    if (msg) _showSpotterMsg(msg, severity);
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //  IN-CAR ADJUSTMENT ANNOUNCEMENTS
+  //  Called from poll-engine when BB / TC / ABS values change.
+  //  Shows a brief spotter-style callout with the new value.
+  //  Reuses existing adjustment card instead of stacking new ones.
+  // ═══════════════════════════════════════════════════════════════
+  window.announceAdjustment = function(type, value, direction) {
+    const stack = document.getElementById('spotterStack');
+    if (!stack) return;
+
+    const arrow = direction > 0 ? '\u25B2' : direction < 0 ? '\u25BC' : '';
+    let label, icon;
+    switch (type) {
+      case 'bb':
+        label = 'Brake Bias ' + arrow + ' ' + (typeof value === 'number' ? value.toFixed(1) : value);
+        icon = 'sp-bb';
+        break;
+      case 'tc':
+        label = 'TC ' + arrow + ' ' + Math.round(value);
+        icon = 'sp-tc';
+        break;
+      case 'abs':
+        label = 'ABS ' + arrow + ' ' + Math.round(value);
+        icon = 'sp-abs';
+        break;
+      default:
+        label = type + ' ' + arrow + ' ' + value;
+        icon = 'default';
+    }
+
+    // Check if an adjustment card of this type already exists in the stack
+    const existingCard = stack.querySelector(`[data-adj-type="${type}"]`);
+    if (existingCard) {
+      // Update existing card text
+      const msgEl = existingCard.querySelector('.sp-message');
+      if (msgEl) {
+        msgEl.textContent = label;
+      }
+      // Reset auto-dismiss timer
+      if (existingCard._spotterTimer) {
+        clearTimeout(existingCard._spotterTimer);
+      }
+      const timer = setTimeout(() => {
+        _fadeOutCard(existingCard);
+      }, _spotterMsgDuration);
+      existingCard._spotterTimer = timer;
+
+      // Flash the card to provide visual feedback
+      existingCard.classList.remove('sp-active');
+      requestAnimationFrame(() => {
+        existingCard.classList.add('sp-active');
+      });
+    } else {
+      // No existing adjustment card — create a new one
+      _pushSpotterMsg(label, 'sp-clear', 'Adjustment', icon, type);
+    }
+  };
+
+  // ═══════════════════════════════════════════════════════════════
+
+  // ═══════════════════════════════════════════════════════════════
+  //  TIRE / TRACK CONDITION MISMATCH DETECTION
+  // ═══════════════════════════════════════════════════════════════
+  let _tyreMismatchLastAlert = 0;
+  const _tyreMismatchCooldown = 60000; // Only alert once per minute
+
+  window.checkTyreMismatch = function(p, isDemo) {
+    const pre = isDemo ? 'K10Motorsports.Plugin.Demo.DS.' : 'K10Motorsports.Plugin.DS.';
+    const isWet = +(p[pre + 'WeatherWet']) === 1;
+    const trackWetness = +(p[pre + 'TrackWetness']) || 0;
+
+    // Tire compound: try multiple possible property paths
+    // Some SimHub plugins expose TireCompound directly; others use raw telemetry indices
+    let onWetTires = false;
+
+    // Try K10 plugin custom property first
+    const compound = +(p[pre + 'TireCompound']);
+    if (!isNaN(compound)) {
+      // 1 = wet tires, 0 = dry tires
+      onWetTires = compound === 1;
+    } else {
+      // Fallback: we don't have reliable tire compound data
+      return;
+    }
+
+    const now = Date.now();
+    if (now - _tyreMismatchLastAlert < _tyreMismatchCooldown) return;
+
+    let msg = '';
+    let severity = '';
+
+    // Wet weather but on dry tires — critical alert
+    if (isWet && !onWetTires && trackWetness > 0.3) {
+      msg = 'Dry tires on wet track — consider pitting for wets';
+      severity = 'sp-warn';
+    }
+    // Dry weather but on wet tires — performance warning
+    else if (!isWet && onWetTires && trackWetness < 0.1) {
+      msg = 'Wet tires on dry track — losing grip to compound';
+      severity = 'sp-warn';
+    }
+
+    if (msg) {
+      _tyreMismatchLastAlert = now;
+      _showSpotterMsg(msg, severity, 'Conditions');
+    }
+  };
+
+
+// ── modules/js/fps.js ──
+// FPS counter
+
+  // ═══════════════════════════════════════════════════════════════
+  //  FPS COUNTER — uses game framerate from API, not browser render rate
+  // ═══════════════════════════════════════════════════════════════
+  let _apiFps = 0;
+
+  function setApiFps(val) {
+    _apiFps = val;
+  }
+
+  let _fpsLastUpdate = 0;
+  function updateFps() {
+    const now = performance.now();
+    if (now - _fpsLastUpdate < 1000) return; // update display once per second
+    _fpsLastUpdate = now;
+    const el = document.getElementById('dsFps');
+    if (el) el.textContent = _apiFps > 0 ? Math.round(_apiFps) : '—';
+  }
+
+
+// ── modules/js/webgl.js ──
+// WebGL FX ENGINE
+
+  // ═══════════════════════════════════════════════════════════════
+  //  WebGL FX ENGINE — Tachometer + Post-Processing
+  // ═══════════════════════════════════════════════════════════════
+  (function initWebGLFX() {
+    'use strict';
+
+    /* ── GL helpers ── */
+    function createShader(gl, type, src) {
+      const s = gl.createShader(type);
+      gl.shaderSource(s, src);
+      gl.compileShader(s);
+      if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) {
+        console.warn('Shader compile:', gl.getShaderInfoLog(s));
+        gl.deleteShader(s); return null;
+      }
+      return s;
+    }
+    function createProgram(gl, vs, fs) {
+      const p = gl.createProgram();
+      gl.attachShader(p, vs); gl.attachShader(p, fs);
+      gl.linkProgram(p);
+      if (!gl.getProgramParameter(p, gl.LINK_STATUS)) {
+        console.warn('Program link:', gl.getProgramInfoLog(p));
+        return null;
+      }
+      return p;
+    }
+    function initGL(canvasId) {
+      const c = document.getElementById(canvasId);
+      if (!c) return null;
+      const gl = c.getContext('webgl2', { alpha: true, premultipliedAlpha: true, antialias: true });
+      if (!gl) { console.warn('WebGL2 not available for', canvasId); return null; }
+      return { canvas: c, gl };
+    }
+    function resizeCanvas(canvas, gl) {
+      const r = canvas.parentElement.getBoundingClientRect();
+      const dpr = window.devicePixelRatio || 1;
+      const w = Math.round(r.width * dpr);
+      const h = Math.round(r.height * dpr);
+      if (canvas.width !== w || canvas.height !== h) {
+        canvas.width = w; canvas.height = h;
+        gl.viewport(0, 0, w, h);
+      }
+    }
+    /** Half-DPR variant for glare canvases — trades sharpness for performance */
+    function resizeCanvasHalfDPR(canvas, gl) {
+      const r = canvas.parentElement.getBoundingClientRect();
+      const dpr = Math.max((window.devicePixelRatio || 1) * 0.5, 1);
+      const w = Math.round(r.width * dpr);
+      const h = Math.round(r.height * dpr);
+      if (canvas.width !== w || canvas.height !== h) {
+        canvas.width = w; canvas.height = h;
+        gl.viewport(0, 0, w, h);
+      }
+    }
+
+    /* ════════════════════════════════════════════
+       TACHOMETER FX — bloom, heat distortion
+       ════════════════════════════════════════════ */
+    const tachoCtx = initGL('tachoGlCanvas');
+    let _tachoRpm = 0;  // updated from main loop
+    let _tachoTime = 0;
+
+    if (tachoCtx) {
+      const { canvas: tC, gl: tGL } = tachoCtx;
+
+      // Full-screen quad vertex shader
+      const quadVS = `#version 300 es
+        in vec2 aPos;
+        out vec2 vUV;
+        void main() {
+          vUV = aPos * 0.5 + 0.5;
+          gl_Position = vec4(aPos, 0.0, 1.0);
+        }`;
+
+      // Tachometer fragment shader — bloom glow + heat distortion
+      // uDPR compensates for HiDPI/Retina displays where the same UV-space
+      // effect is spread over 2-4× more physical pixels, making glow appear dimmer.
+      const tachoFS = `#version 300 es
+        precision highp float;
+        in vec2 vUV;
+        out vec4 fragColor;
+
+        uniform float uRpm;       // 0.0 - 1.0
+        uniform float uTime;
+        uniform vec2  uRes;
+        uniform float uDPR;       // devicePixelRatio (1.0 on 1× screens, 2.0 on Retina)
+
+        // Color zones: green < 0.55, yellow < 0.73, red < 0.91, redline >= 0.91
+        vec3 rpmColor(float r) {
+          if (r < 0.55) return vec3(0.18, 0.82, 0.34);  // green
+          if (r < 0.73) return vec3(0.95, 0.75, 0.15);  // amber
+          return vec3(0.92, 0.22, 0.20);                 // red
+        }
+
+        // Smooth noise for heat distortion
+        float hash(vec2 p) {
+          return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+        }
+        float noise(vec2 p) {
+          vec2 i = floor(p), f = fract(p);
+          f = f * f * (3.0 - 2.0 * f);
+          return mix(mix(hash(i), hash(i + vec2(1,0)), f.x),
+                     mix(hash(i + vec2(0,1)), hash(i + vec2(1,1)), f.x), f.y);
+        }
+
+        void main() {
+          vec2 uv = vUV;
+          // Scale glow spread so it looks the same on 1× and 2× screens
+          float dprScale = max(uDPR, 1.0);
+          float dpr2 = dprScale * dprScale;  // quadratic — compensates for HiDPI area scaling
+
+          // Heat distortion — only active at high RPM
+          float heatIntensity = smoothstep(0.75, 0.95, uRpm) * 0.6 * dpr2;
+          if (heatIntensity > 0.0) {
+            float n1 = noise(uv * 8.0 + uTime * 3.0) * 2.0 - 1.0;
+            float n2 = noise(uv * 6.0 - uTime * 2.5 + 50.0) * 2.0 - 1.0;
+            uv += vec2(n1, n2) * heatIntensity * 0.012;
+          }
+
+          // Bloom glow — bar region is roughly bottom 35% of the block
+          float barTop = 0.35;  // bars live in bottom portion
+          float barY = smoothstep(0.0, barTop, uv.y);
+          float inBar = 1.0 - barY;
+
+          // Horizontal fill: how far the RPM lights extend
+          float fillX = uRpm;
+          float xDist = max(0.0, uv.x - fillX);
+          // Softer falloff on HiDPI so bloom covers equivalent visual area
+          float glowFalloff = exp(-xDist * (6.0 / dpr2)) * inBar;
+
+          // Color based on the edge of the lit region
+          vec3 col = rpmColor(uRpm);
+
+          // Pulsing intensity at redline
+          float pulse = 1.0;
+          if (uRpm >= 0.91) {
+            pulse = 0.85 + 0.15 * sin(uTime * 18.0);
+          }
+
+          // Bloom: soft glow radiating from lit segments — boosted on HiDPI
+          float bloom = glowFalloff * uRpm * 1.2 * dpr2 * pulse;
+
+          // Upward glow bleed above the bars
+          float aboveBar = smoothstep(barTop, barTop + 0.3 * dpr2, uv.y);
+          float upGlow = aboveBar * exp(-abs(uv.x - fillX * 0.5) * (3.0 / dpr2)) * uRpm * 0.35 * dpr2 * pulse;
+
+          // Edge highlight along the top of lit region
+          float edgeGlow = exp(-abs(uv.y - barTop) * (25.0 / dpr2)) * smoothstep(0.0, fillX, uv.x) * uRpm * 0.5 * dpr2;
+
+          float alpha = bloom + upGlow + edgeGlow;
+          vec3 final = col * alpha;
+
+          // ── Redline full-block flash strobe ──
+          if (uRpm >= 0.91) {
+            float redStr = smoothstep(0.91, 0.96, uRpm);
+            // Hard strobe
+            float flash = pow(0.5 + 0.5 * sin(uTime * 22.0), 4.0);
+            // Secondary faster flicker
+            float flicker = 0.8 + 0.2 * sin(uTime * 55.0 + uv.x * 12.0);
+            // Gentle vignette — even glow with soft falloff at edges
+            float vig = 1.0 - 0.2 * length((uv - 0.5) * vec2(0.8, 1.4));
+            float flashA = flash * flicker * redStr * vig * 0.5 * dpr2;
+            vec3 flashCol = vec3(0.95, 0.08, 0.03);
+            final += flashCol * flashA;
+            alpha += flashA;
+            // Scanline overlay for CRT intensity
+            float scan = 0.88 + 0.12 * sin(uv.y * uRes.y * 0.4 + uTime * 45.0);
+            final *= scan;
+            alpha *= scan;
+          }
+
+          float maxAlpha = dprScale > 1.1 ? 0.95 : 0.85;
+          alpha = clamp(alpha, 0.0, maxAlpha);
+          fragColor = vec4(final * alpha, alpha);
+        }`;
+
+      const vs = createShader(tGL, tGL.VERTEX_SHADER, quadVS);
+      const fs = createShader(tGL, tGL.FRAGMENT_SHADER, tachoFS);
+      const prog = createProgram(tGL, vs, fs);
+
+      if (prog) {
+        const aPos = tGL.getAttribLocation(prog, 'aPos');
+        const uRpm = tGL.getUniformLocation(prog, 'uRpm');
+        const uTime = tGL.getUniformLocation(prog, 'uTime');
+        const uRes = tGL.getUniformLocation(prog, 'uRes');
+        const uDPR = tGL.getUniformLocation(prog, 'uDPR');
+
+        // Fullscreen quad
+        const buf = tGL.createBuffer();
+        tGL.bindBuffer(tGL.ARRAY_BUFFER, buf);
+        tGL.bufferData(tGL.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, 1,1]), tGL.STATIC_DRAW);
+
+        tGL.enable(tGL.BLEND);
+        tGL.blendFunc(tGL.ONE, tGL.ONE_MINUS_SRC_ALPHA);
+
+        window._tachoFXFrame = function(dt) {
+          resizeCanvas(tC, tGL);
+          _tachoTime += dt;
+
+          tGL.clearColor(0, 0, 0, 0);
+          tGL.clear(tGL.COLOR_BUFFER_BIT);
+
+          // ── Main bloom/distortion pass ──
+          tGL.useProgram(prog);
+          tGL.bindBuffer(tGL.ARRAY_BUFFER, buf);
+          tGL.enableVertexAttribArray(aPos);
+          tGL.vertexAttribPointer(aPos, 2, tGL.FLOAT, false, 0, 0);
+          tGL.uniform1f(uRpm, _tachoRpm);
+          tGL.uniform1f(uTime, _tachoTime);
+          tGL.uniform2f(uRes, tC.width, tC.height);
+          tGL.uniform1f(uDPR, window.devicePixelRatio || 1.0);
+          tGL.drawArrays(tGL.TRIANGLE_STRIP, 0, 4);
+        };
+      }
+    }
+
+    /* ════════════════════════════════════════════
+       PEDAL VALUES — shared state used by postfx pipeline
+       (histogram bars are now rendered as HTML/CSS in webgl-helpers.js)
+       ════════════════════════════════════════════ */
+    let _pedalValues = { thr: 0, brk: 0, clt: 0 };
+
+    /* ════════════════════════════════════════════
+       POST-PROCESSING PIPELINE — panel-masked effects
+       Single GL context, one draw call. Renders at half DPR.
+       ALL effects are masked to panel boundaries so nothing
+       bleeds onto the game footage.
+
+       Effects:
+         1. Panel edge glow (per-source registry, up to 8)
+         2. G-force vignette (lateral + longitudinal darkening)
+         3. Speed chromatic aberration (RGB split near panels)
+         4. Brake heat wash (warm bloom from brake zone)
+         5. RPM redline pulse (panel-edge red flicker)
+       ════════════════════════════════════════════ */
+    let _postfxTime = 0;
+
+    // ══════════════════════════════════════════════════════════════
+    //  PERFORMANCE INSTRUMENTATION — glare shader perf tracking
+    // ══════════════════════════════════════════════════════════════
+    //  Measures:
+    //    • FPS (frames per second, 1s rolling window)
+    //    • Frame time (ms per glare draw call, via EXT_disjoint_timer_query)
+    //    • Draw call skip rate (% of frames where glare had nothing to draw)
+    //
+    //  Access from console:  window._glarePerf
+    //  Logs a summary every 5 seconds when ambient light is active.
+    // ══════════════════════════════════════════════════════════════
+    const _glarePerf = {
+      fps: 0,
+      frameTimeMs: 0,           // GPU time per glare draw (0 if timer unavailable)
+      drawCalls: 0,
+      skippedFrames: 0,
+      totalFrames: 0,
+      _frameTimes: [],          // last 60 frame timestamps for FPS calc
+      _gpuQueries: [],          // pending GPU timer queries
+      _timerExt: null,          // EXT_disjoint_timer_query_webgl2
+      _lastLogSec: 0,
+      _enabled: false,
+
+      /** Call once after GL context is ready */
+      init(gl) {
+        // Try to get GPU timer extension (available on most Windows drivers)
+        this._timerExt = gl.getExtension('EXT_disjoint_timer_query_webgl2');
+        if (this._timerExt) {
+          console.log('[GlarePerf] GPU timer query available — frame timing enabled');
+        } else {
+          console.log('[GlarePerf] GPU timer query unavailable — FPS-only mode');
+        }
+        this._enabled = true;
+      },
+
+      /** Call at the START of each glare frame */
+      beginFrame(gl) {
+        if (!this._enabled) return null;
+        this.totalFrames++;
+
+        // FPS: rolling 1-second window
+        const now = performance.now();
+        this._frameTimes.push(now);
+        while (this._frameTimes.length > 0 && this._frameTimes[0] < now - 1000) {
+          this._frameTimes.shift();
+        }
+        this.fps = this._frameTimes.length;
+
+        // GPU timer: start query if extension available
+        if (this._timerExt) {
+          const query = gl.createQuery();
+          gl.beginQuery(this._timerExt.TIME_ELAPSED_EXT, query);
+          return query;
+        }
+        return null;
+      },
+
+      /** Call at the END of each glare frame */
+      endFrame(gl, query) {
+        if (!this._enabled) return;
+        this.drawCalls++;
+
+        if (query && this._timerExt) {
+          gl.endQuery(this._timerExt.TIME_ELAPSED_EXT);
+          this._gpuQueries.push({ query, time: performance.now() });
+        }
+
+        // Harvest completed GPU queries
+        this._harvestQueries(gl);
+
+        // Log every 5 seconds
+        const sec = Math.floor(performance.now() / 1000);
+        if (sec % 5 === 0 && sec !== this._lastLogSec) {
+          this._lastLogSec = sec;
+          const skipPct = this.totalFrames > 0
+            ? ((this.skippedFrames / this.totalFrames) * 100).toFixed(1)
+            : '0.0';
+          console.log(
+            `[GlarePerf] FPS=${this.fps} | GPU=${this.frameTimeMs.toFixed(2)}ms | ` +
+            `draws=${this.drawCalls} skipped=${skipPct}% | ` +
+            `ambient=${window._ambientGL ? window._ambientGL.lum.toFixed(2) : 'off'}`
+          );
+        }
+      },
+
+      /** Mark a frame as skipped (no draw call needed) */
+      markSkipped() {
+        if (!this._enabled) return;
+        this.totalFrames++;
+        this.skippedFrames++;
+
+        // Still update FPS counter
+        const now = performance.now();
+        this._frameTimes.push(now);
+        while (this._frameTimes.length > 0 && this._frameTimes[0] < now - 1000) {
+          this._frameTimes.shift();
+        }
+        this.fps = this._frameTimes.length;
+      },
+
+      /** Harvest completed GPU timer queries */
+      _harvestQueries(gl) {
+        const ext = this._timerExt;
+        if (!ext) return;
+        // Check for GPU disjoint (driver reset, etc.)
+        const disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
+        const pending = this._gpuQueries;
+        let i = 0;
+        while (i < pending.length) {
+          const q = pending[i];
+          const available = gl.getQueryParameter(q.query, gl.QUERY_RESULT_AVAILABLE);
+          if (available) {
+            if (!disjoint) {
+              const ns = gl.getQueryParameter(q.query, gl.QUERY_RESULT);
+              this.frameTimeMs = ns / 1e6;  // nanoseconds → milliseconds
+            }
+            gl.deleteQuery(q.query);
+            pending.splice(i, 1);
+          } else if (performance.now() - q.time > 2000) {
+            // Stale query — drop it
+            gl.deleteQuery(q.query);
+            pending.splice(i, 1);
+          } else {
+            i++;
+          }
+        }
+      },
+
+      /** Get a summary snapshot for external consumption */
+      snapshot() {
+        return {
+          fps: this.fps,
+          gpuMs: this.frameTimeMs,
+          drawCalls: this.drawCalls,
+          skippedPct: this.totalFrames > 0
+            ? ((this.skippedFrames / this.totalFrames) * 100)
+            : 0,
+          totalFrames: this.totalFrames,
+        };
+      }
+    };
+    window._glarePerf = _glarePerf;
+
+    // Smoothed telemetry for post-processing
+    const _pfx = {
+      speed: 0, speedTarget: 0,
+      rpm: 0, rpmTarget: 0,
+      latG: 0, latGTarget: 0,
+      longG: 0, longGTarget: 0,
+      brakeHeat: 0,
+      yawRate: 0, yawRateTarget: 0,
+      steer: 0, steerTarget: 0,
+    };
+    // Expose for CSS-only plastic mode (ambient-light.js reads these)
+    window._pfx = _pfx;
+    const _pfxLerp = { speed: 3.0, rpm: 8.0, latG: 5.0, longG: 5.0, yawRate: 4.0, steer: 6.0 };
+
+    /** Resize a full-screen canvas at half DPR for soft effects */
+    function resizeCanvasScreen(canvas, gl) {
+      const dpr = Math.max((window.devicePixelRatio || 1) * 0.5, 1);
+      const w = Math.round(window.innerWidth * dpr);
+      const h = Math.round(window.innerHeight * dpr);
+      if (canvas.width !== w || canvas.height !== h) {
+        canvas.width = w; canvas.height = h;
+        gl.viewport(0, 0, w, h);
+      }
+    }
+
+    const glareCtx = initGL('glareCanvas');
+    if (glareCtx) {
+      const { canvas: gC, gl: gGL } = glareCtx;
+
+      const quadVS = `#version 300 es
+        in vec2 aPos;
+        out vec2 vUV;
+        void main() {
+          vUV = aPos * 0.5 + 0.5;
+          gl_Position = vec4(aPos, 0.0, 1.0);
+        }`;
+
+      // ── Post-processing fragment shader ──
+      // All effects masked to panel rects — nothing escapes onto the game.
+      const postfxFS = `#version 300 es
+        precision highp float;
+        in vec2 vUV;
+        out vec4 fragColor;
+
+        // Panel glow sources (pedals, etc.)
+        uniform float uTime;
+        uniform vec4  uRect[8];      // glow source rects
+        uniform vec4  uColor[8];     // glow source colors
+        uniform int   uCount;        // active glow sources
+
+        // Panel mask rects (ALL visible panels)
+        uniform vec4  uPanelRect[16];
+        uniform float uPanelAlpha[16]; // computed opacity per panel
+        uniform vec2  uPanelRadius[16]; // border-radius in UV space (rx, ry)
+        uniform int   uPanelCount;
+
+        // Telemetry
+        uniform float uSpeed;
+        uniform float uRpm;
+        uniform float uLatG;
+        uniform float uLongG;
+        uniform float uBrakeHeat;
+        uniform float uYawRate;
+        uniform float uSteer;   // steering wheel angle, -1..+1 (negative=left)
+
+        // Ambient light (from Electron screen capture)
+        uniform vec3  uAmbientColor;  // 0-1 RGB
+        uniform float uAmbientLum;    // perceptual luminance 0-1
+        uniform int   uAmbientMode;   // 0=off, 1=matte, 2=reflective
+
+        // ── Rounded-rect SDF — negative inside, positive outside ──
+        float roundedRectSDF(vec2 uv, vec4 rect, vec2 radius) {
+          vec2 center = rect.xy + rect.zw * 0.5;
+          vec2 halfSize = rect.zw * 0.5;
+          vec2 d = abs(uv - center) - halfSize + radius;
+          return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0) - min(radius.x, radius.y);
+        }
+
+        // ── Panel mask: 0.0 outside all panels, panel opacity inside ──
+        // Uses rounded-rect SDF so glare edges match CSS border-radius.
+        // Respects each panel's computed CSS opacity.
+        float panelMask(vec2 uv) {
+          float mask = 0.0;
+          for (int i = 0; i < 16; i++) {
+            if (i >= uPanelCount) break;
+            vec4 r = uPanelRect[i];
+            vec2 rad = uPanelRadius[i];
+            float sdf = roundedRectSDF(uv, r, rad);
+            float fw = fwidth(sdf);  // 1-pixel feather, DPR-independent
+            float m = 1.0 - smoothstep(-fw, fw, sdf);
+            m *= uPanelAlpha[i];
+            mask = max(mask, m);
+          }
+          return mask;
+        }
+
+        float pulse(float t, float speed, float base) {
+          return base + (1.0 - base) * (0.5 + 0.5 * sin(t * speed * 0.6));
+        }
+
+        // ── AMBIENT GLOW — single centered radial, panel-masked ──
+        // ── Steer-rotated UV helper ──
+        // Rotates UV around a center point by -uSteer (inverted: glare moves
+        // opposite the wheel).  ±1 → ∓0.25 rad ≈ ∓14°.
+        // PERF-LITE: rotation reduced 75% (0.25 → 0.0625 rad ≈ ±3.6°)
+        vec2 steerRotateUV(vec2 uv, vec2 center) {
+          float a = -uSteer * 0.0625;
+          float cs = cos(a), sn = sin(a);
+          vec2 d = uv - center;
+          return vec2(d.x * cs - d.y * sn, d.x * sn + d.y * cs) + center;
+        }
+
+        // ── PERF-LITE: single centered radial glow + sweep only ──
+        // Removed: shimmer (sin×sin pow4), edgeBloom (duplicate panelMask loop).
+        // Kept: center glow, bloom pulse, light sweep — enough to sell
+        // sun/cloud movement across glass surfaces.
+        vec4 ambientGlow(vec2 uv) {
+          if (uAmbientMode == 0 || uAmbientLum < 0.01) return vec4(0.0);
+          float modeMul = (uAmbientMode == 1) ? 0.5 : 1.0;
+
+          // Speed scales movement: idle ×0.075, full speed ×0.5 (75% slower)
+          float spdMul = 0.075 + uSpeed * 0.425;
+
+          // Single radial glow from screen center
+          vec2 center = vec2(0.5, 0.45);
+          float dist = length(uv - center);
+          float glow = exp(-dist * dist * 1.8) * 2.0;
+
+          // Bloom pulse: slow breathing
+          float bloom = 0.8 + 0.2 * sin(uTime * 1.5 * spdMul);
+          glow *= bloom;
+
+          // Steer-rotated UV for sweep (rotation at 25% of original)
+          vec2 rUV = steerRotateUV(uv, center);
+
+          // Light sweep: diagonal band simulating sun/cloud movement
+          float sweep = sin(rUV.x * 2.0 + rUV.y * 1.3 - uTime * 0.2 * spdMul) * 0.5 + 0.5;
+          sweep = pow(sweep, 3.0) * 0.7;
+
+          float total = (glow + sweep) * uAmbientLum * modeMul;
+          total = min(total, 2.5);
+
+          vec3 col = uAmbientColor * total;
+          float alpha = total * 0.8;
+          return vec4(col, clamp(alpha, 0.0, 1.0));
+        }
+
+        // EFFECT 1: Panel glow — top-edge reflective source
+        // Light originates from the top-center of each panel
+        // and falls off downward, like overhead light hitting glass.
+        vec4 panelGlow(vec2 uv) {
+          vec3 col = vec3(0.0);
+          float alpha = 0.0;
+          for (int i = 0; i < 8; i++) {
+            if (i >= uCount) break;
+            vec4 rect = uRect[i];
+            vec4 clr  = uColor[i];
+            float inten = clr.a;
+            if (inten < 0.01) continue;
+
+            // Glow source: top-center of panel, 20% down from top edge
+            vec2 src = vec2(rect.x + rect.z * 0.5, rect.y + rect.w * 0.20);
+
+            // Steer-rotate UV around panel center so light tilts opposite the wheel
+            vec2 panelCenter = rect.xy + rect.zw * 0.5;
+            vec2 sUV = steerRotateUV(uv, panelCenter);
+
+            // Elliptical falloff: wider horizontally, tighter vertically
+            vec2 delta = sUV - src;
+            delta.x /= max(rect.z * 0.7, 0.01);  // scale by panel width
+            delta.y /= max(rect.w * 0.5, 0.01);   // tighter vertical
+            float dist = length(delta);
+
+            // Downward bias: glow falls toward bottom of panel (uses rotated UV)
+            float downBias = smoothstep(rect.y, rect.y + rect.w, sUV.y);
+            float spread = 3.0;
+            float glow = exp(-dist * dist * spread) * inten;
+            // Brighter at top, dimmer toward bottom
+            glow *= mix(1.0, 0.3, downBias);
+
+            // PERF-LITE: pulse speed reduced 75% (3.5→0.875, 2.0→0.5)
+            float p = pulse(uTime, 0.875 + inten * 0.5, 0.88);
+            glow *= p;
+
+            col += clr.rgb * glow * 0.9;
+            alpha += glow * 0.4;
+          }
+          return vec4(col, clamp(alpha, 0.0, 0.70));
+        }
+
+        // EFFECT 2: G-force vignette (masked to panels)
+        vec4 gForceVignette(vec2 uv) {
+          float totalG = length(vec2(uLatG, uLongG));
+          if (totalG < 0.3) return vec4(0.0);
+          float gIntensity = smoothstep(0.3, 3.0, totalG);
+          vec2 center = vec2(0.5);
+          float dist = length(uv - center) * 1.4;
+          float vig = smoothstep(0.3, 1.0, dist);
+          vec2 bias = vec2(-uLatG * 0.15, uLongG * 0.12);
+          float biasedDist = length(uv - center + bias) * 1.4;
+          float biasedVig = smoothstep(0.25, 1.0, biasedDist);
+          float finalVig = max(vig, biasedVig) * gIntensity * 0.35;
+          vec3 tint = mix(
+            vec3(0.02, 0.03, 0.06),
+            vec3(0.06, 0.02, 0.01),
+            smoothstep(0.0, 1.5, abs(uLongG))
+          );
+          return vec4(tint, finalVig);
+        }
+
+        // EFFECT 3: Speed chromatic aberration — REMOVED for performance
+        // (dual pow(sin) streaks + steer rotation per pixel, rarely visible)
+        vec4 speedAberration(vec2 uv) { return vec4(0.0); }
+
+        // EFFECT 4: Brake heat wash — REMOVED for performance
+        // (double sin×sin shimmer per pixel, niche visual)
+        vec4 brakeHeatWash(vec2 uv) { return vec4(0.0); }
+
+        // EFFECT 5: RPM redline pulse
+        vec4 rpmRedlinePulse(vec2 uv) {
+          if (uRpm < 0.88) return vec4(0.0);
+          float rpmIntensity = smoothstep(0.88, 0.98, uRpm);
+          float strobe = 1.0;
+          if (uRpm > 0.95) {
+            strobe = 0.6 + 0.4 * abs(sin(uTime * 18.0));
+          }
+          // Edge glow relative to nearby panel edges
+          float edgeDist = min(min(uv.x, 1.0 - uv.x), min(uv.y, 1.0 - uv.y));
+          float edgeGlow = exp(-edgeDist * 30.0);
+          float alpha = edgeGlow * rpmIntensity * strobe * 0.40;
+          vec3 col = vec3(0.95, 0.10, 0.05);
+          return vec4(col * alpha, alpha);
+        }
+
+        // ── Spherical glass reflection per panel ──
+        // Each module has a convex glass dome surface that catches a specular
+        // highlight from an overhead light source, shifted by steering angle.
+        // Dome height scales with ambient mode: full in reflective, 50% in matte.
+        vec4 glassReflection(vec2 uv) {
+          if (uAmbientMode == 0 || uAmbientLum < 0.005) return vec4(0.0);
+
+          // Dome height: reflective=1.0, matte=0.5
+          float domeScale = (uAmbientMode == 1) ? 0.5 : 1.0;
+
+          // Light source: overhead, slightly shifted by steering
+          vec3 lightDir = normalize(vec3(
+            -0.15 + uSteer * 0.12,   // x: steer shifts highlight
+            -0.3,                     // y: slightly above center
+            1.0                       // z: toward viewer
+          ));
+
+          vec3 totalCol = vec3(0.0);
+          float totalAlpha = 0.0;
+
+          for (int i = 0; i < 16; i++) {
+            if (i >= uPanelCount) break;
+            vec4 r = uPanelRect[i];
+            if (r.z < 0.001 || r.w < 0.001) continue;
+
+            // Normalize UV within this panel
+            vec2 local = (uv - r.xy) / r.zw;
+            if (local.x < 0.0 || local.x > 1.0 || local.y < 0.0 || local.y > 1.0) continue;
+
+            // SDF-based soft edge (reuse panel SDF for feathering)
+            float sdf = roundedRectSDF(uv, r, uPanelRadius[i]);
+            float fw = fwidth(sdf);
+            float inside = smoothstep(fw, -fw * 2.0, sdf);
+            if (inside < 0.001) continue;
+
+            // Map local coords to box-shaped dome surface normal
+            // The dome fills the entire panel rect, curving down at edges
+            vec2 centered = local - 0.5;  // -0.5..+0.5
+
+            // Box dome: use rounded-rect distance instead of circular
+            // Panel border-radius in local 0-1 space
+            vec2 panelRLocal = uPanelRadius[i] / r.zw;
+            // SDF of a rounded rect in local space (0 at boundary, negative inside)
+            vec2 q = abs(centered) - (0.5 - panelRLocal);
+            float boxSdf = length(max(q, 0.0)) + min(max(q.x, q.y), 0.0) - min(panelRLocal.x, panelRLocal.y);
+            // Map to 0 at center, 1 at panel edge
+            float edgeDist = smoothstep(-0.5, 0.0, boxSdf);
+
+            // Dome height: 1 at center, 0 at edges (box-shaped falloff)
+            float z = (1.0 - edgeDist) * domeScale;
+            if (z < 0.001) continue;
+
+            // Surface normal: gradient of the dome height
+            // Approximate partial derivatives from the box SDF
+            vec2 grad = centered * 2.0;  // base gradient pointing outward
+            // Steepen near edges using the box shape
+            float edgeSteep = smoothstep(0.3, 0.5, max(abs(centered.x), abs(centered.y)));
+            grad *= (1.0 + edgeSteep * 3.0);
+            vec3 normal = normalize(vec3(-grad, z));
+
+            // Specular: Blinn-Phong only (Fresnel rim + caustic shimmer removed)
+            vec3 viewDir = vec3(0.0, 0.0, 1.0);
+            vec3 halfVec = normalize(lightDir + viewDir);
+            float spec = pow(max(dot(normal, halfVec), 0.0), 32.0 * domeScale + 8.0);
+
+            vec3 specCol = mix(vec3(1.0), uAmbientColor * 1.5 + 0.5, 0.3);
+            float intensity = spec * 0.3 * uAmbientLum * domeScale;
+
+            float a = clamp(intensity * inside * uPanelAlpha[i], 0.0, 0.5);
+            totalCol += specCol * a;
+            totalAlpha += a;
+          }
+
+          totalAlpha = clamp(totalAlpha, 0.0, 0.6);
+          return vec4(totalCol, totalAlpha);
+        }
+
+        void main() {
+          vec2 uv = vUV;
+          uv.y = 1.0 - uv.y;
+
+          // Panel mask — 0.0 outside all panels, 1.0 inside
+          float mask = panelMask(uv);
+          if (mask < 0.001) { fragColor = vec4(0.0); return; }
+
+          // Layer all effects
+          vec4 ambient  = ambientGlow(uv);
+          vec4 glass    = glassReflection(uv);
+          vec4 glow     = panelGlow(uv);
+          vec4 vignette = gForceVignette(uv);
+          vec4 aberr    = speedAberration(uv);
+          vec4 heat     = brakeHeatWash(uv);
+          vec4 redline  = rpmRedlinePulse(uv);
+
+          // Additive composite
+          vec3 col = vec3(0.0);
+          float alpha = 0.0;
+
+          // Glass dome: base layer (between module content and glare)
+          col += glass.rgb;
+          alpha += glass.a;
+
+          // Ambient glow: on top of glass
+          col += ambient.rgb;
+          alpha += ambient.a;
+
+          col += glow.rgb;
+          alpha += glow.a;
+
+          col = mix(col, col - vignette.rgb, vignette.a);
+          alpha = max(alpha, vignette.a * 0.5);
+
+          col += aberr.rgb;
+          alpha += aberr.a;
+
+          col += heat.rgb;
+          alpha += heat.a;
+
+          col += redline.rgb;
+          alpha += redline.a;
+
+          alpha = clamp(alpha, 0.0, 0.80);
+          col = clamp(col, 0.0, 1.0);
+
+          // Circular gradient mask — full intensity at center, 5% at screen edges
+          float edgeRadius = length(uv - vec2(0.5)) / 0.7071; // 0 at center, 1 at corners
+          float radialFade = mix(1.0, 0.05, smoothstep(0.0, 1.0, edgeRadius));
+          alpha *= radialFade;
+
+          // Apply panel mask
+          alpha *= mask;
+          fragColor = vec4(col * alpha, alpha);
+        }`;
+
+      const vs = createShader(gGL, gGL.VERTEX_SHADER, quadVS);
+      const fs = createShader(gGL, gGL.FRAGMENT_SHADER, postfxFS);
+      const prog = createProgram(gGL, vs, fs);
+
+      if (prog) {
+        const aPos   = gGL.getAttribLocation(prog, 'aPos');
+        const uTime  = gGL.getUniformLocation(prog, 'uTime');
+        const uCount = gGL.getUniformLocation(prog, 'uCount');
+        const uRect = [], uColor = [];
+        for (let i = 0; i < 8; i++) {
+          uRect[i]  = gGL.getUniformLocation(prog, 'uRect[' + i + ']');
+          uColor[i] = gGL.getUniformLocation(prog, 'uColor[' + i + ']');
+        }
+        // Panel mask uniforms
+        const uPanelCount = gGL.getUniformLocation(prog, 'uPanelCount');
+        const uPanelRect = [], uPanelAlpha = [], uPanelRadius = [];
+        for (let i = 0; i < 16; i++) {
+          uPanelRect[i]   = gGL.getUniformLocation(prog, 'uPanelRect[' + i + ']');
+          uPanelAlpha[i]  = gGL.getUniformLocation(prog, 'uPanelAlpha[' + i + ']');
+          uPanelRadius[i] = gGL.getUniformLocation(prog, 'uPanelRadius[' + i + ']');
+        }
+        // Telemetry uniforms
+        const uSpeed     = gGL.getUniformLocation(prog, 'uSpeed');
+        const uRpm       = gGL.getUniformLocation(prog, 'uRpm');
+        const uLatG      = gGL.getUniformLocation(prog, 'uLatG');
+        const uLongG     = gGL.getUniformLocation(prog, 'uLongG');
+        const uBrakeHeat = gGL.getUniformLocation(prog, 'uBrakeHeat');
+        const uYawRate   = gGL.getUniformLocation(prog, 'uYawRate');
+        const uSteer     = gGL.getUniformLocation(prog, 'uSteer');
+        // Ambient light uniforms
+        const uAmbientColor = gGL.getUniformLocation(prog, 'uAmbientColor');
+        const uAmbientLum   = gGL.getUniformLocation(prog, 'uAmbientLum');
+        const uAmbientMode  = gGL.getUniformLocation(prog, 'uAmbientMode');
+
+        const buf = gGL.createBuffer();
+        gGL.bindBuffer(gGL.ARRAY_BUFFER, buf);
+        gGL.bufferData(gGL.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, 1,1]), gGL.STATIC_DRAW);
+
+        gGL.enable(gGL.BLEND);
+        gGL.blendFunc(gGL.ONE, gGL.ONE_MINUS_SRC_ALPHA);
+
+        // ── Glow source registry ──
+        const _glareSources = [];
+
+        window.registerGlareSource = function(id, elementId, color, getIntensity) {
+          const idx = _glareSources.findIndex(s => s.id === id);
+          const source = { id, elementId, color, getIntensity };
+          if (idx >= 0) _glareSources[idx] = source;
+          else _glareSources.push(source);
+        };
+
+        window.removeGlareSource = function(id) {
+          const idx = _glareSources.findIndex(s => s.id === id);
+          if (idx >= 0) _glareSources.splice(idx, 1);
+        };
+
+        // Register pedal glare sources
+        window.registerGlareSource('pedal-thr', 'pedalsArea',
+          [0.10, 0.45, 0.08], function() { return _pedalValues.thr * 0.5; });
+        window.registerGlareSource('pedal-brk', 'pedalsArea',
+          [0.92, 0.22, 0.20], function() { return _pedalValues.brk * 0.5; });
+        window.registerGlareSource('pedal-clt', 'pedalsArea',
+          [0.25, 0.50, 0.92], function() { return _pedalValues.clt * 0.35; });
+
+        // Panel rect caches (cleared each frame)
+        const _rectCache = {};
+        const PANEL_SELECTORS = '.panel, .tacho-block, .commentary-inner, .leaderboard-panel, .datastream-panel, .pitbox-panel, .incidents-panel, .spotter-panel';
+        let _panelEls = null;
+
+        function getPanelRectUV(elementId) {
+          if (_rectCache[elementId]) return _rectCache[elementId];
+          const el = document.getElementById(elementId);
+          if (!el) return null;
+          const r = el.getBoundingClientRect();
+          const vw = window.innerWidth, vh = window.innerHeight;
+          const result = [r.left / vw, r.top / vh, r.width / vw, r.height / vh];
+          _rectCache[elementId] = result;
+          return result;
+        }
+
+        function getAllPanelRectsUV() {
+          if (!_panelEls) _panelEls = document.querySelectorAll(PANEL_SELECTORS);
+          const rects = [];
+          const alphas = [];
+          const radii = [];
+          const vw = window.innerWidth, vh = window.innerHeight;
+          for (let i = 0; i < _panelEls.length && rects.length < 16; i++) {
+            const el = _panelEls[i];
+            // Skip hidden panels
+            if (el.offsetWidth === 0 || el.offsetHeight === 0) continue;
+            const r = el.getBoundingClientRect();
+            if (r.width < 2 || r.height < 2) continue;
+            rects.push([r.left / vw, r.top / vh, r.width / vw, r.height / vh]);
+            // Walk up the DOM to compute effective opacity (CSS opacity is inherited)
+            let opacity = 1;
+            let node = el;
+            while (node && node !== document.body) {
+              const o = parseFloat(getComputedStyle(node).opacity);
+              if (o < 1) opacity *= o;
+              node = node.parentElement;
+            }
+            alphas.push(opacity);
+            // Border-radius in UV space for rounded-rect SDF
+            const style = getComputedStyle(el);
+            const brPx = parseFloat(style.borderRadius) || 0;
+            radii.push([brPx / vw, brPx / vh]);
+          }
+          return { rects, alphas, radii };
+        }
+
+        // Smooth telemetry interpolation
+        function lerpPFX(dt) {
+          const p = _pfx;
+          const lr = _pfxLerp;
+          p.speed   += (p.speedTarget   - p.speed)   * Math.min(1, lr.speed   * dt);
+          p.rpm     += (p.rpmTarget     - p.rpm)     * Math.min(1, lr.rpm     * dt);
+          p.latG    += (p.latGTarget    - p.latG)    * Math.min(1, lr.latG    * dt);
+          p.longG   += (p.longGTarget   - p.longG)   * Math.min(1, lr.longG   * dt);
+          p.yawRate += (p.yawRateTarget - p.yawRate) * Math.min(1, lr.yawRate * dt);
+          p.steer   += (p.steerTarget   - p.steer)   * Math.min(1, lr.steer   * dt);
+          // Brake heat: accumulates during braking, slow decay
+          const braking = Math.max(0, _pedalValues.brk);
+          p.brakeHeat += braking * dt * 1.5;
+          p.brakeHeat *= Math.exp(-dt * 0.6);
+          p.brakeHeat = Math.min(p.brakeHeat, 1.0);
+        }
+
+        // Refresh panel element list periodically (panels may show/hide)
+        let _panelRefreshCounter = 0;
+
+        // Init perf instrumentation
+        _glarePerf.init(gGL);
+
+        window._glareFXFrame = function(dt) {
+          _postfxTime += dt;
+          lerpPFX(dt);
+
+          // Refresh panel list every ~60 frames
+          _panelRefreshCounter++;
+          if (_panelRefreshCounter > 60) {
+            _panelRefreshCounter = 0;
+            _panelEls = null;
+          }
+
+          // Clear rect cache each frame
+          for (const k in _rectCache) delete _rectCache[k];
+
+          // Collect active glow sources (up to 8)
+          let count = 0;
+          const rects = [], colors = [];
+          for (let i = 0; i < _glareSources.length && count < 8; i++) {
+            const src = _glareSources[i];
+            const inten = src.getIntensity();
+            if (inten < 0.01) continue;
+            const rect = getPanelRectUV(src.elementId);
+            if (!rect) continue;
+            rects.push(rect);
+            colors.push([src.color[0], src.color[1], src.color[2], inten]);
+            count++;
+          }
+
+          // Get all panel rects + opacities + border-radii for masking
+          const { rects: panelRects, alphas: panelAlphas, radii: panelRadii } = getAllPanelRectsUV();
+
+          const hasGlow    = count > 0;
+          const hasAmbient = (window._ambientGL && window._ambientGL.lum > 0.01);
+          // PERF-LITE: brakeHeat and speed aberration removed, only check
+          // g-force vignette and RPM redline (the two remaining telemetry effects)
+          const hasEffects = Math.abs(_pfx.latG) > 0.25 || Math.abs(_pfx.longG) > 0.25 ||
+                             _pfx.rpm > 0.86;
+
+          if (!hasGlow && !hasAmbient && !hasEffects) {
+            if (gC.width > 0) {
+              gGL.clearColor(0, 0, 0, 0);
+              gGL.clear(gGL.COLOR_BUFFER_BIT);
+            }
+            _glarePerf.markSkipped();
+            return;
+          }
+
+          // ── Perf: begin GPU timer ──
+          const gpuQuery = _glarePerf.beginFrame(gGL);
+
+          resizeCanvasScreen(gC, gGL);
+
+          gGL.clearColor(0, 0, 0, 0);
+          gGL.clear(gGL.COLOR_BUFFER_BIT);
+
+          gGL.useProgram(prog);
+          gGL.bindBuffer(gGL.ARRAY_BUFFER, buf);
+          gGL.enableVertexAttribArray(aPos);
+          gGL.vertexAttribPointer(aPos, 2, gGL.FLOAT, false, 0, 0);
+
+          // Glow source uniforms
+          gGL.uniform1f(uTime, _postfxTime);
+          gGL.uniform1i(uCount, count);
+          for (let i = 0; i < 8; i++) {
+            if (i < count) {
+              gGL.uniform4f(uRect[i], rects[i][0], rects[i][1], rects[i][2], rects[i][3]);
+              gGL.uniform4f(uColor[i], colors[i][0], colors[i][1], colors[i][2], colors[i][3]);
+            } else {
+              gGL.uniform4f(uRect[i], 0, 0, 0, 0);
+              gGL.uniform4f(uColor[i], 0, 0, 0, 0);
+            }
+          }
+
+          // Panel mask uniforms (rects + per-panel opacity + border-radius)
+          gGL.uniform1i(uPanelCount, panelRects.length);
+          for (let i = 0; i < 16; i++) {
+            if (i < panelRects.length) {
+              gGL.uniform4f(uPanelRect[i], panelRects[i][0], panelRects[i][1], panelRects[i][2], panelRects[i][3]);
+              gGL.uniform1f(uPanelAlpha[i], panelAlphas[i]);
+              gGL.uniform2f(uPanelRadius[i], panelRadii[i][0], panelRadii[i][1]);
+            } else {
+              gGL.uniform4f(uPanelRect[i], 0, 0, 0, 0);
+              gGL.uniform1f(uPanelAlpha[i], 0.0);
+              gGL.uniform2f(uPanelRadius[i], 0, 0);
+            }
+          }
+
+          // Telemetry uniforms
+          gGL.uniform1f(uSpeed,     _pfx.speed);
+          gGL.uniform1f(uRpm,       _pfx.rpm);
+          gGL.uniform1f(uLatG,      _pfx.latG);
+          gGL.uniform1f(uLongG,     _pfx.longG);
+          gGL.uniform1f(uBrakeHeat, _pfx.brakeHeat);
+          gGL.uniform1f(uYawRate,   Math.abs(_pfx.yawRate));
+          gGL.uniform1f(uSteer,     _pfx.steer);
+
+          // Ambient light uniforms (from Electron screen capture)
+          const amb = window._ambientGL || { r: 0.3, g: 0.4, b: 0.55, lum: 0.35 };
+          gGL.uniform3f(uAmbientColor, amb.r, amb.g, amb.b);
+          gGL.uniform1f(uAmbientLum, amb.lum);
+          gGL.uniform1i(uAmbientMode, window._ambientModeInt !== undefined ? window._ambientModeInt : 2);
+
+          gGL.drawArrays(gGL.TRIANGLE_STRIP, 0, 4);
+
+          // ── Perf: end GPU timer ──
+          _glarePerf.endFrame(gGL, gpuQuery);
+        };
+      }
+    }
+
+    /* ════════════════════════════════════════════
+       FLAG ICON FX — waving flag with cloth shading
+       ════════════════════════════════════════════ */
+    const flagCtx = initGL('flagGlCanvas');
+    let _flagTime = 0;
+    let _flagColors = { c1: [1,0.85,0.15], c2: [1,1,0.95], pattern: 0.0 };
+    let _flagVisible = false;
+
+    if (flagCtx) {
+      const { canvas: fC, gl: fGL } = flagCtx;
+
+      const quadVS = `#version 300 es
+        in vec2 aPos;
+        out vec2 vUV;
+        void main() {
+          vUV = aPos * 0.5 + 0.5;
+          gl_Position = vec4(aPos, 0.0, 1.0);
+        }`;
+
+      const flagFS = `#version 300 es
+        precision highp float;
+        in vec2 vUV;
+        out vec4 fragColor;
+
+        uniform float uTime;
+        uniform vec3  uColor1;
+        uniform vec3  uColor2;
+        uniform float uPattern;  // 0=solid, 1=horiz stripes, 2=checkered, 3=diagonal, 4=circles
+        uniform vec2  uRes;      // canvas pixel size for aspect correction
+
+        void main() {
+          vec2 uv = vUV;
+          float aspect = uRes.x / max(uRes.y, 1.0);
+
+          // Full-background waving cloth — fills entire box
+          float fx = uv.x;
+          float fy = uv.y;
+
+          // Wave displacement — increases from left to right (cloth physics)
+          float amp = fx * fx * 0.12;
+          float w1 = sin(fx * 12.0 - uTime * 5.0) * amp;
+          float w2 = sin(fx * 18.0 - uTime * 3.5 + 2.0) * amp * 0.35;
+          float wave = w1 + w2;
+
+          // Distort vertical coordinate for cloth wave
+          float fy2 = fy + wave * 0.6;
+
+          // ── Cloth shading — light on peaks, dark in valleys ──
+          float dWave = cos(fx * 12.0 - uTime * 5.0);
+          float shade = 0.80 + 0.20 * dWave * fx;
+
+          // ── Pattern coloring ──
+          vec3 col;
+          if (uPattern < 0.5) {
+            // Solid
+            col = uColor1;
+          } else if (uPattern < 1.5) {
+            // Horizontal stripes — doubled count
+            float bandCount = max(4.0, floor(aspect * 1.2));
+            float band = step(0.5, fract(fy2 * bandCount));
+            col = mix(uColor1, uColor2, band);
+          } else if (uPattern < 2.5) {
+            // Checkered — doubled cells
+            float cellsX = max(8.0, floor(aspect * 4.0));
+            float cellsY = 4.0;
+            float cx = step(0.5, fract(fx * cellsX + wave * 0.5));
+            float cy = step(0.5, fract(fy2 * cellsY));
+            col = mix(uColor1, uColor2, abs(cx - cy));
+          } else if (uPattern < 3.5) {
+            // Diagonal stripes — doubled, with wave distortion
+            float diag = step(0.5, fract((fx * aspect + fy2 * 3.0) * 1.6));
+            col = mix(uColor1, uColor2, diag);
+          } else {
+            // Circles (meatball flag) — red circles on black background
+            float cellsX = max(6.0, floor(aspect * 3.0));
+            float cellsY = 3.0;
+            float cx = fract(fx * cellsX + wave * 0.3);
+            float cy = fract(fy2 * cellsY);
+            float d = length(vec2(cx - 0.5, cy - 0.5));
+            float circle = 1.0 - smoothstep(0.28, 0.34, d);
+            col = mix(uColor2, uColor1, circle);
+          }
+
+          col *= shade;
+
+          // Flag cloth alpha — tripled for high visibility
+          float alpha = 0.48;
+
+          // Brightness variation from the wave folds
+          alpha *= (0.85 + 0.30 * abs(dWave) * fx);
+
+          fragColor = vec4(col * alpha, alpha);
+        }`;
+
+      const vs = createShader(fGL, fGL.VERTEX_SHADER, quadVS);
+      const fs = createShader(fGL, fGL.FRAGMENT_SHADER, flagFS);
+      const prog = createProgram(fGL, vs, fs);
+
+      if (prog) {
+        const aPos    = fGL.getAttribLocation(prog, 'aPos');
+        const uTime   = fGL.getUniformLocation(prog, 'uTime');
+        const uColor1 = fGL.getUniformLocation(prog, 'uColor1');
+        const uColor2 = fGL.getUniformLocation(prog, 'uColor2');
+        const uPat    = fGL.getUniformLocation(prog, 'uPattern');
+        const uRes    = fGL.getUniformLocation(prog, 'uRes');
+
+        const buf = fGL.createBuffer();
+        fGL.bindBuffer(fGL.ARRAY_BUFFER, buf);
+        fGL.bufferData(fGL.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, 1,1]), fGL.STATIC_DRAW);
+
+        fGL.enable(fGL.BLEND);
+        fGL.blendFunc(fGL.ONE, fGL.ONE_MINUS_SRC_ALPHA);
+
+        window._flagFXFrame = function(dt) {
+          if (!_flagVisible) return;
+          resizeCanvas(fC, fGL);
+          _flagTime += dt;
+
+          fGL.clearColor(0, 0, 0, 0);
+          fGL.clear(fGL.COLOR_BUFFER_BIT);
+
+          fGL.useProgram(prog);
+          fGL.bindBuffer(fGL.ARRAY_BUFFER, buf);
+          fGL.enableVertexAttribArray(aPos);
+          fGL.vertexAttribPointer(aPos, 2, fGL.FLOAT, false, 0, 0);
+
+          fGL.uniform1f(uTime, _flagTime);
+          fGL.uniform3fv(uColor1, _flagColors.c1);
+          fGL.uniform3fv(uColor2, _flagColors.c2);
+          fGL.uniform1f(uPat, _flagColors.pattern);
+          fGL.uniform2f(uRes, fC.width, fC.height);
+
+          fGL.drawArrays(fGL.TRIANGLE_STRIP, 0, 4);
+        };
+      }
+    }
+
+    // Flag color definitions per flag type
+    window._FLAG_GL_COLORS = {
+      yellow:    { c1: [1.0, 0.85, 0.12], c2: [1.0, 1.0, 0.92],  pattern: 0.0 },
+      red:       { c1: [0.90, 0.14, 0.12], c2: [0.50, 0.06, 0.06], pattern: 0.0 },
+      blue:      { c1: [0.20, 0.45, 0.92], c2: [0.08, 0.20, 0.55], pattern: 3.0 },
+      green:     { c1: [0.20, 0.72, 0.28], c2: [0.10, 0.42, 0.16], pattern: 0.0 },
+      white:     { c1: [0.95, 0.95, 0.95], c2: [0.72, 0.72, 0.72], pattern: 0.0 },
+      debris:    { c1: [1.0, 0.85, 0.12], c2: [0.90, 0.18, 0.12], pattern: 3.0 },
+      checkered: { c1: [0.95, 0.95, 0.95], c2: [0.06, 0.06, 0.06], pattern: 2.0 },
+      black:     { c1: [0.06, 0.06, 0.06], c2: [0.80, 0.12, 0.08], pattern: 1.0 },
+      meatball:  { c1: [0.85, 0.12, 0.10], c2: [0.06, 0.06, 0.06], pattern: 4.0 }, // red circles on black
+      orange:    { c1: [1.0, 0.60, 0.08], c2: [0.90, 0.35, 0.05], pattern: 0.0 }   // solid orange
+    };
+
+    window.setFlagGLColors = function(flagType) {
+      const def = window._FLAG_GL_COLORS[flagType];
+      if (def) {
+        _flagColors.c1 = def.c1;
+        _flagColors.c2 = def.c2;
+        _flagColors.pattern = def.pattern;
+        _flagVisible = true;
+      } else {
+        _flagVisible = false;
+      }
+    };
+
+    /* ════════════════════════════════════════════
+       LEADERBOARD PLAYER HIGHLIGHT — shimmer/glow
+       ════════════════════════════════════════════ */
+    const lbCtx = initGL('lbPlayerGlCanvas');
+    let _lbTime = 0;
+    let _lbPlayerTop = 0;     // 0-1 normalized
+    let _lbPlayerBottom = 1;   // 0-1 normalized
+    let _lbHasPlayer = false;
+    // Highlight mode: 0=blue(same), 1=green(ahead), 2=red(behind), 3=gold(P1)
+    let _lbHighlightMode = 0;
+
+    if (lbCtx) {
+      const { canvas: lC, gl: lGL } = lbCtx;
+
+      const quadVS = `#version 300 es
+        in vec2 aPos;
+        out vec2 vUV;
+        void main() {
+          vUV = aPos * 0.5 + 0.5;
+          gl_Position = vec4(aPos, 0.0, 1.0);
+        }`;
+
+      const lbFS = `#version 300 es
+        precision highp float;
+        in vec2 vUV;
+        out vec4 fragColor;
+
+        uniform float uTime;
+        uniform float uPlayerTop;    // normalized y of player row top
+        uniform float uPlayerBot;    // normalized y of player row bottom
+        uniform float uMode;         // 0=blue, 1=green, 2=red, 3=gold(P1)
+        uniform vec2  uRes;
+
+        // Pseudo-random for P1 sparkles
+        float hash21(vec2 p) {
+          p = fract(p * vec2(123.34, 456.21));
+          p += dot(p, p + 45.32);
+          return fract(p.x * p.y);
+        }
+
+        void main() {
+          vec2 uv = vUV;
+          float y = 1.0 - uv.y;
+
+          if (y < uPlayerTop || y > uPlayerBot) {
+            fragColor = vec4(0.0);
+            return;
+          }
+
+          float ly = (y - uPlayerTop) / max(uPlayerBot - uPlayerTop, 0.001);
+          float lx = uv.x;
+
+          // ── Color selection by mode ──
+          // 0=blue(same), 1=green(ahead), 2=red(behind), 3=gold(P1)
+          vec3 baseColor;
+          vec3 brightColor;
+          if (uMode < 0.5) {
+            baseColor  = vec3(0.25, 0.45, 0.80);   // blue
+            brightColor = vec3(0.40, 0.60, 0.95);
+          } else if (uMode < 1.5) {
+            baseColor  = vec3(0.15, 0.70, 0.40);   // green
+            brightColor = vec3(0.25, 0.85, 0.55);
+          } else if (uMode < 2.5) {
+            baseColor  = vec3(0.80, 0.20, 0.15);   // red
+            brightColor = vec3(0.95, 0.35, 0.25);
+          } else {
+            baseColor  = vec3(0.76, 0.60, 0.22);   // deep gold
+            brightColor = vec3(1.0, 0.88, 0.55);    // bright gold
+          }
+
+          // ── Effect 1: Shimmer sweep ──
+          float sweepSpeed = 0.25;
+          float sweepX = fract(uTime * sweepSpeed);
+          float beamW = 0.08;
+          float beam = exp(-pow((lx - sweepX) / beamW, 2.0)) * 0.55;
+          float trail = exp(-max(0.0, lx - sweepX + 0.1) * 4.0) * 0.08
+                      * step(sweepX - 0.3, lx);
+          float effect1 = beam + trail;
+
+          // ── Effect 2: Edge breathing glow ──
+          float edgeY = min(ly, 1.0 - ly);
+          float edgeGlow = exp(-edgeY * 10.0) * 0.35;
+          float leftGlow = exp(-lx * 6.0) * 0.45;
+          float pulse = 0.55 + 0.45 * sin(uTime * 1.8);
+          float effect2 = (edgeGlow + leftGlow) * pulse;
+
+          // ── Crossfade between effects (~8s per full cycle) ──
+          float blend = 0.5 + 0.5 * sin(uTime * 0.4);
+          float effect = mix(effect1, effect2, blend);
+
+          float rowEdge = smoothstep(0.0, 0.15, ly) * smoothstep(1.0, 0.85, ly);
+          effect *= rowEdge;
+
+          float alpha = clamp(effect * 0.55, 0.0, 0.5);
+          vec3 col = baseColor;
+
+          // ── P1 sparkle overlay (very sparse) ──
+          if (uMode > 2.5) {
+            float beamBright = exp(-pow((lx - sweepX) / beamW, 2.0)) * 0.15 * rowEdge;
+            col = mix(baseColor, brightColor, beamBright * 2.0 + 0.3);
+
+            float gridScale = 24.0;
+            vec2 gridCell = floor(vec2(lx, ly) * gridScale);
+            float cellRand = hash21(gridCell);
+            if (cellRand > 0.94) {
+              vec2 cellUV = fract(vec2(lx, ly) * gridScale);
+              float sparklePhase = cellRand * 6.28 + uTime * (2.5 + cellRand * 2.0);
+              float blink = pow(max(0.0, sin(sparklePhase)), 28.0);
+              float dist = length(cellUV - 0.5);
+              float point = exp(-dist * dist * 50.0);
+              float sparkle = blink * point * rowEdge * 0.5;
+              col += vec3(1.0, 0.97, 0.85) * sparkle;
+              alpha += sparkle;
+            }
+          }
+
+          alpha = clamp(alpha, 0.0, 0.55);
+          fragColor = vec4(col * alpha, alpha);
+        }`;
+
+      const vs = createShader(lGL, lGL.VERTEX_SHADER, quadVS);
+      const fs = createShader(lGL, lGL.FRAGMENT_SHADER, lbFS);
+      const prog = createProgram(lGL, vs, fs);
+
+      if (prog) {
+        const aPos       = lGL.getAttribLocation(prog, 'aPos');
+        const uTime      = lGL.getUniformLocation(prog, 'uTime');
+        const uPlayerTop = lGL.getUniformLocation(prog, 'uPlayerTop');
+        const uPlayerBot = lGL.getUniformLocation(prog, 'uPlayerBot');
+        const uMode      = lGL.getUniformLocation(prog, 'uMode');
+        const uRes       = lGL.getUniformLocation(prog, 'uRes');
+
+        const buf = lGL.createBuffer();
+        lGL.bindBuffer(lGL.ARRAY_BUFFER, buf);
+        lGL.bufferData(lGL.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, 1,1]), lGL.STATIC_DRAW);
+
+        lGL.enable(lGL.BLEND);
+        lGL.blendFunc(lGL.ONE, lGL.ONE_MINUS_SRC_ALPHA);
+
+        window._lbFXFrame = function(dt) {
+          if (!_lbHasPlayer) return;
+          resizeCanvas(lC, lGL);
+          _lbTime += dt;
+
+          lGL.clearColor(0, 0, 0, 0);
+          lGL.clear(lGL.COLOR_BUFFER_BIT);
+
+          lGL.useProgram(prog);
+          lGL.bindBuffer(lGL.ARRAY_BUFFER, buf);
+          lGL.enableVertexAttribArray(aPos);
+          lGL.vertexAttribPointer(aPos, 2, lGL.FLOAT, false, 0, 0);
+
+          lGL.uniform1f(uTime, _lbTime);
+          lGL.uniform1f(uPlayerTop, _lbPlayerTop);
+          lGL.uniform1f(uPlayerBot, _lbPlayerBottom);
+          lGL.uniform1f(uMode, _lbHighlightMode);
+          lGL.uniform2f(uRes, lC.width, lC.height);
+
+          lGL.drawArrays(lGL.TRIANGLE_STRIP, 0, 4);
+        };
+      }
+    }
+
+    // Update leaderboard player row position for WebGL highlight
+    window.updateLBPlayerPos = function() {
+      const inner = document.querySelector('.lb-inner');
+      const playerRow = document.querySelector('.lb-row.lb-player');
+      if (!inner || !playerRow) {
+        _lbHasPlayer = false;
+        return;
+      }
+      const ir = inner.getBoundingClientRect();
+      const pr = playerRow.getBoundingClientRect();
+      if (ir.height < 1) { _lbHasPlayer = false; return; }
+      _lbPlayerTop = (pr.top - ir.top) / ir.height;
+      _lbPlayerBottom = (pr.bottom - ir.top) / ir.height;
+      _lbHasPlayer = true;
+    };
+
+    // Update highlight mode: 0=blue(same), 1=green(ahead), 2=red(behind), 3=gold(P1)
+    window.setLBHighlightMode = function(mode) { _lbHighlightMode = mode; };
+
+    /* ════════════════════════════════════════════
+       K10 LOGO BACKGROUND — ultra-subtle chevron drift
+       SDF-based chevron shapes from the K10 logomark,
+       barely perceptible at 3-4% opacity, drifting so slowly
+       you only notice after 4-5 minutes of watching.
+       ════════════════════════════════════════════ */
+    const k10LogoCtx = initGL('k10LogoGlCanvas');
+    let _k10LogoTime = 0;
+
+    if (k10LogoCtx) {
+      const { canvas: kC, gl: kGL } = k10LogoCtx;
+
+      const quadVS = `#version 300 es
+        in vec2 aPos;
+        out vec2 vUV;
+        void main() {
+          vUV = aPos * 0.5 + 0.5;
+          gl_Position = vec4(aPos, 0.0, 1.0);
+        }`;
+
+      const k10FS = `#version 300 es
+        precision highp float;
+        in vec2 vUV;
+        out vec4 fragColor;
+        uniform float uTime;
+        uniform vec2  uRes;
+
+        // Rotate 2D point
+        vec2 rot(vec2 p, float a) {
+          float c = cos(a), s = sin(a);
+          return vec2(p.x*c - p.y*s, p.x*s + p.y*c);
+        }
+
+        // SDF for a single chevron (two angled bars forming a > shape)
+        // Centered at origin, pointing right, with arm length and thickness
+        float sdChevron(vec2 p, float armLen, float thick, float angle) {
+          // Mirror across x-axis for the two arms
+          vec2 q = vec2(p.x, abs(p.y));
+          // Rotate the arm direction
+          vec2 dir = vec2(cos(angle), sin(angle));
+          // Project onto arm line
+          float t = clamp(dot(q, dir), 0.0, armLen);
+          vec2 closest = dir * t;
+          return length(q - closest) - thick;
+        }
+
+        // Smoother chevron using box-like approach
+        float sdChevronV(vec2 p, float size, float thick) {
+          vec2 q = vec2(p.x, abs(p.y));
+          // V-shape: line from (0, size) to (size*0.6, 0)
+          vec2 a = vec2(0.0, size);
+          vec2 b = vec2(size * 0.7, 0.0);
+          vec2 ab = b - a;
+          vec2 aq = q - a;
+          float t = clamp(dot(aq, ab) / dot(ab, ab), 0.0, 1.0);
+          vec2 closest = a + ab * t;
+          return length(q - closest) - thick;
+        }
+
+        void main() {
+          vec2 uv = vUV;
+          float aspect = uRes.x / uRes.y;
+          vec2 p = (uv - 0.5) * vec2(aspect, 1.0);
+
+          float t = uTime;
+
+          // Three chevrons that drift independently at glacial speeds
+          // Each has its own phase, position offset, scale, and slight rotation
+
+          float totalAlpha = 0.0;
+          vec3 totalColor = vec3(0.0);
+
+          // Chevron 1 — leftmost, lighter red
+          {
+            // Drift: very slow circular path + slight horizontal oscillation
+            vec2 offset = vec2(
+              sin(t * 0.008 + 0.0) * 0.12 + cos(t * 0.003) * 0.05,
+              cos(t * 0.006 + 1.0) * 0.08 + sin(t * 0.004) * 0.03
+            );
+            float scale = 0.38 + sin(t * 0.005 + 2.0) * 0.03;
+            float angle = sin(t * 0.004) * 0.06;
+            vec2 cp = rot(p - vec2(-0.15, 0.0) - offset, angle) / scale;
+            float d = sdChevronV(cp, 0.5, 0.06);
+            float shape = 1.0 - smoothstep(-0.01, 0.03, d);
+            float breath = 0.5 + 0.5 * sin(t * 0.012 + 0.0);
+            float a = shape * breath * 0.035;
+            totalColor += vec3(0.85, 0.30, 0.25) * a;
+            totalAlpha += a;
+          }
+
+          // Chevron 2 — middle, medium red
+          {
+            vec2 offset = vec2(
+              cos(t * 0.007 + 2.0) * 0.10 + sin(t * 0.0035) * 0.04,
+              sin(t * 0.009 + 0.5) * 0.10 + cos(t * 0.005) * 0.03
+            );
+            float scale = 0.42 + cos(t * 0.006 + 1.0) * 0.025;
+            float angle = cos(t * 0.005 + 1.0) * 0.05;
+            vec2 cp = rot(p - vec2(0.0, 0.0) - offset, angle) / scale;
+            float d = sdChevronV(cp, 0.5, 0.06);
+            float shape = 1.0 - smoothstep(-0.01, 0.03, d);
+            float breath = 0.5 + 0.5 * sin(t * 0.010 + 2.1);
+            float a = shape * breath * 0.035;
+            totalColor += vec3(0.75, 0.22, 0.20) * a;
+            totalAlpha += a;
+          }
+
+          // Chevron 3 — rightmost, dark maroon/wine
+          {
+            vec2 offset = vec2(
+              sin(t * 0.006 + 4.0) * 0.11 + cos(t * 0.004) * 0.05,
+              cos(t * 0.008 + 3.0) * 0.09 + sin(t * 0.003) * 0.04
+            );
+            float scale = 0.35 + sin(t * 0.007 + 3.5) * 0.03;
+            float angle = sin(t * 0.003 + 2.0) * 0.07;
+            vec2 cp = rot(p - vec2(0.12, 0.0) - offset, angle) / scale;
+            float d = sdChevronV(cp, 0.5, 0.06);
+            float shape = 1.0 - smoothstep(-0.01, 0.03, d);
+            float breath = 0.5 + 0.5 * sin(t * 0.014 + 4.2);
+            float a = shape * breath * 0.035;
+            totalColor += vec3(0.55, 0.12, 0.15) * a;
+            totalAlpha += a;
+          }
+
+          // Very subtle edge vignette to keep it contained
+          float vig = smoothstep(0.0, 0.15, min(uv.x, min(uv.y, min(1.0-uv.x, 1.0-uv.y))));
+          totalAlpha *= vig;
+          totalColor *= vig;
+
+          totalAlpha = clamp(totalAlpha, 0.0, 0.06);
+          fragColor = vec4(totalColor, totalAlpha);
+        }`;
+
+      const vs = createShader(kGL, kGL.VERTEX_SHADER, quadVS);
+      const fs = createShader(kGL, kGL.FRAGMENT_SHADER, k10FS);
+      const prog = createProgram(kGL, vs, fs);
+
+      if (prog) {
+        const aPos  = kGL.getAttribLocation(prog, 'aPos');
+        const uTime = kGL.getUniformLocation(prog, 'uTime');
+        const uRes  = kGL.getUniformLocation(prog, 'uRes');
+
+        const buf = kGL.createBuffer();
+        kGL.bindBuffer(kGL.ARRAY_BUFFER, buf);
+        kGL.bufferData(kGL.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, 1,1]), kGL.STATIC_DRAW);
+
+        kGL.enable(kGL.BLEND);
+        kGL.blendFunc(kGL.ONE, kGL.ONE_MINUS_SRC_ALPHA);
+
+        window._k10LogoFXFrame = function(dt) {
+          resizeCanvas(kC, kGL);
+          _k10LogoTime += dt;
+
+          kGL.clearColor(0, 0, 0, 0);
+          kGL.clear(kGL.COLOR_BUFFER_BIT);
+
+          kGL.useProgram(prog);
+          kGL.bindBuffer(kGL.ARRAY_BUFFER, buf);
+          kGL.enableVertexAttribArray(aPos);
+          kGL.vertexAttribPointer(aPos, 2, kGL.FLOAT, false, 0, 0);
+
+          kGL.uniform1f(uTime, _k10LogoTime);
+          kGL.uniform2f(uRes, kC.width, kC.height);
+
+          kGL.drawArrays(kGL.TRIANGLE_STRIP, 0, 4);
+        };
+      }
+    }
+
+    /* ════════════════════════════════════════════
+       LEADERBOARD EVENT OVERLAY — position change / race start / finish
+       Subtle full-panel flash effects, lower intensity than flag animations
+       ════════════════════════════════════════════ */
+    const lbEvtCtx = initGL('lbEventGlCanvas');
+    let _lbEvtTime = 0;
+    let _lbEvtActive = false;
+    let _lbEvtColor = [0.0, 0.8, 0.3]; // green default
+    let _lbEvtDuration = 1.2;           // seconds
+    let _lbEvtElapsed = 99;             // start expired
+    let _lbEvtMode = 0;                 // 0=flash, 1=green-flag sweep, 2=checkered
+
+    if (lbEvtCtx) {
+      const { canvas: eC, gl: eGL } = lbEvtCtx;
+
+      const quadVS = `#version 300 es
+        in vec2 aPos;
+        out vec2 vUV;
+        void main() {
+          vUV = aPos * 0.5 + 0.5;
+          gl_Position = vec4(aPos, 0.0, 1.0);
+        }`;
+
+      const evtFS = `#version 300 es
+        precision highp float;
+        in vec2 vUV;
+        out vec4 fragColor;
+
+        uniform float uTime;
+        uniform float uElapsed;
+        uniform float uDuration;
+        uniform vec3  uColor;
+        uniform float uMode;     // 0=flash, 1=green sweep, 2=checkered, 3=P1 gold
+        uniform vec2  uRes;
+
+        // Pseudo-random hash for sparkle particles
+        float hash21(vec2 p) {
+          p = fract(p * vec2(123.34, 456.21));
+          p += dot(p, p + 45.32);
+          return fract(p.x * p.y);
+        }
+
+        void main() {
+          vec2 uv = vUV;
+          float progress = clamp(uElapsed / uDuration, 0.0, 1.0);
+
+          // Global fade out — starts fading at 40% through
+          float fadeOut = smoothstep(1.0, 0.4, progress);
+
+          float alpha = 0.0;
+          vec3 col = uColor;
+
+          if (uMode < 0.5) {
+            // ── MODE 0: Subtle edge flash (position change) ──
+            float edgeX = min(uv.x, 1.0 - uv.x);
+            float edgeY = min(uv.y, 1.0 - uv.y);
+            float edge = exp(-min(edgeX, edgeY) * 8.0);
+            float attack = smoothstep(0.0, 0.15, progress);
+            float envelope = attack * fadeOut;
+            alpha = edge * envelope * 0.28;
+            alpha += envelope * 0.04;
+          }
+          else if (uMode < 1.5) {
+            // ── MODE 1: Green flag sweep (race start) ──
+            float sweepPos = progress * 1.6 - 0.3;
+            float sweep = exp(-pow((uv.x - sweepPos) / 0.15, 2.0));
+            alpha = sweep * fadeOut * 0.22;
+            alpha += fadeOut * 0.03 * (1.0 - progress);
+          }
+          else if (uMode < 2.5) {
+            // ── MODE 2: Checkered finish ──
+            float scale = 8.0;
+            float cx = floor(uv.x * scale);
+            float cy = floor(uv.y * scale);
+            float checker = mod(cx + cy, 2.0);
+            float reveal = smoothstep(uv.x - 0.3, uv.x + 0.1, progress * 1.5);
+            col = mix(vec3(0.9), vec3(0.15), checker);
+            alpha = reveal * fadeOut * 0.16;
+          }
+          else {
+            // ── MODE 3: P1 Gold celebration ──
+            // Rich gold palette — warm, not yellow
+            vec3 goldDeep = vec3(0.76, 0.60, 0.22);   // deep warm gold
+            vec3 goldBright = vec3(1.0, 0.88, 0.55);   // bright highlight gold
+            vec3 goldWhite = vec3(1.0, 0.97, 0.85);    // near-white sparkle peak
+
+            // ── Slow fade-in, long presence, gentle fade-out ──
+            float fadeIn = smoothstep(0.0, 0.12, progress);
+            float fadeP1 = fadeIn * smoothstep(1.0, 0.5, progress);
+
+            // ── Warm edge glow (stronger than normal gain) ──
+            float edgeX = min(uv.x, 1.0 - uv.x);
+            float edgeY = min(uv.y, 1.0 - uv.y);
+            float edge = exp(-min(edgeX, edgeY) * 5.0);
+            float edgeAlpha = edge * fadeP1 * 0.35;
+
+            // ── Soft horizontal shimmer sweep ──
+            float shimmerPos = fract(uTime * 0.3 + 0.2);
+            float shimmer = exp(-pow((uv.x - shimmerPos) / 0.12, 2.0)) * 0.18;
+            shimmer *= fadeP1;
+
+            // ── Sparse sparkle particles ──
+            // Grid of potential sparkle sites — only a few activate
+            float sparkle = 0.0;
+            float gridScale = 18.0; // controls density — higher = more cells but sparser activation
+            vec2 gridCell = floor(uv * gridScale);
+            float cellRand = hash21(gridCell);
+
+            // Only ~8% of cells can sparkle at all
+            if (cellRand > 0.92) {
+              vec2 cellUV = fract(uv * gridScale);
+              // Each sparkle has its own timing offset
+              float sparklePhase = cellRand * 6.28 + uTime * (2.0 + cellRand * 3.0);
+              // Sharp on/off blink — visible for only a narrow window
+              float blink = pow(max(0.0, sin(sparklePhase)), 24.0);
+              // Point-like: bright only near cell center
+              float dist = length(cellUV - 0.5);
+              float point = exp(-dist * dist * 40.0);
+              // Stagger appearance across the animation
+              float appear = smoothstep(cellRand * 0.4, cellRand * 0.4 + 0.1, progress);
+              sparkle = blink * point * appear * fadeP1 * 0.65;
+            }
+
+            // Compose: edge glow is deep gold, shimmer is bright gold, sparkles are near-white
+            col = goldDeep * edgeAlpha
+                + goldBright * shimmer
+                + goldWhite * sparkle;
+            alpha = edgeAlpha + shimmer + sparkle;
+            // Very subtle overall warm wash
+            col += goldDeep * fadeP1 * 0.03;
+            alpha += fadeP1 * 0.03;
+          }
+
+          alpha = clamp(alpha, 0.0, 0.55);
+          fragColor = vec4(col * alpha, alpha);
+        }`;
+
+      const vs = createShader(eGL, eGL.VERTEX_SHADER, quadVS);
+      const fs = createShader(eGL, eGL.FRAGMENT_SHADER, evtFS);
+      const prog = createProgram(eGL, vs, fs);
+
+      if (prog) {
+        const aPos      = eGL.getAttribLocation(prog, 'aPos');
+        const uTime     = eGL.getUniformLocation(prog, 'uTime');
+        const uElapsed  = eGL.getUniformLocation(prog, 'uElapsed');
+        const uDuration = eGL.getUniformLocation(prog, 'uDuration');
+        const uColor    = eGL.getUniformLocation(prog, 'uColor');
+        const uMode     = eGL.getUniformLocation(prog, 'uMode');
+        const uRes      = eGL.getUniformLocation(prog, 'uRes');
+
+        const buf = eGL.createBuffer();
+        eGL.bindBuffer(eGL.ARRAY_BUFFER, buf);
+        eGL.bufferData(eGL.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, 1,1]), eGL.STATIC_DRAW);
+
+        eGL.enable(eGL.BLEND);
+        eGL.blendFunc(eGL.ONE, eGL.ONE_MINUS_SRC_ALPHA);
+
+        window._lbEvtFXFrame = function(dt) {
+          _lbEvtElapsed += dt;
+          if (_lbEvtElapsed > _lbEvtDuration) {
+            // Clear canvas when animation is done
+            if (_lbEvtActive) {
+              eGL.clearColor(0, 0, 0, 0);
+              eGL.clear(eGL.COLOR_BUFFER_BIT);
+              _lbEvtActive = false;
+            }
+            return;
+          }
+          _lbEvtActive = true;
+          resizeCanvas(eC, eGL);
+          _lbEvtTime += dt;
+
+          eGL.clearColor(0, 0, 0, 0);
+          eGL.clear(eGL.COLOR_BUFFER_BIT);
+
+          eGL.useProgram(prog);
+          eGL.bindBuffer(eGL.ARRAY_BUFFER, buf);
+          eGL.enableVertexAttribArray(aPos);
+          eGL.vertexAttribPointer(aPos, 2, eGL.FLOAT, false, 0, 0);
+
+          eGL.uniform1f(uTime, _lbEvtTime);
+          eGL.uniform1f(uElapsed, _lbEvtElapsed);
+          eGL.uniform1f(uDuration, _lbEvtDuration);
+          eGL.uniform3fv(uColor, _lbEvtColor);
+          eGL.uniform1f(uMode, _lbEvtMode);
+          eGL.uniform2f(uRes, eC.width, eC.height);
+
+          eGL.drawArrays(eGL.TRIANGLE_STRIP, 0, 4);
+        };
+      }
+    }
+
+    // Public API: trigger a leaderboard event animation
+    // type: 'gain' | 'lose' | 'p1' | 'green' | 'finish'
+    window.triggerLBEvent = function(type) {
+      switch (type) {
+        case 'gain':
+          _lbEvtColor = [0.1, 0.85, 0.35];  // green
+          _lbEvtDuration = 1.0;
+          _lbEvtMode = 0;
+          break;
+        case 'lose':
+          _lbEvtColor = [0.9, 0.15, 0.1];   // red
+          _lbEvtDuration = 1.0;
+          _lbEvtMode = 0;
+          break;
+        case 'p1':
+          _lbEvtColor = [0.76, 0.60, 0.22]; // deep gold (shader handles its own palette)
+          _lbEvtDuration = 3.5;
+          _lbEvtMode = 3;
+          break;
+        case 'green':
+          _lbEvtColor = [0.1, 0.85, 0.35];  // green
+          _lbEvtDuration = 2.0;
+          _lbEvtMode = 1;
+          break;
+        case 'finish':
+          _lbEvtColor = [0.9, 0.9, 0.9];    // white (checkered)
+          _lbEvtDuration = 2.5;
+          _lbEvtMode = 2;
+          break;
+      }
+      _lbEvtElapsed = 0;
+      _lbEvtActive = true;
+    };
+
+    /* ════════════════════════════════════════════
+       SPOTTER GLOW — edge glow that fades in/out with messages
+       Color varies by severity: warn=amber, danger=red, clear=green
+       ════════════════════════════════════════════ */
+    const spotCtx = initGL('spotterGlCanvas');
+    let _spotTime = 0;
+    // 0=idle(off), 1=warn(amber), 2=danger(red), 3=clear(green)
+    let _spotMode = 0;
+    let _spotIntensity = 0;  // smoothly animated 0→1
+
+    if (spotCtx) {
+      const { canvas: sC, gl: sGL } = spotCtx;
+
+      const quadVS = `#version 300 es
+        in vec2 aPos;
+        out vec2 vUV;
+        void main() {
+          vUV = aPos * 0.5 + 0.5;
+          gl_Position = vec4(aPos, 0.0, 1.0);
+        }`;
+
+      const spotFS = `#version 300 es
+        precision highp float;
+        in vec2 vUV;
+        out vec4 fragColor;
+
+        uniform float uTime;
+        uniform float uIntensity;  // 0-1 animated fade
+        uniform float uMode;       // 1=warn, 2=danger, 3=clear
+        uniform vec2  uRes;
+
+        float hash(vec2 p) {
+          return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+        }
+        float noise(vec2 p) {
+          vec2 i = floor(p), f = fract(p);
+          f = f * f * (3.0 - 2.0 * f);
+          return mix(mix(hash(i), hash(i + vec2(1,0)), f.x),
+                     mix(hash(i + vec2(0,1)), hash(i + vec2(1,1)), f.x), f.y);
+        }
+
+        void main() {
+          if (uIntensity < 0.005) { fragColor = vec4(0.0); return; }
+
+          vec2 uv = vUV;
+
+          // Color by mode
+          vec3 col;
+          float pulseSpeed;
+          if (uMode < 1.5) {
+            // Warn — warm amber
+            col = vec3(0.95, 0.70, 0.15);
+            pulseSpeed = 2.5;
+          } else if (uMode < 2.5) {
+            // Danger — urgent red
+            col = vec3(0.92, 0.18, 0.12);
+            pulseSpeed = 4.0;
+          } else {
+            // Clear — cool green
+            col = vec3(0.15, 0.82, 0.40);
+            pulseSpeed = 1.8;
+          }
+
+          // Edge distance — glow hugs all edges
+          float edgeX = min(uv.x, 1.0 - uv.x);
+          float edgeY = min(uv.y, 1.0 - uv.y);
+          float edgeDist = min(edgeX, edgeY);
+
+          // Primary edge glow — exponential falloff from borders
+          float edgeGlow = exp(-edgeDist * 12.0);
+
+          // Corner hotspots — brighter where two edges meet
+          float cornerDist = length(vec2(edgeX, edgeY));
+          float cornerGlow = exp(-cornerDist * 8.0) * 0.4;
+
+          // Animated pulse — breathing intensity
+          float pulse = 0.65 + 0.35 * sin(uTime * pulseSpeed);
+
+          // Danger mode: add a faster flicker overlay
+          float flicker = 1.0;
+          if (uMode > 1.5 && uMode < 2.5) {
+            flicker = 0.85 + 0.15 * sin(uTime * 11.0 + uv.x * 5.0);
+          }
+
+          // Noise-based shimmer along the edges
+          float shimmer = noise(uv * 6.0 + uTime * 1.5) * 0.3 + 0.7;
+
+          // Compose
+          float glow = (edgeGlow + cornerGlow) * pulse * flicker * shimmer;
+          glow *= uIntensity;
+
+          // Sweep highlight — slow beam traveling around the perimeter
+          float sweep = fract(uTime * 0.3);
+          // Parametric edge position: top→right→bottom→left mapped to 0→1
+          float perim;
+          if (uv.y < 0.05) perim = uv.x * 0.25;                          // top edge
+          else if (uv.x > 0.95) perim = 0.25 + uv.y * 0.25;             // right edge
+          else if (uv.y > 0.95) perim = 0.5 + (1.0 - uv.x) * 0.25;     // bottom edge
+          else if (uv.x < 0.05) perim = 0.75 + (1.0 - uv.y) * 0.25;    // left edge
+          else perim = -1.0;
+
+          if (perim >= 0.0) {
+            float beamDist = min(abs(perim - sweep), min(abs(perim - sweep + 1.0), abs(perim - sweep - 1.0)));
+            float beam = exp(-beamDist * beamDist * 800.0) * 0.5 * uIntensity;
+            glow += beam;
+          }
+
+          float alpha = clamp(glow * 0.6, 0.0, 0.65);
+          fragColor = vec4(col * alpha, alpha);
+        }`;
+
+      const vs = createShader(sGL, sGL.VERTEX_SHADER, quadVS);
+      const fs = createShader(sGL, sGL.FRAGMENT_SHADER, spotFS);
+      const prog = createProgram(sGL, vs, fs);
+
+      if (prog) {
+        const aPos       = sGL.getAttribLocation(prog, 'aPos');
+        const uTime      = sGL.getUniformLocation(prog, 'uTime');
+        const uIntensity = sGL.getUniformLocation(prog, 'uIntensity');
+        const uMode      = sGL.getUniformLocation(prog, 'uMode');
+        const uRes       = sGL.getUniformLocation(prog, 'uRes');
+
+        const buf = sGL.createBuffer();
+        sGL.bindBuffer(sGL.ARRAY_BUFFER, buf);
+        sGL.bufferData(sGL.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, 1,1]), sGL.STATIC_DRAW);
+
+        sGL.enable(sGL.BLEND);
+        sGL.blendFunc(sGL.ONE, sGL.ONE_MINUS_SRC_ALPHA);
+
+        window._spotterFXFrame = function(dt) {
+          // Smooth intensity towards target
+          const target = _spotMode > 0 ? 1.0 : 0.0;
+          const speed = target > 0.5 ? 6.0 : 3.0; // fast in, slower out
+          _spotIntensity += (target - _spotIntensity) * Math.min(1.0, dt * speed);
+
+          if (_spotIntensity < 0.005) {
+            // Clear canvas when fully faded
+            sGL.clearColor(0, 0, 0, 0);
+            sGL.clear(sGL.COLOR_BUFFER_BIT);
+            return;
+          }
+
+          // Only resize canvas when glow is ramping up — prevents jarring
+          // shrink when fading cards are removed from the DOM
+          if (target > 0.5) resizeCanvas(sC, sGL);
+          _spotTime += dt;
+
+          sGL.clearColor(0, 0, 0, 0);
+          sGL.clear(sGL.COLOR_BUFFER_BIT);
+
+          sGL.useProgram(prog);
+          sGL.bindBuffer(sGL.ARRAY_BUFFER, buf);
+          sGL.enableVertexAttribArray(aPos);
+          sGL.vertexAttribPointer(aPos, 2, sGL.FLOAT, false, 0, 0);
+
+          sGL.uniform1f(uTime, _spotTime);
+          sGL.uniform1f(uIntensity, _spotIntensity);
+          sGL.uniform1f(uMode, _spotMode);
+          sGL.uniform2f(uRes, sC.width, sC.height);
+
+          sGL.drawArrays(sGL.TRIANGLE_STRIP, 0, 4);
+        };
+      }
+    }
+
+    // Public API: set spotter glow mode
+    // 'warn' | 'danger' | 'clear' | 'off'
+    window.setSpotterGlow = function(type) {
+      switch (type) {
+        case 'warn':   _spotMode = 1; break;
+        case 'danger': _spotMode = 2; break;
+        case 'clear':  _spotMode = 3; break;
+        default:       _spotMode = 0; break;
+      }
+    };
+
+    /* ════════════════════════════════════════════
+       COMMENTARY TRAIL FX — flowing energy border
+       ════════════════════════════════════════════ */
+    const commGLCtx = initGL('commentaryGlCanvas');
+    let _commTrailActive = false;
+    let _commTrailTime = 0;
+    let _commTrailHue = 200;   // updated via setCommentaryTrailGL
+
+    if (commGLCtx) {
+      const { canvas: cC, gl: cGL } = commGLCtx;
+
+      const commVS = `#version 300 es
+        in vec2 aPos;
+        out vec2 vUV;
+        void main() {
+          vUV = aPos * 0.5 + 0.5;
+          gl_Position = vec4(aPos, 0.0, 1.0);
+        }`;
+
+      // Trail fragment shader — energy particles tracing the border,
+      // subtle inner ambient shimmer, hue-driven color.
+      const commFS = `#version 300 es
+        precision highp float;
+        in vec2 vUV;
+        out vec4 fragColor;
+
+        uniform float uTime;
+        uniform vec2  uRes;
+        uniform float uIntensity;  // 0-1 fade
+        uniform float uHue;        // 0-360
+
+        // ── Noise ──
+        float hash(vec2 p) {
+          return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+        }
+        float noise(vec2 p) {
+          vec2 i = floor(p), f = fract(p);
+          f = f * f * (3.0 - 2.0 * f);
+          return mix(mix(hash(i), hash(i + vec2(1,0)), f.x),
+                     mix(hash(i + vec2(0,1)), hash(i + vec2(1,1)), f.x), f.y);
+        }
+
+        // ── HSL to RGB ──
+        vec3 hsl2rgb(float h, float s, float l) {
+          float c = (1.0 - abs(2.0 * l - 1.0)) * s;
+          float x = c * (1.0 - abs(mod(h / 60.0, 2.0) - 1.0));
+          float m = l - c * 0.5;
+          vec3 rgb;
+          if (h < 60.0)       rgb = vec3(c, x, 0);
+          else if (h < 120.0) rgb = vec3(x, c, 0);
+          else if (h < 180.0) rgb = vec3(0, c, x);
+          else if (h < 240.0) rgb = vec3(0, x, c);
+          else if (h < 300.0) rgb = vec3(x, 0, c);
+          else                rgb = vec3(c, 0, x);
+          return rgb + m;
+        }
+
+        void main() {
+          vec2 uv = vUV;
+          float t = uTime;
+          float inten = uIntensity;
+          float aspect = uRes.x / uRes.y;
+
+          // Rounded-rect SDF (UV-space with aspect correction)
+          vec2 center = vec2(0.5);
+          float cornerR = 0.06;
+          vec2 d = abs(uv - center) - vec2(0.5 - cornerR);
+          // aspect-correct for x
+          d.x *= aspect;
+          float sdf = length(max(d, 0.0)) + min(max(d.x, d.y), 0.0) - cornerR * aspect;
+
+          // Border band — narrow strip along the edge
+          float borderW = 0.022;
+          float border = smoothstep(borderW, borderW * 0.3, abs(sdf));
+
+          // ── Trail particles: 3 streams at different speeds ──
+          // Parametric angle around the perimeter
+          float angle = atan(uv.y - 0.5, (uv.x - 0.5) * aspect);
+          float a = angle / 6.28318 + 0.5; // normalize 0-1
+
+          float trail1 = pow(max(0.0, sin(a * 12.5663 + t * 3.0)), 16.0);
+          float trail2 = pow(max(0.0, sin(a * 18.8496 - t * 2.2 + 1.0)), 12.0);
+          float trail3 = pow(max(0.0, sin(a * 8.3776  + t * 4.5 + 2.5)), 20.0);
+
+          float trails = (trail1 * 0.7 + trail2 * 0.5 + trail3 * 0.9);
+          trails *= border;
+
+          // ── Flowing shimmer along border ──
+          float shimmer = noise(vec2(a * 8.0 + t * 1.5, t * 0.3)) * 0.5 + 0.5;
+          shimmer *= border * 0.35;
+
+          // ── Subtle inner ambient glow ──
+          float innerDist = smoothstep(0.0, -0.08, sdf);
+          float ambient = innerDist * 0.04 * (0.7 + 0.3 * sin(t * 0.8));
+
+          // ── Color: hue-matched with slight variation on trails ──
+          vec3 baseCol = hsl2rgb(uHue, 0.6, 0.55);
+          vec3 brightCol = hsl2rgb(uHue, 0.7, 0.7);
+          vec3 trailCol = mix(baseCol, brightCol, trails);
+
+          // ── Compose ──
+          float alpha = (trails * 0.6 + shimmer * 0.4 + ambient) * inten;
+          vec3 col = trailCol;
+
+          // Clamp
+          alpha = clamp(alpha, 0.0, 0.65);
+
+          fragColor = vec4(col * alpha, alpha);
+        }`;
+
+      const cvs = createShader(cGL, cGL.VERTEX_SHADER, commVS);
+      const cfs = createShader(cGL, cGL.FRAGMENT_SHADER, commFS);
+      const commProg = (cvs && cfs) ? createProgram(cGL, cvs, cfs) : null;
+
+      if (commProg) {
+        const commPosLoc = cGL.getAttribLocation(commProg, 'aPos');
+        const commUTime = cGL.getUniformLocation(commProg, 'uTime');
+        const commURes = cGL.getUniformLocation(commProg, 'uRes');
+        const commUInten = cGL.getUniformLocation(commProg, 'uIntensity');
+        const commUHue = cGL.getUniformLocation(commProg, 'uHue');
+
+        const commBuf = cGL.createBuffer();
+        cGL.bindBuffer(cGL.ARRAY_BUFFER, commBuf);
+        cGL.bufferData(cGL.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, 1,1]), cGL.STATIC_DRAW);
+
+        let _commInten = 0;
+
+        window._commTrailFXFrame = function(dt) {
+          if (_commTrailActive) {
+            _commInten = Math.min(1, _commInten + dt * 2.0);  // fade in ~0.5s
+            _commTrailTime += dt;
+          } else {
+            _commInten = Math.max(0, _commInten - dt * 3.0);  // fade out faster
+            if (_commInten <= 0) return;
+          }
+
+          resizeCanvas(cC, cGL);
+          cGL.enable(cGL.BLEND);
+          cGL.blendFunc(cGL.SRC_ALPHA, cGL.ONE);  // additive
+          cGL.clearColor(0, 0, 0, 0);
+          cGL.clear(cGL.COLOR_BUFFER_BIT);
+
+          cGL.useProgram(commProg);
+          cGL.uniform1f(commUTime, _commTrailTime);
+          cGL.uniform2f(commURes, cC.width, cC.height);
+          cGL.uniform1f(commUInten, _commInten);
+          cGL.uniform1f(commUHue, _commTrailHue);
+
+          cGL.bindBuffer(cGL.ARRAY_BUFFER, commBuf);
+          cGL.enableVertexAttribArray(commPosLoc);
+          cGL.vertexAttribPointer(commPosLoc, 2, cGL.FLOAT, false, 0, 0);
+          cGL.drawArrays(cGL.TRIANGLE_STRIP, 0, 4);
+        };
+      }
+    }
+
+    // Public API: toggle commentary trail + set hue
+    window.setCommentaryTrailGL = function(active, hue) {
+      _commTrailActive = active;
+      if (typeof hue === 'number') _commTrailHue = hue;
+      if (active) _commTrailTime = 0;
+    };
+
+    /* ════════════════════════════════════════════
+       BONKERS PIT BANNER FX — fire / energy burst
+       ════════════════════════════════════════════ */
+    const pitGLCtx = initGL('pitGlCanvas');
+    let _bonkersGLActive = false;
+    let _bonkersTime = 0;
+
+    if (pitGLCtx) {
+      const { canvas: pC, gl: pGL } = pitGLCtx;
+
+      const pitVS = `#version 300 es
+        in vec2 aPos;
+        out vec2 vUV;
+        void main() {
+          vUV = aPos * 0.5 + 0.5;
+          gl_Position = vec4(aPos, 0.0, 1.0);
+        }`;
+
+      const pitFS = `#version 300 es
+        precision highp float;
+        in vec2 vUV;
+        out vec4 fragColor;
+
+        uniform float uTime;
+        uniform vec2  uRes;
+        uniform float uIntensity;  // 0-1, ramps up
+
+        // ── Noise functions ──
+        float hash(vec2 p) {
+          return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+        }
+        float noise(vec2 p) {
+          vec2 i = floor(p), f = fract(p);
+          f = f * f * (3.0 - 2.0 * f);
+          return mix(mix(hash(i), hash(i + vec2(1,0)), f.x),
+                     mix(hash(i + vec2(0,1)), hash(i + vec2(1,1)), f.x), f.y);
+        }
+        float fbm(vec2 p) {
+          float v = 0.0, a = 0.5;
+          for (int i = 0; i < 4; i++) {
+            v += a * noise(p);
+            p *= 2.1;
+            a *= 0.5;
+          }
+          return v;
+        }
+
+        void main() {
+          vec2 uv = vUV;
+          vec2 center = vec2(0.5, 0.5);
+          float t = uTime;
+          float inten = uIntensity;
+
+          // Distance from perimeter (0 at edge, 1 at center)
+          float dx = abs(uv.x - 0.5) * 2.0;
+          float dy = abs(uv.y - 0.5) * 2.0;
+          float edgeDist = max(dx, dy);
+          float border = smoothstep(0.7, 1.0, edgeDist);
+
+          // ── Fire layer: fbm-driven flames rising from edges ──
+          vec2 fireUV = uv * vec2(4.0, 3.0);
+          fireUV.y -= t * 2.5;                    // flames rise
+          float fire = fbm(fireUV + t * 0.8);
+          fire = smoothstep(0.3, 0.7, fire);
+          fire *= border * inten;
+
+          // Fire color: red core → orange → yellow tips
+          vec3 fireCol = mix(vec3(0.9, 0.1, 0.0), vec3(1.0, 0.7, 0.0), fire);
+          fireCol = mix(fireCol, vec3(1.0, 1.0, 0.3), fire * fire);
+
+          // ── Energy arcs: bright streaks along perimeter ──
+          float angle = atan(uv.y - 0.5, uv.x - 0.5);
+          float arc1 = sin(angle * 8.0 + t * 12.0) * 0.5 + 0.5;
+          float arc2 = sin(angle * 5.0 - t * 9.0 + 1.5) * 0.5 + 0.5;
+          float arcMask = smoothstep(0.82, 0.95, edgeDist);
+          float arcs = (pow(arc1, 8.0) + pow(arc2, 6.0) * 0.7) * arcMask * inten;
+          vec3 arcCol = mix(vec3(1.0, 0.3, 0.0), vec3(1.0, 0.9, 0.2), arc1);
+
+          // ── Heat shimmer: distorted inner haze ──
+          float shimmer = noise(uv * 10.0 + t * 3.0) * 0.15;
+          float innerGlow = smoothstep(0.85, 0.5, edgeDist) * shimmer * inten;
+          vec3 shimmerCol = vec3(0.8, 0.2, 0.0) * innerGlow;
+
+          // ── Pulse: whole-surface throb ──
+          float pulse = (sin(t * 15.0) * 0.5 + 0.5) * 0.12 * inten * border;
+
+          // ── Compose ──
+          vec3 col = fireCol * fire * 0.9
+                   + arcCol * arcs * 0.8
+                   + shimmerCol
+                   + vec3(1.0, 0.5, 0.1) * pulse;
+
+          float alpha = fire * 0.7 + arcs * 0.6 + innerGlow + pulse;
+          alpha = clamp(alpha * inten, 0.0, 0.85);
+
+          fragColor = vec4(col * alpha, alpha);
+        }`;
+
+      const pvs = createShader(pGL, pGL.VERTEX_SHADER, pitVS);
+      const pfs = createShader(pGL, pGL.FRAGMENT_SHADER, pitFS);
+      const pitProg = (pvs && pfs) ? createProgram(pGL, pvs, pfs) : null;
+
+      if (pitProg) {
+        const pitPosLoc = pGL.getAttribLocation(pitProg, 'aPos');
+        const pitUTime = pGL.getUniformLocation(pitProg, 'uTime');
+        const pitURes = pGL.getUniformLocation(pitProg, 'uRes');
+        const pitUInten = pGL.getUniformLocation(pitProg, 'uIntensity');
+
+        // Full-screen quad
+        const pitBuf = pGL.createBuffer();
+        pGL.bindBuffer(pGL.ARRAY_BUFFER, pitBuf);
+        pGL.bufferData(pGL.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, 1,1]), pGL.STATIC_DRAW);
+
+        let _bonkersInten = 0;  // smoothly ramps 0→1
+
+        window._bonkersFXFrame = function(dt) {
+          // Ramp intensity
+          if (_bonkersGLActive) {
+            _bonkersInten = Math.min(1, _bonkersInten + dt * 2.5); // ramp up over 0.4s
+            _bonkersTime += dt;
+          } else {
+            _bonkersInten = Math.max(0, _bonkersInten - dt * 4.0); // ramp down faster
+            if (_bonkersInten <= 0) return;
+          }
+
+          resizeCanvas(pC, pGL);
+          pGL.enable(pGL.BLEND);
+          pGL.blendFunc(pGL.SRC_ALPHA, pGL.ONE);  // additive for fire
+          pGL.clearColor(0, 0, 0, 0);
+          pGL.clear(pGL.COLOR_BUFFER_BIT);
+
+          pGL.useProgram(pitProg);
+          pGL.uniform1f(pitUTime, _bonkersTime);
+          pGL.uniform2f(pitURes, pC.width, pC.height);
+          pGL.uniform1f(pitUInten, _bonkersInten);
+
+          pGL.bindBuffer(pGL.ARRAY_BUFFER, pitBuf);
+          pGL.enableVertexAttribArray(pitPosLoc);
+          pGL.vertexAttribPointer(pitPosLoc, 2, pGL.FLOAT, false, 0, 0);
+          pGL.drawArrays(pGL.TRIANGLE_STRIP, 0, 4);
+        };
+      }
+    }
+
+    // Public API: toggle bonkers WebGL
+    window.setBonkersGL = function(active) {
+      _bonkersGLActive = active;
+      if (active) _bonkersTime = 0;
+    };
+
+    /* ════════════════════════════════════════════
+       INCIDENTS MODULE FX — penalty / DQ fire glow
+       Reuses the bonkers fire pattern with two modes:
+         'penalty' → yellower, subtler, lower intensity
+         'dq'      → full red bonkers fire
+       ════════════════════════════════════════════ */
+    const incGLCtx = initGL('incGlCanvas');
+    let _incGLMode = '';   // '', 'penalty', 'dq'
+    let _incGLTime = 0;
+    let _incGLInten = 0;
+
+    if (incGLCtx) {
+      const { canvas: iC, gl: iGL } = incGLCtx;
+
+      const incVS = `#version 300 es
+        in vec2 aPos;
+        out vec2 vUV;
+        void main() {
+          vUV = aPos * 0.5 + 0.5;
+          gl_Position = vec4(aPos, 0.0, 1.0);
+        }`;
+
+      const incFS = `#version 300 es
+        precision highp float;
+        in vec2 vUV;
+        out vec4 fragColor;
+
+        uniform float uTime;
+        uniform vec2  uRes;
+        uniform float uIntensity;
+        uniform float uHueShift;   // 0.0 = red/orange (DQ), 1.0 = yellow/amber (penalty)
+
+        float hash(vec2 p) {
+          return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+        }
+        float noise(vec2 p) {
+          vec2 i = floor(p), f = fract(p);
+          f = f * f * (3.0 - 2.0 * f);
+          return mix(mix(hash(i), hash(i+vec2(1,0)), f.x),
+                     mix(hash(i+vec2(0,1)), hash(i+vec2(1,1)), f.x), f.y);
+        }
+        float fbm(vec2 p) {
+          float v = 0.0, a = 0.5;
+          for (int i = 0; i < 4; i++) { v += a * noise(p); p *= 2.1; a *= 0.5; }
+          return v;
+        }
+
+        void main() {
+          vec2 uv = vUV;
+          float t = uTime;
+          float inten = uIntensity;
+          float dx = abs(uv.x - 0.5) * 2.0;
+          float dy = abs(uv.y - 0.5) * 2.0;
+          float edgeDist = max(dx, dy);
+          float border = smoothstep(0.65, 1.0, edgeDist);
+
+          // Fire
+          vec2 fireUV = uv * vec2(4.0, 3.0);
+          fireUV.y -= t * 2.0;
+          float fire = fbm(fireUV + t * 0.6);
+          fire = smoothstep(0.35, 0.7, fire) * border * inten;
+
+          // Color shift: DQ (hueShift=0) = red→orange, penalty (hueShift=1) = amber→yellow
+          vec3 coreCol  = mix(vec3(0.9, 0.1, 0.0), vec3(0.85, 0.65, 0.0), uHueShift);
+          vec3 tipCol   = mix(vec3(1.0, 0.7, 0.0), vec3(1.0, 0.95, 0.3), uHueShift);
+          vec3 brightCol = mix(vec3(1.0, 1.0, 0.3), vec3(1.0, 1.0, 0.6), uHueShift);
+          vec3 fireCol = mix(coreCol, tipCol, fire);
+          fireCol = mix(fireCol, brightCol, fire * fire);
+
+          // Energy arcs — subtler for penalty
+          float angle = atan(uv.y - 0.5, uv.x - 0.5);
+          float arcSpeed = mix(10.0, 6.0, uHueShift);
+          float arc1 = sin(angle * 6.0 + t * arcSpeed) * 0.5 + 0.5;
+          float arcMask = smoothstep(0.80, 0.95, edgeDist);
+          float arcs = pow(arc1, 8.0) * arcMask * inten * mix(0.8, 0.4, uHueShift);
+          vec3 arcCol = mix(tipCol, brightCol, arc1);
+
+          // Compose
+          vec3 col = fireCol * fire * 0.85 + arcCol * arcs * 0.7;
+          float alpha = fire * 0.6 + arcs * 0.5;
+          alpha = clamp(alpha * inten, 0.0, mix(0.80, 0.50, uHueShift));
+
+          fragColor = vec4(col * alpha, alpha);
+        }`;
+
+      const ivs = createShader(iGL, iGL.VERTEX_SHADER, incVS);
+      const ifs = createShader(iGL, iGL.FRAGMENT_SHADER, incFS);
+      const incProg = (ivs && ifs) ? createProgram(iGL, ivs, ifs) : null;
+
+      if (incProg) {
+        const incPosLoc = iGL.getAttribLocation(incProg, 'aPos');
+        const incUTime  = iGL.getUniformLocation(incProg, 'uTime');
+        const incURes   = iGL.getUniformLocation(incProg, 'uRes');
+        const incUInten = iGL.getUniformLocation(incProg, 'uIntensity');
+        const incUHue   = iGL.getUniformLocation(incProg, 'uHueShift');
+
+        const incBuf = iGL.createBuffer();
+        iGL.bindBuffer(iGL.ARRAY_BUFFER, incBuf);
+        iGL.bufferData(iGL.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, 1,1]), iGL.STATIC_DRAW);
+
+        window._incidentsFXFrame = function(dt) {
+          const active = _incGLMode !== '';
+          if (active) {
+            _incGLInten = Math.min(1, _incGLInten + dt * 2.0);
+            _incGLTime += dt;
+          } else {
+            _incGLInten = Math.max(0, _incGLInten - dt * 3.0);
+            if (_incGLInten <= 0) return;
+          }
+
+          resizeCanvas(iC, iGL);
+          iGL.enable(iGL.BLEND);
+          iGL.blendFunc(iGL.SRC_ALPHA, iGL.ONE);
+          iGL.clearColor(0, 0, 0, 0);
+          iGL.clear(iGL.COLOR_BUFFER_BIT);
+
+          iGL.useProgram(incProg);
+          iGL.uniform1f(incUTime, _incGLTime);
+          iGL.uniform2f(incURes, iC.width, iC.height);
+          iGL.uniform1f(incUInten, _incGLInten);
+          iGL.uniform1f(incUHue, _incGLMode === 'penalty' ? 1.0 : 0.0);
+
+          iGL.bindBuffer(iGL.ARRAY_BUFFER, incBuf);
+          iGL.enableVertexAttribArray(incPosLoc);
+          iGL.vertexAttribPointer(incPosLoc, 2, iGL.FLOAT, false, 0, 0);
+          iGL.drawArrays(iGL.TRIANGLE_STRIP, 0, 4);
+        };
+      }
+    }
+
+    // Public API: set incidents fire mode ('', 'penalty', 'dq')
+    window.setIncidentsGL = function(mode) {
+      const prev = _incGLMode;
+      _incGLMode = mode || '';
+      if (_incGLMode && !prev) _incGLTime = 0;
+      // Toggle CSS class for canvas opacity
+      const panel = document.getElementById('incidentsPanel');
+      if (panel) panel.classList.toggle('inc-bonkers', _incGLMode !== '');
+    };
+
+    /* ════════════════════════════════════════════
+       GRID FLAG FX — flag-colored energy tendrils
+       that radiate outward beyond the card edges.
+       Three flag colors drift as aurora-like wisps,
+       with particle sparks at the periphery.
+       ════════════════════════════════════════════ */
+    // ═══════════════════════════════════════════════════════════════
+    // MANUFACTURER COUNTRY FLAG — aurora wisps WebGL effect
+    // Shows for 5 seconds on: practice pit exit, quali first timed lap,
+    // race green lights. Fades out over 1s via CSS transition.
+    // ═══════════════════════════════════════════════════════════════
+    const mfrFlagCtx = initGL('mfrFlagCanvas');
+    let _mfrFlagActive = false;
+    let _mfrFlagTime = 0;
+    let _mfrFlagDuration = 5.0; // seconds before fade-out starts
+    let _mfrFlagInten = 0;
+    let _mfrFlagCol1 = [0.5, 0.5, 0.5];
+    let _mfrFlagCol2 = [0.5, 0.5, 0.5];
+    let _mfrFlagCol3 = [0.5, 0.5, 0.5];
+
+    if (mfrFlagCtx) {
+      const { canvas: mfC, gl: mfGL } = mfrFlagCtx;
+
+      const mfVS = `#version 300 es
+        in vec2 aPos;
+        out vec2 vUV;
+        void main() {
+          vUV = aPos * 0.5 + 0.5;
+          gl_Position = vec4(aPos, 0.0, 1.0);
+        }`;
+
+      // Aurora wisps — same style as grid flag, adapted for logo square
+      const mfFS = `#version 300 es
+        precision highp float;
+        in vec2 vUV;
+        out vec4 fragColor;
+
+        uniform float uTime;
+        uniform float uIntensity;
+        uniform vec2  uRes;
+        uniform vec3  uCol1;
+        uniform vec3  uCol2;
+        uniform vec3  uCol3;
+
+        float hash(vec2 p) {
+          return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+        }
+        float noise(vec2 p) {
+          vec2 i = floor(p), f = fract(p);
+          f = f * f * (3.0 - 2.0 * f);
+          return mix(mix(hash(i), hash(i+vec2(1,0)), f.x),
+                     mix(hash(i+vec2(0,1)), hash(i+vec2(1,1)), f.x), f.y);
+        }
+        float fbm(vec2 p) {
+          float v = 0.0, a = 0.5;
+          for (int i = 0; i < 4; i++) {
+            v += a * noise(p);
+            p = p * 2.1 + 0.3;
+            a *= 0.5;
+          }
+          return v;
+        }
+
+        void main() {
+          vec2 uv = vUV;
+          float aspect = uRes.x / uRes.y;
+          vec2 p = (uv - 0.5) * vec2(aspect, 1.0);
+          float t = uTime;
+
+          // ── Aurora wisps: fbm-driven flowing tendrils ──
+          float angle = atan(p.y, p.x);
+          float dist = length(p);
+
+          // Three color channels at different speeds/offsets
+          float n1 = fbm(vec2(angle * 1.2 - t * 0.4, dist * 3.0 + t * 0.2));
+          float n2 = fbm(vec2(angle * 1.2 + t * 0.5 + 2.094, dist * 3.0 - t * 0.15));
+          float n3 = fbm(vec2(angle * 1.2 - t * 0.35 + 4.189, dist * 3.0 + t * 0.25));
+
+          // Shape each wisp
+          float falloff = exp(-dist * 2.5);
+          float w1 = pow(n1, 2.5) * falloff;
+          float w2 = pow(n2, 2.5) * falloff;
+          float w3 = pow(n3, 2.5) * falloff;
+
+          // Boost flag colors for vibrancy
+          vec3 c1 = uCol1 * 0.8 + 0.2;
+          vec3 c2 = uCol2 * 0.8 + 0.2;
+          vec3 c3 = uCol3 * 0.8 + 0.2;
+
+          vec3 col = c1 * w1 + c2 * w2 + c3 * w3;
+
+          // ── Edge glow ──
+          float edgeGlow = exp(-dist * 6.0) * 0.35;
+          float wTotal = w1 + w2 + w3 + 0.001;
+          vec3 edgeCol = (c1 * w1 + c2 * w2 + c3 * w3) / wTotal;
+          col += edgeCol * edgeGlow;
+
+          // ── Spark particles ──
+          float sparkNoise = noise(uv * 40.0 + t * vec2(1.3, 0.7));
+          float sparkMask = smoothstep(0.92, 0.96, sparkNoise) * falloff * 1.5;
+          col += edgeCol * sparkMask;
+
+          // ── Breathing pulse ──
+          float pulse = 0.85 + 0.15 * sin(t * 1.5);
+
+          float alpha = (w1 + w2 + w3 + edgeGlow + sparkMask * 0.5) * uIntensity * pulse;
+          alpha = clamp(alpha, 0.0, 0.7);
+
+          // Soft fade at canvas edges
+          float canvasEdge = min(min(uv.x, 1.0 - uv.x), min(uv.y, 1.0 - uv.y));
+          alpha *= smoothstep(0.0, 0.08, canvasEdge);
+
+          fragColor = vec4(col * alpha, alpha);
+        }`;
+
+      const mfvs = createShader(mfGL, mfGL.VERTEX_SHADER, mfVS);
+      const mffs = createShader(mfGL, mfGL.FRAGMENT_SHADER, mfFS);
+      const mfProg = (mfvs && mffs) ? createProgram(mfGL, mfvs, mffs) : null;
+
+      if (mfProg) {
+        const mfPosLoc  = mfGL.getAttribLocation(mfProg, 'aPos');
+        const mfUTime   = mfGL.getUniformLocation(mfProg, 'uTime');
+        const mfUInten  = mfGL.getUniformLocation(mfProg, 'uIntensity');
+        const mfURes    = mfGL.getUniformLocation(mfProg, 'uRes');
+        const mfUCol1   = mfGL.getUniformLocation(mfProg, 'uCol1');
+        const mfUCol2   = mfGL.getUniformLocation(mfProg, 'uCol2');
+        const mfUCol3   = mfGL.getUniformLocation(mfProg, 'uCol3');
+
+        const mfBuf = mfGL.createBuffer();
+        mfGL.bindBuffer(mfGL.ARRAY_BUFFER, mfBuf);
+        mfGL.bufferData(mfGL.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, 1,1]), mfGL.STATIC_DRAW);
+
+        window._mfrFlagFXFrame = function(dt) {
+          if (_mfrFlagActive) {
+            _mfrFlagInten = Math.min(1, _mfrFlagInten + dt * 2.0);
+            _mfrFlagTime += dt;
+            // Auto-stop after duration
+            if (_mfrFlagTime >= _mfrFlagDuration) {
+              _mfrFlagActive = false;
+              // Trigger CSS fade-out
+              const cvs = document.getElementById('mfrFlagCanvas');
+              if (cvs) cvs.classList.remove('flag-visible');
+            }
+          } else {
+            _mfrFlagInten = Math.max(0, _mfrFlagInten - dt * 1.5);
+            if (_mfrFlagInten <= 0) return;
+          }
+
+          resizeCanvas(mfC, mfGL);
+          mfGL.enable(mfGL.BLEND);
+          mfGL.blendFunc(mfGL.SRC_ALPHA, mfGL.ONE);
+          mfGL.clearColor(0, 0, 0, 0);
+          mfGL.clear(mfGL.COLOR_BUFFER_BIT);
+
+          mfGL.useProgram(mfProg);
+          mfGL.uniform1f(mfUTime, _mfrFlagTime);
+          mfGL.uniform1f(mfUInten, _mfrFlagInten);
+          mfGL.uniform2f(mfURes, mfC.width, mfC.height);
+          mfGL.uniform3fv(mfUCol1, _mfrFlagCol1);
+          mfGL.uniform3fv(mfUCol2, _mfrFlagCol2);
+          mfGL.uniform3fv(mfUCol3, _mfrFlagCol3);
+
+          mfGL.bindBuffer(mfGL.ARRAY_BUFFER, mfBuf);
+          mfGL.enableVertexAttribArray(mfPosLoc);
+          mfGL.vertexAttribPointer(mfPosLoc, 2, mfGL.FLOAT, false, 0, 0);
+          mfGL.drawArrays(mfGL.TRIANGLE_STRIP, 0, 4);
+        };
+      }
+    }
+
+    // Public API: trigger the manufacturer flag animation
+    window.showMfrFlag = function(hex1, hex2, hex3) {
+      function hexToGL(hex) {
+        hex = hex.replace('#', '');
+        return [
+          parseInt(hex.substring(0, 2), 16) / 255,
+          parseInt(hex.substring(2, 4), 16) / 255,
+          parseInt(hex.substring(4, 6), 16) / 255
+        ];
+      }
+      _mfrFlagCol1 = hexToGL(hex1);
+      _mfrFlagCol2 = hexToGL(hex2);
+      _mfrFlagCol3 = hexToGL(hex3);
+      _mfrFlagActive = true;
+      _mfrFlagTime = 0;
+      _mfrFlagInten = 0;
+      const cvs = document.getElementById('mfrFlagCanvas');
+      if (cvs) cvs.classList.add('flag-visible');
+    };
+
+    // Public API: cancel early if needed
+    window.hideMfrFlag = function() {
+      _mfrFlagActive = false;
+      const cvs = document.getElementById('mfrFlagCanvas');
+      if (cvs) cvs.classList.remove('flag-visible');
+    };
+
+    const flagGLCtx = initGL('gridFlagGlCanvas');
+    let _flagGLActive = false;
+    let _flagGLTime = 0;
+    // Flag colors (linear RGB) — updated via setGridFlagColors
+    let _gridFlagCol1 = [0.35, 0.55, 0.85];
+    let _gridFlagCol2 = [0.6, 0.65, 0.8];
+    let _gridFlagCol3 = [0.5, 0.7, 0.95];
+
+    if (flagGLCtx) {
+      const { canvas: fC, gl: fGL } = flagGLCtx;
+
+      const flagVS = `#version 300 es
+        in vec2 aPos;
+        out vec2 vUV;
+        void main() {
+          vUV = aPos * 0.5 + 0.5;
+          gl_Position = vec4(aPos, 0.0, 1.0);
+        }`;
+
+      const flagFS = `#version 300 es
+        precision highp float;
+        in vec2 vUV;
+        out vec4 fragColor;
+
+        uniform float uTime;
+        uniform float uIntensity;
+        uniform vec2  uRes;
+        uniform vec3  uCol1;
+        uniform vec3  uCol2;
+        uniform vec3  uCol3;
+
+        // Noise helpers
+        float hash(vec2 p) {
+          return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+        }
+        float noise(vec2 p) {
+          vec2 i = floor(p), f = fract(p);
+          f = f * f * (3.0 - 2.0 * f);
+          return mix(mix(hash(i), hash(i+vec2(1,0)), f.x),
+                     mix(hash(i+vec2(0,1)), hash(i+vec2(1,1)), f.x), f.y);
+        }
+        float fbm(vec2 p) {
+          float v = 0.0, a = 0.5;
+          for (int i = 0; i < 4; i++) {
+            v += a * noise(p);
+            p = p * 2.1 + 0.3;
+            a *= 0.5;
+          }
+          return v;
+        }
+
+        // Rounded-rect SDF
+        float roundedBox(vec2 p, vec2 b, float r) {
+          vec2 d = abs(p) - b + r;
+          return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0) - r;
+        }
+
+        void main() {
+          vec2 uv = vUV;
+          float aspect = uRes.x / uRes.y;
+          vec2 p = (uv - 0.5) * vec2(aspect, 1.0);
+          float t = uTime;
+
+          // Card shape — the inner card occupies ~60% of canvas
+          // (canvas extends 80px beyond card on each side)
+          vec2 boxSize = vec2(aspect * 0.30, 0.34);
+          float r = 0.035;
+          float d = roundedBox(p, boxSize, r);
+
+          // Only draw outside the card
+          if (d < -0.005) { fragColor = vec4(0.0); return; }
+
+          // ── Aurora wisps: fbm-driven flowing tendrils ──
+          float angle = atan(p.y, p.x);
+          float edgeDist = max(0.0, d);
+
+          // Three color channels at different speeds/offsets
+          float n1 = fbm(vec2(angle * 1.2 - t * 0.4, edgeDist * 3.0 + t * 0.2));
+          float n2 = fbm(vec2(angle * 1.2 + t * 0.5 + 2.094, edgeDist * 3.0 - t * 0.15));
+          float n3 = fbm(vec2(angle * 1.2 - t * 0.35 + 4.189, edgeDist * 3.0 + t * 0.25));
+
+          // Shape each wisp: strong near edge, fading outward
+          float falloff = exp(-edgeDist * 4.5);
+          float w1 = pow(n1, 2.5) * falloff;
+          float w2 = pow(n2, 2.5) * falloff;
+          float w3 = pow(n3, 2.5) * falloff;
+
+          // Boost flag colors for vibrancy
+          vec3 c1 = uCol1 * 0.8 + 0.2;
+          vec3 c2 = uCol2 * 0.8 + 0.2;
+          vec3 c3 = uCol3 * 0.8 + 0.2;
+
+          vec3 col = c1 * w1 + c2 * w2 + c3 * w3;
+
+          // ── Edge glow: soft light hugging the card border ──
+          float edgeGlow = exp(-edgeDist * 12.0) * 0.35;
+          float wTotal = w1 + w2 + w3 + 0.001;
+          vec3 edgeCol = (c1 * w1 + c2 * w2 + c3 * w3) / wTotal;
+          col += edgeCol * edgeGlow;
+
+          // ── Spark particles: bright dots at the periphery ──
+          float sparkNoise = noise(uv * 40.0 + t * vec2(1.3, 0.7));
+          float sparkMask = smoothstep(0.92, 0.96, sparkNoise) * falloff * 1.5;
+          col += edgeCol * sparkMask;
+
+          // ── Breathing pulse ──
+          float pulse = 0.85 + 0.15 * sin(t * 1.5);
+
+          float alpha = (w1 + w2 + w3 + edgeGlow + sparkMask * 0.5) * uIntensity * pulse;
+          alpha = clamp(alpha, 0.0, 0.7);
+
+          // Soft fade at canvas edges to avoid hard cutoff
+          float canvasEdge = min(min(uv.x, 1.0 - uv.x), min(uv.y, 1.0 - uv.y));
+          alpha *= smoothstep(0.0, 0.08, canvasEdge);
+
+          fragColor = vec4(col * alpha, alpha);
+        }`;
+
+      const fvs = createShader(fGL, fGL.VERTEX_SHADER, flagVS);
+      const ffs = createShader(fGL, fGL.FRAGMENT_SHADER, flagFS);
+      const flagProg = (fvs && ffs) ? createProgram(fGL, fvs, ffs) : null;
+
+      if (flagProg) {
+        const flagPosLoc = fGL.getAttribLocation(flagProg, 'aPos');
+        const flagUTime  = fGL.getUniformLocation(flagProg, 'uTime');
+        const flagUInten = fGL.getUniformLocation(flagProg, 'uIntensity');
+        const flagURes   = fGL.getUniformLocation(flagProg, 'uRes');
+        const flagUCol1  = fGL.getUniformLocation(flagProg, 'uCol1');
+        const flagUCol2  = fGL.getUniformLocation(flagProg, 'uCol2');
+        const flagUCol3  = fGL.getUniformLocation(flagProg, 'uCol3');
+
+        const flagBuf = fGL.createBuffer();
+        fGL.bindBuffer(fGL.ARRAY_BUFFER, flagBuf);
+        fGL.bufferData(fGL.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, 1,1]), fGL.STATIC_DRAW);
+
+        let _flagInten = 0;
+
+        window._gridFlagFXFrame = function(dt) {
+          if (_flagGLActive) {
+            _flagInten = Math.min(1, _flagInten + dt * 1.5);
+            _flagGLTime += dt;
+          } else {
+            _flagInten = Math.max(0, _flagInten - dt * 2.0);
+            if (_flagInten <= 0) return;
+          }
+
+          resizeCanvas(fC, fGL);
+          fGL.enable(fGL.BLEND);
+          fGL.blendFunc(fGL.SRC_ALPHA, fGL.ONE);
+          fGL.clearColor(0, 0, 0, 0);
+          fGL.clear(fGL.COLOR_BUFFER_BIT);
+
+          fGL.useProgram(flagProg);
+          fGL.uniform1f(flagUTime, _flagGLTime);
+          fGL.uniform1f(flagUInten, _flagInten);
+          fGL.uniform2f(flagURes, fC.width, fC.height);
+          fGL.uniform3fv(flagUCol1, _gridFlagCol1);
+          fGL.uniform3fv(flagUCol2, _gridFlagCol2);
+          fGL.uniform3fv(flagUCol3, _gridFlagCol3);
+
+          fGL.bindBuffer(fGL.ARRAY_BUFFER, flagBuf);
+          fGL.enableVertexAttribArray(flagPosLoc);
+          fGL.vertexAttribPointer(flagPosLoc, 2, fGL.FLOAT, false, 0, 0);
+          fGL.drawArrays(fGL.TRIANGLE_STRIP, 0, 4);
+        };
+      }
+    }
+
+    // Public API: toggle grid flag WebGL
+    window.setGridFlagGL = function(active) {
+      _flagGLActive = active;
+      if (active) _flagGLTime = 0;
+    };
+
+    // Public API: set flag colors for the grid flag glow (hex → linear RGB)
+    window.setGridFlagColors = function(hex1, hex2, hex3) {
+      function hexToGL(hex) {
+        hex = hex.replace('#', '');
+        return [
+          parseInt(hex.substring(0, 2), 16) / 255,
+          parseInt(hex.substring(2, 4), 16) / 255,
+          parseInt(hex.substring(4, 6), 16) / 255
+        ];
+      }
+      _gridFlagCol1 = hexToGL(hex1);
+      _gridFlagCol2 = hexToGL(hex2);
+      _gridFlagCol3 = hexToGL(hex3);
+    };
+
+    /* ── Master FX animation loop ── */
+    let _lastFXTime = 0;
+    function fxLoop(now) {
+      const dt = Math.min((now - _lastFXTime) / 1000, 0.05); // cap at 50ms
+      _lastFXTime = now;
+      // Skip rendering when WebGL effects are disabled
+      if (typeof _settings !== 'undefined' && _settings.showWebGL === false) {
+        requestAnimationFrame(fxLoop);
+        return;
+      }
+      if (window._tachoFXFrame) window._tachoFXFrame(dt);
+      if (window._flagFXFrame) window._flagFXFrame(dt);
+      if (window._lbFXFrame) window._lbFXFrame(dt);
+      if (window._lbEvtFXFrame) window._lbEvtFXFrame(dt);
+      if (window._k10LogoFXFrame) window._k10LogoFXFrame(dt);
+      if (window._spotterFXFrame) window._spotterFXFrame(dt);
+      if (window._bonkersFXFrame) window._bonkersFXFrame(dt);
+      if (window._incidentsFXFrame) window._incidentsFXFrame(dt);
+      if (window._commTrailFXFrame) window._commTrailFXFrame(dt);
+      if (window._mfrFlagFXFrame) window._mfrFlagFXFrame(dt);
+      if (window._gridFlagFXFrame) window._gridFlagFXFrame(dt);
+      if (window._glareFXFrame) window._glareFXFrame(dt);
+      requestAnimationFrame(fxLoop);
+    }
+    requestAnimationFrame((now) => { _lastFXTime = now; requestAnimationFrame(fxLoop); });
+
+    /* ── Public API for main update loop ── */
+    window.updateGLFX = function(rpmRatio, thr, brk, clt) {
+      _tachoRpm = rpmRatio;
+      _pedalValues.thr = thr;
+      _pedalValues.brk = brk;
+      _pedalValues.clt = clt;
+    };
+
+    /** Extended telemetry feed for post-processing pipeline.
+     *  Call from poll-engine alongside updateGLFX.
+     *  @param {object} t — telemetry snapshot:
+     *    speed  : mph (raw)
+     *    rpm    : 0–1 ratio
+     *    latG   : lateral G (signed, positive = right turn)
+     *    longG  : longitudinal G (signed, negative = braking)
+     *    yawRate: rad/s */
+    window.updatePostFX = function(t) {
+      if (!t) return;
+      if (t.speed !== undefined) _pfx.speedTarget = Math.min(t.speed / 200, 1.0);
+      if (t.rpm   !== undefined) _pfx.rpmTarget   = t.rpm;
+      if (t.latG  !== undefined) _pfx.latGTarget   = t.latG;
+      if (t.longG !== undefined) _pfx.longGTarget  = t.longG;
+      if (t.yawRate !== undefined) _pfx.yawRateTarget = t.yawRate;
+      if (t.steer !== undefined) _pfx.steerTarget = t.steer;
+    };
+  })();
+
+
+// ── modules/js/ambient-light.js ──
+// ═══════════════════════════════════════════════════════════════
+//  AMBIENT LIGHT — Per-panel glow + glass reflections
+// ═══════════════════════════════════════════════════════════════
+//
+//  No WebGL canvas — all glow/reflection is done via CSS pseudo-
+//  elements (::before = radial glow, ::after = glass highlight).
+//
+//  This JS module handles:
+//    • Smooth LERP interpolation of the ambient color
+//    • Updating --ambient-r / --ambient-g / --ambient-b on :root
+//    • Receiving color from the C# plugin via poll data
+//      (replaces the old Electron desktopCapturer IPC pipeline)
+//    • Falling back to polled flag-state color
+//
+//  The CSS breathing animation runs independently in ambient.css.
+// ═══════════════════════════════════════════════════════════════
+
+(function initAmbientLight() {
+  'use strict';
+
+  // ── State ──
+  let _enabled = false;
+  let _rafId = null;
+  let _hasReceivedColor = false;
+  let _usePolledColor = false;
+
+  // Current + target color (smooth interpolation, 0-1 range)
+  let _curR = 0, _curG = 0, _curB = 0;
+  let _tgtR = 0, _tgtG = 0, _tgtB = 0;
+
+  const LERP = 0.30;
+
+  // ── Flag-to-color mapping ──
+  const FLAG_AMBIENT = {
+    green:     { r: 0.35, g: 0.85, b: 0.45 },
+    yellow:    { r: 0.95, g: 0.82, b: 0.25 },
+    red:       { r: 0.90, g: 0.20, b: 0.15 },
+    blue:      { r: 0.30, g: 0.50, b: 0.95 },
+    white:     { r: 0.85, g: 0.85, b: 0.90 },
+    black:     { r: 0.25, g: 0.25, b: 0.25 },
+    checkered: { r: 0.80, g: 0.80, b: 0.82 },
+    meatball:  { r: 0.90, g: 0.35, b: 0.20 },
+    orange:    { r: 0.95, g: 0.60, b: 0.15 },
+    debris:    { r: 0.85, g: 0.72, b: 0.25 },
+    none:      { r: 0.45, g: 0.55, b: 0.75 },
+  };
+
+  // ── Update CSS vars that drive glow + reflection tint on panels ──
+  // No brightness floor — dark sampled colors darken the modules.
+  // --ambient-lum (0-1) tells CSS how bright the ambient light is,
+  // so panels can dim their background when the lighting source is dark.
+  // Expose ambient color for WebGL postfx shader (0-1 range)
+  window._ambientGL = { r: 0, g: 0, b: 0, lum: 0 };
+
+  function updateReflectionColor(r, g, b) {
+    const root = document.documentElement.style;
+    root.setProperty('--ambient-r', String(Math.round(r * 255)));
+    root.setProperty('--ambient-g', String(Math.round(g * 255)));
+    root.setProperty('--ambient-b', String(Math.round(b * 255)));
+    // Perceptual luminance (rec. 709)
+    const lum = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    root.setProperty('--ambient-lum', lum.toFixed(3));
+    // Push to WebGL-readable global
+    const a = window._ambientGL;
+    a.r = r; a.g = g; a.b = b; a.lum = lum;
+  }
+
+  function clearReflectionColor() {
+    const root = document.documentElement.style;
+    root.setProperty('--ambient-r', '80');
+    root.setProperty('--ambient-g', '100');
+    root.setProperty('--ambient-b', '140');
+  }
+
+  // ── Polled color from flag state ──
+  function pollFlagColor() {
+    const flag = window._currentFlagState || 'none';
+    const c = FLAG_AMBIENT[flag] || FLAG_AMBIENT.none;
+    _tgtR = c.r;
+    _tgtG = c.g;
+    _tgtB = c.b;
+  }
+
+  // ── Render loop — LERP + push CSS vars each frame ──
+  let _logTimer = 0;
+  function render(timestamp) {
+    if (!_enabled) return;
+    _rafId = requestAnimationFrame(render);
+
+    if (_usePolledColor) pollFlagColor();
+
+    // Smooth interpolation
+    _curR += (_tgtR - _curR) * LERP;
+    _curG += (_tgtG - _curG) * LERP;
+    _curB += (_tgtB - _curB) * LERP;
+
+    // Push to CSS vars (drives both ::before glow and ::after reflection)
+    updateReflectionColor(_curR, _curG, _curB);
+
+    // Plastic mode: push telemetry to CSS custom properties so the
+    // CSS-only glow can animate with speed + steering rotation.
+    // Only writes when plastic is active to avoid unnecessary DOM work.
+    if (window._ambientModeInt === 0 && document.body.classList.contains('ambient-plastic')) {
+      const pfx = window._pfx;
+      if (pfx) {
+        const root = document.documentElement.style;
+        // steer: -1..+1 → rotation in degrees (inverted, ±4° like WebGL)
+        root.setProperty('--plastic-rotate', (-pfx.steer * 4).toFixed(2) + 'deg');
+        // speed: 0..1 → sweep offset (0px..30px horizontal shift)
+        const spdMul = 0.075 + pfx.speed * 0.425;
+        root.setProperty('--plastic-sweep', (spdMul * 60).toFixed(1) + 'px');
+        // time-based sweep position (slow diagonal drift)
+        const timeSec = timestamp * 0.001;
+        const sweepPhase = Math.sin(timeSec * 0.2 * spdMul) * 0.5 + 0.5;
+        root.setProperty('--plastic-phase', sweepPhase.toFixed(3));
+      }
+    }
+
+    // Diagnostic log every 5s
+    const t = timestamp * 0.001;
+    const sec = Math.floor(t);
+    if (sec % 5 === 0 && sec !== _logTimer) {
+      _logTimer = sec;
+      console.log(`[Ambient] color=(${_curR.toFixed(2)}, ${_curG.toFixed(2)}, ${_curB.toFixed(2)}) polled=${_usePolledColor} received=${_hasReceivedColor}`);
+    }
+  }
+
+  // ── Receive color from poll data (C# plugin ScreenColorSampler) ──
+  // Called by poll-engine.js each frame when ambient data is present.
+  window.updateAmbientFromPoll = function(r, g, b) {
+    if (!_hasReceivedColor) {
+      console.log('[Ambient] First color received from poll data:', r, g, b);
+    }
+    _hasReceivedColor = true;
+    _usePolledColor = false;
+    _tgtR = r / 255;
+    _tgtG = g / 255;
+    _tgtB = b / 255;
+  };
+
+  // ── Public API ──
+
+  window.startAmbientLight = function() {
+    if (_enabled) return;
+
+    _enabled = true;
+    _rafId = requestAnimationFrame(render);
+
+    // Flag-based color until screen capture data arrives from poll
+    _usePolledColor = true;
+    console.log('[Ambient] Started (polled until capture data arrives)');
+  };
+
+  // External color push (0-1 range)
+  window.setAmbientColor = function(r, g, b) {
+    _hasReceivedColor = true;
+    _usePolledColor = false;
+    _tgtR = r;
+    _tgtG = g;
+    _tgtB = b;
+  };
+
+  window.stopAmbientLight = function() {
+    _enabled = false;
+    if (_rafId) { cancelAnimationFrame(_rafId); _rafId = null; }
+    clearReflectionColor();
+    _usePolledColor = false;
+    _hasReceivedColor = false;
+    console.log('[Ambient] Stopped');
+  };
+
+  window.isAmbientLightActive = function() {
+    return _enabled;
+  };
+
+  // Expose color state for the settings preview
+  window.getAmbientColor = function() {
+    return {
+      r: _curR, g: _curG, b: _curB,
+      tr: _tgtR, tg: _tgtG, tb: _tgtB,
+      enabled: _enabled,
+      hasData: _hasReceivedColor,
+      polled: _usePolledColor,
+    };
+  };
+
+})();
+
+
+// ── modules/js/ambient-capture.js ──
+// ═══════════════════════════════════════════════════════════════
+//  AMBIENT CAPTURE — Region selection + settings color preview
+// ═══════════════════════════════════════════════════════════════
+//
+//  1) User draws a capture rectangle via "Draw Region" button.
+//     The rect is sent to the C# plugin via HTTP so the native
+//     ScreenColorSampler captures color from that region only.
+//
+//  2) Settings preview: a colored div + info text showing the
+//     current ambient color (~15fps, only while settings open).
+//     (Screen thumbnail preview is no longer available since
+//     capture moved from Electron to the C# plugin.)
+//
+//  3) When settings re-open, the saved capture rect is re-drawn
+//     so the user can see where they last placed it.
+// ═══════════════════════════════════════════════════════════════
+
+(function initAmbientCapture() {
+  'use strict';
+
+  let _captureRect = null;     // { x, y, w, h } as ratios of viewport
+
+  // Preview state
+  let _previewInterval = null;
+
+  // Region selection state
+  let _isSelecting = false;
+  let _startX = 0, _startY = 0;
+
+  // ═════════════════════════════════════════════
+  //  REGION SELECTION UI
+  // ═════════════════════════════════════════════
+
+  window.startCaptureAreaSelection = async function() {
+    // No permission needed — capture is done natively by the C# plugin
+    // (Windows GDI+ doesn't require special permissions)
+
+    // Show selection overlay (settings stay open for click surface)
+    const overlay = document.getElementById('captureAreaOverlay');
+    if (!overlay) return;
+
+    overlay.style.display = 'block';
+    const rectEl = document.getElementById('captureAreaRect');
+    if (rectEl) rectEl.style.display = 'none';
+
+    overlay.addEventListener('mousedown', onSelectionStart);
+    document.addEventListener('keydown', onSelectionEscape);
+  };
+
+  function onSelectionStart(e) {
+    if (e.button !== 0) return;
+    _isSelecting = true;
+    _startX = e.clientX;
+    _startY = e.clientY;
+    const rectEl = document.getElementById('captureAreaRect');
+    if (rectEl) {
+      rectEl.style.display = 'block';
+      rectEl.style.left = _startX + 'px';
+      rectEl.style.top = _startY + 'px';
+      rectEl.style.width = '0px';
+      rectEl.style.height = '0px';
+    }
+    document.addEventListener('mousemove', onSelectionMove);
+    document.addEventListener('mouseup', onSelectionEnd);
+  }
+
+  function onSelectionMove(e) {
+    if (!_isSelecting) return;
+    const rectEl = document.getElementById('captureAreaRect');
+    if (!rectEl) return;
+    const x = Math.min(e.clientX, _startX);
+    const y = Math.min(e.clientY, _startY);
+    const w = Math.abs(e.clientX - _startX);
+    const h = Math.abs(e.clientY - _startY);
+    rectEl.style.left = x + 'px';
+    rectEl.style.top = y + 'px';
+    rectEl.style.width = w + 'px';
+    rectEl.style.height = h + 'px';
+  }
+
+  function onSelectionEnd(e) {
+    if (!_isSelecting) return;
+    _isSelecting = false;
+    document.removeEventListener('mousemove', onSelectionMove);
+    document.removeEventListener('mouseup', onSelectionEnd);
+
+    const x = Math.min(e.clientX, _startX);
+    const y = Math.min(e.clientY, _startY);
+    const w = Math.abs(e.clientX - _startX);
+    const h = Math.abs(e.clientY - _startY);
+
+    if (w < 20 || h < 20) {
+      console.warn('[AmbientCapture] Selection too small, ignoring');
+      closeSelectionOverlay();
+      return;
+    }
+
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    _captureRect = { x: x / vw, y: y / vh, w: w / vw, h: h / vh };
+
+    // Persist locally
+    if (window._settings) {
+      window._settings.ambientCaptureRect = _captureRect;
+      if (typeof window.saveSettings === 'function') window.saveSettings();
+    }
+
+    // Send to C# plugin via HTTP so ScreenColorSampler uses this region
+    sendRectToPlugin(_captureRect);
+
+    console.log('[AmbientCapture] Region set:', _captureRect);
+    closeSelectionOverlay();
+  }
+
+  function onSelectionEscape(e) {
+    if (e.key === 'Escape') closeSelectionOverlay();
+  }
+
+  function closeSelectionOverlay() {
+    const overlay = document.getElementById('captureAreaOverlay');
+    if (overlay) {
+      overlay.style.display = 'none';
+      overlay.removeEventListener('mousedown', onSelectionStart);
+    }
+    document.removeEventListener('keydown', onSelectionEscape);
+    document.removeEventListener('mousemove', onSelectionMove);
+    document.removeEventListener('mouseup', onSelectionEnd);
+    _isSelecting = false;
+  }
+
+  // ═════════════════════════════════════════════
+  //  SEND RECT TO C# PLUGIN VIA HTTP
+  // ═════════════════════════════════════════════
+
+  function sendRectToPlugin(rect) {
+    if (!rect) return;
+    const url = (window._simhubUrlOverride || SIMHUB_URL) +
+      '?action=setrect' +
+      '&x=' + rect.x.toFixed(6) +
+      '&y=' + rect.y.toFixed(6) +
+      '&w=' + rect.w.toFixed(6) +
+      '&h=' + rect.h.toFixed(6);
+    fetch(url).catch(err => {
+      console.warn('[AmbientCapture] Failed to send rect to plugin:', err);
+    });
+  }
+
+  // ═════════════════════════════════════════════
+  //  SETTINGS PREVIEW — realtime color swatch
+  //  ~15fps, only when settings panel is open.
+  //  (No thumbnail preview — that required Electron IPC)
+  // ═════════════════════════════════════════════
+
+  window.startAmbientPreview = function() {
+    if (_previewInterval) return;
+
+    // Show saved capture rect overlay outline (non-interactive)
+    showSavedRect();
+
+    // Update color swatch at ~15fps
+    _previewInterval = setInterval(updatePreview, 66);
+    updatePreview(); // immediate first frame
+  };
+
+  window.stopAmbientPreview = function() {
+    if (_previewInterval) {
+      clearInterval(_previewInterval);
+      _previewInterval = null;
+    }
+    hideSavedRect();
+  };
+
+  function updatePreview() {
+    const swatch = document.getElementById('ambientPreviewSwatch');
+    const info = document.getElementById('ambientPreviewInfo');
+    if (!swatch && !info) return;
+
+    // Get ambient color state
+    const state = (typeof window.getAmbientColor === 'function')
+      ? window.getAmbientColor()
+      : { r: 0, g: 0, b: 0, tr: 0, tg: 0, tb: 0, enabled: false, hasData: false, polled: false };
+
+    // Use target color (immediate, not lerped) so preview reacts fast
+    const cr = state.tr !== undefined ? state.tr : state.r;
+    const cg = state.tg !== undefined ? state.tg : state.g;
+    const cb = state.tb !== undefined ? state.tb : state.b;
+    const r8 = Math.round(cr * 255);
+    const g8 = Math.round(cg * 255);
+    const b8 = Math.round(cb * 255);
+
+    // Color swatch — just set the background color
+    if (swatch) {
+      swatch.style.background = `rgb(${r8}, ${g8}, ${b8})`;
+    }
+
+    // Info text
+    if (info) {
+      let source;
+      if (!state.enabled) source = 'OFF';
+      else if (state.hasData && !state.polled) source = 'Screen Capture';
+      else if (state.polled) source = 'Flag State';
+      else source = 'No region set';
+
+      const rect = _captureRect
+        ? `Region: ${Math.round(_captureRect.w * 100)}% × ${Math.round(_captureRect.h * 100)}%`
+        : 'Draw a region to start';
+
+      info.textContent = `RGB(${r8}, ${g8}, ${b8}) — ${source} — ${rect}`;
+    }
+  }
+
+  // ═════════════════════════════════════════════
+  //  SAVED RECT VISUALIZATION
+  //  When settings open, show where the capture
+  //  rect is positioned as a dashed outline.
+  // ═════════════════════════════════════════════
+
+  let _savedRectDiv = null;
+
+  function showSavedRect() {
+    // Load from settings if we don't have one in memory
+    if (!_captureRect && window._settings && window._settings.ambientCaptureRect) {
+      _captureRect = window._settings.ambientCaptureRect;
+    }
+    if (!_captureRect) return;
+
+    if (!_savedRectDiv) {
+      _savedRectDiv = document.createElement('div');
+      _savedRectDiv.id = 'savedCaptureRect';
+      _savedRectDiv.style.cssText =
+        'position:fixed;z-index:9999;pointer-events:none;' +
+        'border:2px dashed hsla(45,100%,60%,0.6);' +
+        'background:hsla(45,100%,60%,0.05);' +
+        'border-radius:3px;' +
+        'box-shadow:0 0 8px hsla(45,100%,60%,0.2);';
+      document.body.appendChild(_savedRectDiv);
+    }
+
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    _savedRectDiv.style.left   = Math.round(_captureRect.x * vw) + 'px';
+    _savedRectDiv.style.top    = Math.round(_captureRect.y * vh) + 'px';
+    _savedRectDiv.style.width  = Math.round(_captureRect.w * vw) + 'px';
+    _savedRectDiv.style.height = Math.round(_captureRect.h * vh) + 'px';
+    _savedRectDiv.style.display = 'block';
+  }
+
+  function hideSavedRect() {
+    if (_savedRectDiv) _savedRectDiv.style.display = 'none';
+  }
+
+  // ── Restore saved capture rect on load ──
+  window.restoreAmbientCapture = function() {
+    if (window._settings && window._settings.ambientCaptureRect) {
+      _captureRect = window._settings.ambientCaptureRect;
+      // Send to C# plugin via HTTP
+      sendRectToPlugin(_captureRect);
+      console.log('[AmbientCapture] Restored saved region:', _captureRect);
+    }
+  };
+
+  window.stopAmbientCapture = function() {
+    // Nothing to stop — C# plugin handles capture lifecycle
+  };
+
+})();
+
+
+// ── modules/js/commentary-viz.js ──
+// Commentary Data Visualizations
+
+  // ═══════════════════════════════════════════════════════════════
+  //  COMMENTARY DATA VISUALIZATIONS
+  //  Canvas-based mini visualizations that appear beneath the
+  //  commentary text, driven by the topicId that triggered the
+  //  commentary event. Live-updating while the commentary is visible.
+  // ═══════════════════════════════════════════════════════════════
+
+  const _vizCanvas = document.getElementById('commentaryVizCanvas');
+  const _vizCtx = _vizCanvas ? _vizCanvas.getContext('2d') : null;
+  const _vizContainer = document.getElementById('commentaryViz');
+  const _vizValueEl = document.getElementById('commentaryVizValue');
+  const _vizLabelEl = document.getElementById('commentaryVizLabel');
+
+  let _vizActive = false;
+  let _vizTopicId = '';
+  let _vizHue = 0;
+  let _vizHistory = [];       // rolling data buffer for live line charts
+  const _VIZ_HIST_LEN = 60;  // ~2 seconds of samples at 30fps poll rate
+  let _vizGridGhostPos = 0;   // captured on first grid frame so it doesn't drift
+
+  // ── Viz type definitions ──
+  // Each topicId maps to a visualization type and configuration.
+  // 'gauge'   — arc gauge showing a single value 0-1
+  // 'bar'     — horizontal bar with label
+  // 'line'    — rolling line chart with history buffer
+  // 'gforce'  — 2D g-force dot (lat vs long)
+  // 'quad'    — four-corner display (tyres)
+  // 'delta'   — +/- delta bar centered at zero
+  // 'counter' — simple large numeric display (no canvas)
+  const _vizConfig = {
+    // ── Car response ──
+    spin_catch:            { type: 'gforce',  label: 'G-Force',        unit: 'g' },
+    high_cornering_load:   { type: 'gforce',  label: 'Cornering Load', unit: 'g' },
+    heavy_braking:         { type: 'line',    label: 'Brake Pressure', unit: '%',    src: 'brake' },
+    car_balance_sustained: { type: 'gforce',  label: 'Car Balance',    unit: 'g' },
+    rapid_gear_change:     { type: 'line',    label: 'RPM',            unit: '',     src: 'rpm' },
+    wall_contact:          { type: 'incident', label: 'Incidents' },
+    off_track:             { type: 'incident', label: 'Incidents' },
+    kerb_hit:              { type: 'gforce',  label: 'Impact',         unit: 'g' },
+
+    // ── Hardware ──
+    abs_activation:        { type: 'line',    label: 'Brake + ABS',    unit: '%',    src: 'brake' },
+    tc_intervention:       { type: 'line',    label: 'Throttle + TC',  unit: '%',    src: 'throttle' },
+    ffb_torque_spike:      { type: 'line',    label: 'Steer Torque',   unit: '',     src: 'steerTorque' },
+    brake_bias_change:     { type: 'gauge',   label: 'Brake Bias',     unit: '%',    src: 'brakeBias', min: 40, max: 65 },
+    tc_setting_change:     { type: 'gauge',   label: 'TC Level',       unit: '',     src: 'tc', min: 0, max: 12 },
+    abs_setting_change:    { type: 'gauge',   label: 'ABS Level',      unit: '',     src: 'abs', min: 0, max: 12 },
+    arb_front_change:      { type: 'bar',     label: 'Front ARB',      unit: '',     src: 'tc' },
+    arb_rear_change:       { type: 'bar',     label: 'Rear ARB',       unit: '',     src: 'abs' },
+
+    // ── Game feel ──
+    qualifying_push:       { type: 'delta',   label: 'Lap Delta',      unit: 's',    src: 'lapDelta' },
+    personal_best:         { type: 'delta',   label: 'Lap Delta',      unit: 's',    src: 'lapDelta' },
+    long_stint:            { type: 'counter', label: 'Laps',           src: 'laps' },
+    session_time_low:      { type: 'counter', label: 'Remaining',      src: 'sessionTime' },
+    drs_active:            { type: 'line',    label: 'Speed',          unit: 'mph',  src: 'speed' },
+    ers_low:               { type: 'gauge',   label: 'ERS Battery',    unit: '%',    src: 'fuel', min: 0, max: 100 },
+
+    // ── Racing experience ──
+    close_battle:          { type: 'delta',   label: 'Gap',            unit: 's',    src: 'gapAhead' },
+    position_gained:       { type: 'grid',    label: 'Grid Position' },
+    position_lost:         { type: 'grid',    label: 'Grid Position' },
+    incident_spike:        { type: 'incident', label: 'Incidents' },
+    low_fuel:              { type: 'gauge',   label: 'Fuel',           unit: 'L',    src: 'fuel', min: 0, max: 100 },
+    hot_tyres:             { type: 'quad',    label: 'Tyre Temps',     unit: '°C',   src: 'tyreTemp' },
+    tyre_wear_high:        { type: 'quad',    label: 'Tyre Wear',      unit: '%',    src: 'tyreWear' },
+    track_temp_hot:        { type: 'counter', label: 'Track Temp',     src: 'trackTemp' },
+    track_temp_cold:       { type: 'counter', label: 'Track Temp',     src: 'trackTemp' },
+    wet_track:             { type: 'counter', label: 'Track Temp',     src: 'trackTemp' },
+
+    // Catch-all for topics that appear in demo
+    pit_entry:             { type: 'counter', label: 'Laps',           src: 'laps' },
+    race_start:            { type: 'grid',    label: 'Grid Position' },
+    formation_lap:         { type: 'grid',    label: 'Grid Position' },
+    yellow_flag:           { type: 'incident', label: 'Incidents' },
+    black_flag:            { type: 'incident', label: 'Incidents' },
+    debris_on_track:       { type: 'incident', label: 'Incidents' },
+  };
+
+  // ── Latest telemetry snapshot (updated by poll engine) ──
+  let _vizTelemetry = {};
+
+  // Public: called by poll-engine each frame to push fresh data
+  window.updateCommentaryVizData = function(data) {
+    _vizTelemetry = data;
+    if (_vizActive) _renderVizFrame();
+  };
+
+  // Public: activate a viz for the given topicId
+  window.showCommentaryViz = function(topicId, hue) {
+    const cfg = _vizConfig[topicId];
+    if (!cfg || !_vizContainer) {
+      if (_vizContainer) _vizContainer.classList.remove('viz-active');
+      _vizActive = false;
+      return;
+    }
+    _vizTopicId = topicId;
+    _vizHue = hue;
+    _vizHistory = [];
+    _vizActive = true;
+    _vizContainer.classList.add('viz-active');
+    _vizContainer.setAttribute('data-viz-type', cfg.type);
+    if (_vizLabelEl) _vizLabelEl.textContent = cfg.label;
+    if (_vizValueEl) _vizValueEl.textContent = '';
+    _renderVizFrame();
+  };
+
+  // Public: deactivate
+  window.hideCommentaryViz = function() {
+    _vizActive = false;
+    _vizHistory = [];
+    _vizGridGhostPos = 0;
+    if (_vizContainer) _vizContainer.classList.remove('viz-active');
+  };
+
+  // ── Resolve a data value from the telemetry snapshot ──
+  function _getVizValue(src) {
+    const t = _vizTelemetry;
+    switch (src) {
+      case 'brake':       return t.brake || 0;
+      case 'throttle':    return t.throttle || 0;
+      case 'rpm':         return t.rpmRatio || 0;
+      case 'speed':       return t.speed || 0;
+      case 'brakeBias':   return t.brakeBias || 0;
+      case 'tc':          return t.tc || 0;
+      case 'abs':         return t.abs || 0;
+      case 'fuel':        return t.fuelPct || 0;
+      case 'lapDelta':    return t.lapDelta || 0;
+      case 'gapAhead':    return t.gapAhead || 0;
+      case 'steerTorque': return t.steerTorque || 0;
+      case 'position':    return t.position || 0;
+      case 'prevPosition': return t.prevPosition || 0;
+      case 'startPosition': return t.startPosition || 0;
+      case 'totalCars':   return t.totalCars || 0;
+      case 'incidents':   return t.incidents || 0;
+      case 'incidentLimitPenalty': return t.incidentLimitPenalty || 0;
+      case 'incidentLimitDQ':     return t.incidentLimitDQ || 0;
+      case 'laps':        return t.lap || 0;
+      case 'sessionTime': return t.sessionTime || '';
+      case 'trackTemp':   return t.trackTemp || 0;
+      case 'tyreTemp':    return t.tyreTemps || [0,0,0,0];
+      case 'tyreWear':    return t.tyreWears || [0,0,0,0];
+      default:            return 0;
+    }
+  }
+
+  // ── Master render dispatcher ──
+  function _renderVizFrame() {
+    const cfg = _vizConfig[_vizTopicId];
+    if (!cfg) return;
+
+    switch (cfg.type) {
+      case 'line':    _renderLine(cfg);    break;
+      case 'gauge':   _renderGauge(cfg);   break;
+      case 'gforce':  _renderGForce(cfg);  break;
+      case 'bar':     _renderBar(cfg);     break;
+      case 'delta':   _renderDelta(cfg);   break;
+      case 'quad':    _renderQuad(cfg);    break;
+      case 'counter':  _renderCounter(cfg);  break;
+      case 'grid':     _renderGrid(cfg);     break;
+      case 'incident': _renderIncident(cfg); break;
+    }
+  }
+
+  // ── Canvas setup helper ──
+  function _prepCanvas() {
+    if (!_vizCanvas || !_vizCtx) return null;
+    const rect = _vizCanvas.parentElement.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+    const w = Math.round(rect.width * dpr);
+    const h = Math.round(rect.height * dpr);
+    if (w < 2 || h < 2) return null;
+    if (_vizCanvas.width !== w || _vizCanvas.height !== h) {
+      _vizCanvas.width = w;
+      _vizCanvas.height = h;
+    }
+    _vizCtx.clearRect(0, 0, w, h);
+    return { ctx: _vizCtx, w, h, dpr };
+  }
+
+  function _hslStr(h, s, l, a) {
+    return `hsla(${h}, ${s}%, ${l}%, ${a})`;
+  }
+
+  // ════════════════════════════════════════════
+  //  LINE — rolling waveform with glow
+  // ════════════════════════════════════════════
+  function _renderLine(cfg) {
+    const val = _getVizValue(cfg.src);
+    // Normalize to 0-1 for line chart
+    let norm = val;
+    if (cfg.src === 'speed') norm = Math.min(1, val / 200);
+    else if (cfg.src === 'steerTorque') norm = Math.min(1, Math.abs(val) / 50);
+    else if (cfg.src === 'rpm') norm = val; // already 0-1
+
+    _vizHistory.push(norm);
+    if (_vizHistory.length > _VIZ_HIST_LEN) _vizHistory.shift();
+
+    const c = _prepCanvas();
+    if (!c) return;
+    const { ctx, w, h } = c;
+    const count = _vizHistory.length;
+    if (count < 2) return;
+
+    // Fill area under curve
+    ctx.beginPath();
+    ctx.moveTo(0, h);
+    for (let i = 0; i < count; i++) {
+      const x = (i / (count - 1)) * w;
+      const y = h - _vizHistory[i] * (h - 4) - 2;
+      ctx.lineTo(x, y);
+    }
+    ctx.lineTo(w, h);
+    ctx.closePath();
+    const fillGrad = ctx.createLinearGradient(0, 0, 0, h);
+    fillGrad.addColorStop(0, _hslStr(_vizHue, 60, 55, 0.25));
+    fillGrad.addColorStop(1, _hslStr(_vizHue, 60, 55, 0.02));
+    ctx.fillStyle = fillGrad;
+    ctx.fill();
+
+    // Stroke line
+    ctx.beginPath();
+    for (let i = 0; i < count; i++) {
+      const x = (i / (count - 1)) * w;
+      const y = h - _vizHistory[i] * (h - 4) - 2;
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    const grad = ctx.createLinearGradient(0, 0, w, 0);
+    grad.addColorStop(0, _hslStr(_vizHue, 50, 60, 0.15));
+    grad.addColorStop(0.5, _hslStr(_vizHue, 60, 65, 0.6));
+    grad.addColorStop(1, _hslStr(_vizHue, 60, 65, 0.9));
+    ctx.strokeStyle = grad;
+    ctx.lineWidth = 2;
+    ctx.lineJoin = 'round';
+    ctx.stroke();
+
+    // Live dot at leading edge
+    const lastY = h - _vizHistory[count - 1] * (h - 4) - 2;
+    ctx.beginPath();
+    ctx.arc(w - 1, lastY, 3, 0, Math.PI * 2);
+    ctx.fillStyle = _hslStr(_vizHue, 60, 70, 0.9);
+    ctx.fill();
+
+    // Value display
+    const displayVal = cfg.src === 'speed' ? Math.round(val) :
+                       cfg.src === 'steerTorque' ? val.toFixed(1) :
+                       Math.round(val * 100);
+    if (_vizValueEl) _vizValueEl.textContent = displayVal + (cfg.unit ? ' ' + cfg.unit : '');
+  }
+
+  // ════════════════════════════════════════════
+  //  GAUGE — arc gauge with animated fill
+  // ════════════════════════════════════════════
+  function _renderGauge(cfg) {
+    const rawVal = _getVizValue(cfg.src);
+    const min = cfg.min || 0;
+    const max = cfg.max || 100;
+    const pct = Math.max(0, Math.min(1, (rawVal - min) / (max - min)));
+
+    const c = _prepCanvas();
+    if (!c) return;
+    const { ctx, w, h } = c;
+
+    const cx = w / 2;
+    const cy = h * 0.7;
+    const r = Math.min(cx, cy) * 0.85;
+    const startAngle = Math.PI * 0.8;
+    const endAngle = Math.PI * 2.2;
+    const fillAngle = startAngle + (endAngle - startAngle) * pct;
+
+    // Background arc
+    ctx.beginPath();
+    ctx.arc(cx, cy, r, startAngle, endAngle, false);
+    ctx.strokeStyle = _hslStr(_vizHue, 20, 25, 0.3);
+    ctx.lineWidth = Math.max(6, r * 0.12);
+    ctx.lineCap = 'round';
+    ctx.stroke();
+
+    // Filled arc
+    if (pct > 0.01) {
+      ctx.beginPath();
+      ctx.arc(cx, cy, r, startAngle, fillAngle, false);
+      const arcGrad = ctx.createLinearGradient(cx - r, cy, cx + r, cy);
+      arcGrad.addColorStop(0, _hslStr(_vizHue, 55, 50, 0.7));
+      arcGrad.addColorStop(1, _hslStr(_vizHue, 65, 65, 0.95));
+      ctx.strokeStyle = arcGrad;
+      ctx.lineWidth = Math.max(6, r * 0.12);
+      ctx.lineCap = 'round';
+      ctx.stroke();
+
+      // Glow at tip
+      const tipX = cx + Math.cos(fillAngle) * r;
+      const tipY = cy + Math.sin(fillAngle) * r;
+      const glow = ctx.createRadialGradient(tipX, tipY, 0, tipX, tipY, r * 0.2);
+      glow.addColorStop(0, _hslStr(_vizHue, 60, 65, 0.5));
+      glow.addColorStop(1, _hslStr(_vizHue, 60, 65, 0));
+      ctx.fillStyle = glow;
+      ctx.fillRect(tipX - r * 0.2, tipY - r * 0.2, r * 0.4, r * 0.4);
+    }
+
+    if (_vizValueEl) {
+      const fmt = cfg.src === 'brakeBias' ? rawVal.toFixed(1) : Math.round(rawVal);
+      _vizValueEl.textContent = fmt + (cfg.unit ? ' ' + cfg.unit : '');
+    }
+  }
+
+  // ════════════════════════════════════════════
+  //  G-FORCE — 2D dot (lateral vs longitudinal)
+  // ════════════════════════════════════════════
+  function _renderGForce(cfg) {
+    const latG = _vizTelemetry.latG || 0;
+    const longG = _vizTelemetry.longG || 0;
+    const totalG = Math.sqrt(latG * latG + longG * longG);
+
+    const c = _prepCanvas();
+    if (!c) return;
+    const { ctx, w, h } = c;
+
+    const cx = w / 2;
+    const cy = h / 2;
+    const maxR = Math.min(cx, cy) * 0.85;
+
+    // Background rings
+    for (let ring = 1; ring <= 3; ring++) {
+      ctx.beginPath();
+      ctx.arc(cx, cy, (maxR / 3) * ring, 0, Math.PI * 2);
+      ctx.strokeStyle = _hslStr(_vizHue, 20, 30, 0.15);
+      ctx.lineWidth = 1;
+      ctx.stroke();
+    }
+
+    // Crosshairs
+    ctx.beginPath();
+    ctx.moveTo(cx - maxR, cy); ctx.lineTo(cx + maxR, cy);
+    ctx.moveTo(cx, cy - maxR); ctx.lineTo(cx, cy + maxR);
+    ctx.strokeStyle = _hslStr(_vizHue, 20, 40, 0.12);
+    ctx.lineWidth = 1;
+    ctx.stroke();
+
+    // G-force dot — normalize to 3g range
+    const scale = maxR / 3;
+    const dotX = cx + (latG * scale);
+    const dotY = cy - (longG * scale); // up = positive longG (accel)
+
+    // Trail (store positions)
+    if (!_vizHistory.length || _vizHistory[0].x !== undefined) {
+      // ok
+    } else {
+      _vizHistory = [];
+    }
+    _vizHistory.push({ x: dotX, y: dotY });
+    if (_vizHistory.length > 20) _vizHistory.shift();
+
+    // Draw trail
+    for (let i = 0; i < _vizHistory.length - 1; i++) {
+      const alpha = (i / _vizHistory.length) * 0.3;
+      ctx.beginPath();
+      ctx.arc(_vizHistory[i].x, _vizHistory[i].y, 2, 0, Math.PI * 2);
+      ctx.fillStyle = _hslStr(_vizHue, 55, 60, alpha);
+      ctx.fill();
+    }
+
+    // Main dot with glow
+    const glowR = 8 + totalG * 4;
+    const glow = ctx.createRadialGradient(dotX, dotY, 0, dotX, dotY, glowR);
+    glow.addColorStop(0, _hslStr(_vizHue, 65, 65, 0.7));
+    glow.addColorStop(0.5, _hslStr(_vizHue, 60, 60, 0.2));
+    glow.addColorStop(1, _hslStr(_vizHue, 60, 60, 0));
+    ctx.fillStyle = glow;
+    ctx.fillRect(dotX - glowR, dotY - glowR, glowR * 2, glowR * 2);
+
+    ctx.beginPath();
+    ctx.arc(dotX, dotY, 4, 0, Math.PI * 2);
+    ctx.fillStyle = _hslStr(_vizHue, 60, 70, 0.95);
+    ctx.fill();
+
+    if (_vizValueEl) _vizValueEl.textContent = totalG.toFixed(2) + ' g';
+  }
+
+  // ════════════════════════════════════════════
+  //  BAR — simple horizontal filled bar
+  // ════════════════════════════════════════════
+  function _renderBar(cfg) {
+    const rawVal = _getVizValue(cfg.src);
+    const pct = Math.max(0, Math.min(1, rawVal / 12)); // 0-12 range for TC/ABS
+
+    const c = _prepCanvas();
+    if (!c) return;
+    const { ctx, w, h } = c;
+
+    const barH = Math.max(8, h * 0.35);
+    const barY = (h - barH) / 2;
+    const radius = barH / 2;
+
+    // Background
+    _roundRect(ctx, 0, barY, w, barH, radius);
+    ctx.fillStyle = _hslStr(_vizHue, 20, 20, 0.3);
+    ctx.fill();
+
+    // Fill
+    if (pct > 0.01) {
+      const fillW = Math.max(barH, w * pct);
+      _roundRect(ctx, 0, barY, fillW, barH, radius);
+      const grad = ctx.createLinearGradient(0, 0, fillW, 0);
+      grad.addColorStop(0, _hslStr(_vizHue, 55, 45, 0.7));
+      grad.addColorStop(1, _hslStr(_vizHue, 65, 60, 0.95));
+      ctx.fillStyle = grad;
+      ctx.fill();
+    }
+
+    if (_vizValueEl) _vizValueEl.textContent = Math.round(rawVal) + (cfg.unit ? ' ' + cfg.unit : '');
+  }
+
+  function _roundRect(ctx, x, y, w, h, r) {
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.lineTo(x + w - r, y);
+    ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+    ctx.lineTo(x + w, y + h - r);
+    ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+    ctx.lineTo(x + r, y + h);
+    ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+    ctx.lineTo(x, y + r);
+    ctx.quadraticCurveTo(x, y, x + r, y);
+    ctx.closePath();
+  }
+
+  // ════════════════════════════════════════════
+  //  DELTA — centered +/- bar (lap delta, gap)
+  // ════════════════════════════════════════════
+  function _renderDelta(cfg) {
+    const rawVal = _getVizValue(cfg.src);
+    // Clamp to ±5 seconds for display range
+    const clamped = Math.max(-5, Math.min(5, rawVal));
+    const pct = clamped / 5; // -1 to +1
+
+    const c = _prepCanvas();
+    if (!c) return;
+    const { ctx, w, h } = c;
+
+    const barH = Math.max(8, h * 0.35);
+    const barY = (h - barH) / 2;
+    const midX = w / 2;
+
+    // Background bar
+    _roundRect(ctx, 0, barY, w, barH, barH / 2);
+    ctx.fillStyle = _hslStr(0, 0, 25, 0.2);
+    ctx.fill();
+
+    // Center line
+    ctx.beginPath();
+    ctx.moveTo(midX, barY - 2);
+    ctx.lineTo(midX, barY + barH + 2);
+    ctx.strokeStyle = _hslStr(0, 0, 60, 0.4);
+    ctx.lineWidth = 1;
+    ctx.stroke();
+
+    // Delta fill
+    if (Math.abs(pct) > 0.005) {
+      const isNeg = pct < 0;
+      const hue = isNeg ? 145 : 0; // green for negative (gaining), red for positive (losing)
+      const fillW = Math.abs(pct) * (w / 2);
+      const fillX = isNeg ? midX - fillW : midX;
+
+      ctx.beginPath();
+      ctx.rect(fillX, barY, fillW, barH);
+      ctx.fillStyle = _hslStr(hue, 60, 50, 0.7);
+      ctx.fill();
+    }
+
+    // Value display
+    const sign = rawVal > 0.005 ? '+' : rawVal < -0.005 ? '' : '';
+    if (_vizValueEl) _vizValueEl.textContent = sign + rawVal.toFixed(3) + ' ' + cfg.unit;
+    if (_vizValueEl) _vizValueEl.style.color = rawVal < -0.005 ? 'hsl(145, 60%, 60%)' : rawVal > 0.005 ? 'hsl(0, 60%, 65%)' : '';
+  }
+
+  // ════════════════════════════════════════════
+  //  QUAD — four-corner display (tyres) with heatmap
+  // ════════════════════════════════════════════
+
+  // Tyre temp color bands — matches getTyreTempClass() in webgl-helpers.js
+  // Thresholds are °F (iRacing native). Returns { hue, sat, label }.
+  function _tyreTempColor(tempF) {
+    if (tempF <= 0)   return { hue: 0,   sat: 0,  label: '' };       // no data
+    if (tempF < 150)  return { hue: 200, sat: 70, label: 'cold' };   // blue  < 66°C
+    if (tempF < 230)  return { hue: 123, sat: 45, label: 'optimal' };// green 66-110°C
+    if (tempF < 270)  return { hue: 45,  sat: 90, label: 'hot' };    // amber 110-132°C
+    return              { hue: 0,   sat: 70, label: 'danger' };       // red   > 132°C
+  }
+
+  // Tyre wear color (percentage 0-100)
+  function _tyreWearColor(pct) {
+    if (pct > 50)  return { hue: 123, sat: 45 };  // green
+    if (pct > 25)  return { hue: 45,  sat: 90 };  // amber
+    return           { hue: 0,   sat: 70 };        // red
+  }
+
+  function _renderQuad(cfg) {
+    const vals = _getVizValue(cfg.src);
+    const arr = Array.isArray(vals) ? vals : [0, 0, 0, 0];
+
+    const c = _prepCanvas();
+    if (!c) return;
+    const { ctx, w, h, dpr } = c;
+
+    const gap = 4 * dpr;
+    const cellW = (w - gap) / 2;
+    const cellH = (h - gap) / 2;
+    const positions = [
+      [0, 0],                    // FL
+      [cellW + gap, 0],          // FR
+      [0, cellH + gap],          // RL
+      [cellW + gap, cellH + gap] // RR
+    ];
+    const labels = ['FL', 'FR', 'RL', 'RR'];
+    const isTemp = cfg.src === 'tyreTemp';
+
+    for (let i = 0; i < 4; i++) {
+      const [x, y] = positions[i];
+      const val = arr[i] || 0;
+      const col = isTemp ? _tyreTempColor(val) : _tyreWearColor(val);
+      const hue = col.hue;
+      const sat = col.sat;
+
+      // ── Heatmap fill: radial gradient from center of cell ──
+      const cx = x + cellW / 2;
+      const cy = y + cellH / 2;
+      const rMax = Math.max(cellW, cellH) * 0.8;
+
+      // Intensity scales with how extreme the value is
+      let intensity;
+      if (isTemp) {
+        // Hotter = brighter fill; cold = very faint
+        intensity = val <= 0 ? 0 : Math.max(0.12, Math.min(0.55, (val - 100) / 300));
+      } else {
+        // Lower wear = brighter fill (more alarming)
+        intensity = Math.max(0.12, 0.55 - (val / 100) * 0.4);
+      }
+
+      // Cell base
+      _roundRect(ctx, x, y, cellW, cellH, 4 * dpr);
+      ctx.fillStyle = `hsla(${hue}, ${sat}%, 12%, 0.6)`;
+      ctx.fill();
+
+      // Heatmap radial glow
+      const radGrad = ctx.createRadialGradient(cx, cy, 0, cx, cy, rMax);
+      radGrad.addColorStop(0, `hsla(${hue}, ${sat}%, 45%, ${intensity})`);
+      radGrad.addColorStop(0.6, `hsla(${hue}, ${sat}%, 30%, ${intensity * 0.4})`);
+      radGrad.addColorStop(1, `hsla(${hue}, ${sat}%, 20%, 0)`);
+      _roundRect(ctx, x, y, cellW, cellH, 4 * dpr);
+      ctx.fillStyle = radGrad;
+      ctx.fill();
+
+      // Border — brighter at higher intensity
+      _roundRect(ctx, x, y, cellW, cellH, 4 * dpr);
+      ctx.strokeStyle = `hsla(${hue}, ${sat}%, 50%, ${0.3 + intensity * 0.5})`;
+      ctx.lineWidth = 1;
+      ctx.stroke();
+
+      // Value text
+      ctx.fillStyle = `hsla(${hue}, ${sat}%, 70%, 0.95)`;
+      ctx.font = `bold ${11 * dpr}px system-ui, sans-serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      const dispVal = isTemp ? Math.round(val) + '°' : Math.round(val) + '%';
+      ctx.fillText(dispVal, cx, cy - 2 * dpr);
+
+      // Corner label
+      ctx.fillStyle = `hsla(${hue}, ${Math.round(sat * 0.7)}%, 60%, 0.5)`;
+      ctx.font = `${7 * dpr}px system-ui, sans-serif`;
+      ctx.fillText(labels[i], cx, cy + 10 * dpr);
+    }
+
+    if (_vizValueEl) _vizValueEl.textContent = '';
+  }
+
+  // ════════════════════════════════════════════
+  //  GRID — dot-strip position display
+  //  Row of dots (one per car), player highlighted,
+  //  ghost position shown with ring outline.
+  //  Mirrors the pre-race grid strip style.
+  // ════════════════════════════════════════════
+  function _renderGrid(cfg) {
+    const pos = Math.round(_getVizValue('position')) || 0;
+    if (pos <= 0) return;
+    let total = Math.round(_getVizValue('totalCars')) || 0;
+    if (total < pos) total = pos + 4;
+    const startPos = Math.round(_getVizValue('startPosition')) || 0;
+
+    // Capture ghost on first render only
+    if (_vizGridGhostPos === 0) {
+      const prev = Math.round(_getVizValue('prevPosition'));
+      if (prev > 0 && prev !== pos) _vizGridGhostPos = prev;
+    }
+
+    const c = _prepCanvas();
+    if (!c) return;
+    const { ctx, w, h, dpr } = c;
+
+    // ── Layout ──
+    const dotSize = 7 * dpr;
+    const dotGap = 3 * dpr;
+    const dotR = 2 * dpr;           // corner radius
+    const dotsPerRow = Math.floor((w + dotGap) / (dotSize + dotGap));
+    const rows = Math.ceil(total / dotsPerRow);
+    const stripH = rows * (dotSize + dotGap) - dotGap;
+    const startY = Math.max(0, (h * 0.6 - stripH) / 2);  // vertically center in top 60%
+
+    for (let i = 1; i <= total; i++) {
+      const idx = i - 1;
+      const col = idx % dotsPerRow;
+      const row = Math.floor(idx / dotsPerRow);
+      // Center each row
+      const carsInRow = Math.min(dotsPerRow, total - row * dotsPerRow);
+      const rowW = carsInRow * (dotSize + dotGap) - dotGap;
+      const rowOffX = (w - rowW) / 2;
+      const x = rowOffX + col * (dotSize + dotGap);
+      const y = startY + row * (dotSize + dotGap);
+
+      const isPlayer = (i === pos);
+      const isGhost = (_vizGridGhostPos > 0 && i === _vizGridGhostPos);
+      const isStart = (startPos > 0 && i === startPos && startPos !== pos);
+
+      _roundRect(ctx, x, y, dotSize, dotSize, dotR);
+      if (isPlayer) {
+        // Player — bright hue-matched fill with glow
+        ctx.fillStyle = `hsla(${_vizHue}, 80%, 55%, 1)`;
+        ctx.fill();
+        ctx.save();
+        ctx.shadowColor = `hsla(${_vizHue}, 90%, 60%, 0.7)`;
+        ctx.shadowBlur = 8 * dpr;
+        _roundRect(ctx, x, y, dotSize, dotSize, dotR);
+        ctx.fillStyle = `hsla(${_vizHue}, 80%, 55%, 0.6)`;
+        ctx.fill();
+        ctx.restore();
+      } else if (isGhost) {
+        // Ghost (previous position) — dashed outline
+        ctx.fillStyle = `hsla(${_vizHue}, 30%, 20%, 0.3)`;
+        ctx.fill();
+        _roundRect(ctx, x, y, dotSize, dotSize, dotR);
+        ctx.setLineDash([2 * dpr, 2 * dpr]);
+        ctx.strokeStyle = `hsla(${_vizHue}, 55%, 55%, 0.6)`;
+        ctx.lineWidth = 1.2 * dpr;
+        ctx.stroke();
+        ctx.setLineDash([]);
+      } else if (isStart) {
+        // Start position — dim ring
+        ctx.fillStyle = 'hsla(0, 0%, 25%, 0.4)';
+        ctx.fill();
+        _roundRect(ctx, x, y, dotSize, dotSize, dotR);
+        ctx.strokeStyle = 'hsla(0, 0%, 50%, 0.3)';
+        ctx.lineWidth = 1 * dpr;
+        ctx.stroke();
+      } else {
+        // Other cars — neutral dim
+        ctx.fillStyle = 'hsla(0, 0%, 30%, 0.45)';
+        ctx.fill();
+      }
+    }
+
+    // ── Value label ──
+    if (_vizValueEl) {
+      const change = (_vizGridGhostPos > 0 && _vizGridGhostPos !== pos)
+        ? _vizGridGhostPos - pos
+        : (startPos > 0 ? startPos - pos : 0);
+      if (change !== 0) {
+        _vizValueEl.textContent = 'P' + pos + ' / ' + total + (change > 0 ? ' \u25B2' + change : ' \u25BC' + Math.abs(change));
+        _vizValueEl.style.color = change > 0 ? 'hsl(145, 60%, 60%)' : 'hsl(0, 60%, 65%)';
+      } else {
+        _vizValueEl.textContent = 'P' + pos + ' / ' + total;
+        _vizValueEl.style.color = '';
+      }
+    }
+  }
+
+  // ════════════════════════════════════════════
+  //  INCIDENT — quad-style incident tracker
+  //  2×2 cells:
+  //    [Count  ] [To Pen ]
+  //    [To DQ  ] [Accrued]  (bar fill)
+  //  Uses _settings.incPenalty / incDQ thresholds.
+  // ════════════════════════════════════════════
+
+  // Incident severity heatmap: green(0) → amber → red
+  function _incSeverityColor(count, limit) {
+    if (count <= 0)                return { hue: 123, sat: 40 };  // green — clean
+    const pct = count / Math.max(1, limit);
+    if (pct < 0.35)               return { hue: 123, sat: 45 };  // green — comfortable
+    if (pct < 0.55)               return { hue: 60,  sat: 50 };  // yellow — caution
+    if (pct < 0.75)               return { hue: 35,  sat: 65 };  // amber — warning
+    if (pct < 0.90)               return { hue: 15,  sat: 70 };  // orange — danger
+    return                          { hue: 0,   sat: 75 };        // red — critical
+  }
+
+  // Remaining-to-threshold heatmap: green(safe) → red(imminent)
+  function _incRemainingColor(remaining) {
+    if (remaining <= 0)  return { hue: 0,   sat: 80 };   // red — at/past limit
+    if (remaining <= 2)  return { hue: 0,   sat: 70 };   // red — critical
+    if (remaining <= 4)  return { hue: 15,  sat: 65 };   // orange
+    if (remaining <= 6)  return { hue: 35,  sat: 55 };   // amber
+    return                 { hue: 123, sat: 40 };          // green — safe
+  }
+
+  function _renderIncident(cfg) {
+    const count = Math.round(_getVizValue('incidents')) || 0;
+    // Read real incident limits from SDK; fall back to settings / defaults
+    const sdkPen = Math.round(_getVizValue('incidentLimitPenalty')) || 0;
+    const sdkDQ  = Math.round(_getVizValue('incidentLimitDQ')) || 0;
+    const penLimit = sdkPen > 0 ? sdkPen : ((typeof _settings !== 'undefined' && _settings.incPenalty) || 17);
+    const dqLimit  = sdkDQ  > 0 ? sdkDQ  : ((typeof _settings !== 'undefined' && _settings.incDQ)      || 25);
+    const toPen = Math.max(0, penLimit - count);
+    const toDQ  = Math.max(0, dqLimit - count);
+
+    const c = _prepCanvas();
+    if (!c) return;
+    const { ctx, w, h, dpr } = c;
+
+    // ── 2×2 quad layout ──
+    const gap = 4 * dpr;
+    const cellW = (w - gap) / 2;
+    const cellH = (h - gap) / 2;
+    const positions = [
+      [0, 0],                    // Count (top-left)
+      [cellW + gap, 0],          // To Penalty (top-right)
+      [0, cellH + gap],          // To DQ (bottom-left)
+      [cellW + gap, cellH + gap] // Accrued bar (bottom-right)
+    ];
+
+    // Accrued fraction as a percentage of DQ limit
+    const accruedPct = Math.min(100, Math.round((count / dqLimit) * 100));
+
+    // Cell data
+    const cells = [
+      { val: '' + count,
+        label: 'COUNT',
+        col: _incSeverityColor(count, dqLimit),
+        intensity: Math.max(0.15, Math.min(0.55, count / dqLimit)) },
+      { val: toPen > 0 ? '' + toPen : 'PEN!',
+        label: 'TO PEN',
+        col: _incRemainingColor(toPen),
+        intensity: toPen <= 0 ? 0.55 : toPen <= 3 ? 0.45 : 0.25 },
+      { val: toDQ > 0 ? '' + toDQ : 'DQ!',
+        label: 'TO DQ',
+        col: _incRemainingColor(toDQ),
+        intensity: toDQ <= 0 ? 0.55 : toDQ <= 3 ? 0.45 : 0.20 },
+      { val: accruedPct + '%',
+        label: 'ACCRUED',
+        col: _incSeverityColor(count, dqLimit),
+        intensity: Math.max(0.10, Math.min(0.40, count / dqLimit * 0.6)) }
+    ];
+
+    for (let i = 0; i < 4; i++) {
+      const [x, y] = positions[i];
+      const cell = cells[i];
+      const hue = cell.col.hue;
+      const sat = cell.col.sat;
+      const intensity = cell.intensity;
+
+      // Cell base fill
+      _roundRect(ctx, x, y, cellW, cellH, 4 * dpr);
+      ctx.fillStyle = `hsla(${hue}, ${sat}%, 12%, 0.6)`;
+      ctx.fill();
+
+      // Bottom-right cell: horizontal bar fill instead of radial glow
+      if (i === 3) {
+        const fillW = Math.max(0, (count / dqLimit) * cellW);
+        if (fillW > 0) {
+          ctx.save();
+          _roundRect(ctx, x, y, cellW, cellH, 4 * dpr);
+          ctx.clip();
+          ctx.fillStyle = `hsla(${hue}, ${sat}%, 35%, ${intensity + 0.15})`;
+          ctx.fillRect(x, y, fillW, cellH);
+          ctx.restore();
+        }
+
+        // Penalty marker line
+        const penX = x + (penLimit / dqLimit) * cellW;
+        if (penX > x && penX < x + cellW) {
+          ctx.beginPath();
+          ctx.moveTo(penX, y + 2 * dpr);
+          ctx.lineTo(penX, y + cellH - 2 * dpr);
+          ctx.strokeStyle = `hsla(35, 80%, 55%, ${toPen <= 0 ? 0.3 : 0.6})`;
+          ctx.lineWidth = 1 * dpr;
+          ctx.setLineDash([2 * dpr, 2 * dpr]);
+          ctx.stroke();
+          ctx.setLineDash([]);
+        }
+      } else {
+        // Heatmap radial glow (other cells)
+        const cx = x + cellW / 2;
+        const cy = y + cellH / 2;
+        const rMax = Math.max(cellW, cellH) * 0.8;
+        const radGrad = ctx.createRadialGradient(cx, cy, 0, cx, cy, rMax);
+        radGrad.addColorStop(0, `hsla(${hue}, ${sat}%, 45%, ${intensity})`);
+        radGrad.addColorStop(0.6, `hsla(${hue}, ${sat}%, 30%, ${intensity * 0.4})`);
+        radGrad.addColorStop(1, `hsla(${hue}, ${sat}%, 20%, 0)`);
+        _roundRect(ctx, x, y, cellW, cellH, 4 * dpr);
+        ctx.fillStyle = radGrad;
+        ctx.fill();
+      }
+
+      // Border
+      _roundRect(ctx, x, y, cellW, cellH, 4 * dpr);
+      ctx.strokeStyle = `hsla(${hue}, ${sat}%, 50%, ${0.3 + intensity * 0.5})`;
+      ctx.lineWidth = 1;
+      ctx.stroke();
+
+      // Value text
+      ctx.fillStyle = `hsla(${hue}, ${Math.max(sat, 30)}%, 70%, 0.95)`;
+      ctx.font = `bold ${11 * dpr}px system-ui, sans-serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      const cx2 = x + cellW / 2;
+      const cy2 = y + cellH / 2;
+      ctx.fillText(cell.val, cx2, cy2 - 2 * dpr);
+
+      // Label
+      ctx.fillStyle = `hsla(${hue}, ${Math.round(sat * 0.7)}%, 60%, 0.5)`;
+      ctx.font = `${7 * dpr}px system-ui, sans-serif`;
+      ctx.fillText(cell.label, cx2, cy2 + 10 * dpr);
+    }
+
+    if (_vizValueEl) _vizValueEl.textContent = '';
+  }
+
+  // ════════════════════════════════════════════
+  //  COUNTER — simple large numeric (no canvas)
+  // ════════════════════════════════════════════
+  function _renderCounter(cfg) {
+    const rawVal = _getVizValue(cfg.src);
+    // Clear canvas
+    if (_vizCtx && _vizCanvas) _vizCtx.clearRect(0, 0, _vizCanvas.width, _vizCanvas.height);
+
+    let display;
+    if (cfg.src === 'position' && rawVal > 0) display = 'P' + Math.round(rawVal);
+    else if (cfg.src === 'sessionTime' && typeof rawVal === 'string') display = rawVal;
+    else if (cfg.src === 'trackTemp') display = rawVal.toFixed(1) + '°C';
+    else display = Math.round(rawVal);
+
+    if (_vizValueEl) {
+      _vizValueEl.textContent = display;
+      _vizValueEl.style.color = '';
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+
+
+// ── modules/js/game-logo.js ──
+// ═══════════════════════════════════════════════════════════════
+// K10 Motorsports — Game Logo Overlay
+// Shows the current game's logo (iRacing, LMU, etc.) in the
+// corner opposite the main dashboard layout position.
+// ═══════════════════════════════════════════════════════════════
+
+(function() {
+  'use strict';
+
+  var _logoEl = null;
+  var _currentSvg = '';
+  var _currentGameId = '';
+  var _visible = false;
+
+  // Map game IDs to SVG filenames
+  var GAME_LOGO_FILES = {
+    'iracing': 'iracing.svg',
+    'lmu':     'le-mans-ultimate.svg'
+  };
+
+  // Logo-corner mapping: dashboard position → logo position
+  // Logo goes on the same vertical edge as the dashboard but on the
+  // opposite horizontal side — keeps it aligned with main modules.
+  var OPPOSITE_CORNER = {
+    'top-right':       'top-left',
+    'top-left':        'top-right',
+    'bottom-right':    'bottom-left',
+    'bottom-left':     'bottom-right',
+    'absolute-center': 'bottom-left'
+  };
+
+  // CSS class map for positioning
+  var POS_STYLES = {
+    'top-left':     'top:10px;left:10px;',
+    'top-right':    'top:10px;right:10px;',
+    'bottom-left':  'bottom:10px;left:10px;',
+    'bottom-right': 'bottom:10px;right:10px;'
+  };
+
+  function createLogoElement() {
+    if (_logoEl) return;
+    _logoEl = document.createElement('div');
+    _logoEl.id = 'gameLogoOverlay';
+    _logoEl.style.cssText =
+      'position:fixed;z-index:50;width:250px;pointer-events:none;' +
+      'opacity:0;transition:opacity 0.4s ease;' +
+      'display:flex;align-items:center;justify-content:center;';
+    document.body.appendChild(_logoEl);
+  }
+
+  function updatePosition() {
+    if (!_logoEl) return;
+    var layoutPos = (window._settings && window._settings.layoutPosition) || 'top-right';
+    var logoPos = OPPOSITE_CORNER[layoutPos] || 'bottom-left';
+    var style = POS_STYLES[logoPos] || POS_STYLES['bottom-left'];
+    // Reset all positioning
+    _logoEl.style.top = '';
+    _logoEl.style.right = '';
+    _logoEl.style.bottom = '';
+    _logoEl.style.left = '';
+    // Apply new position
+    var parts = style.split(';').filter(Boolean);
+    parts.forEach(function(p) {
+      var kv = p.split(':');
+      if (kv.length === 2) _logoEl.style[kv[0].trim()] = kv[1].trim();
+    });
+  }
+
+  function loadSvg(gameId) {
+    var file = GAME_LOGO_FILES[gameId];
+    if (!file) {
+      // No logo for this game
+      if (_logoEl) _logoEl.style.opacity = '0';
+      _currentGameId = gameId;
+      _currentSvg = '';
+      return;
+    }
+    if (gameId === _currentGameId && _currentSvg) {
+      // Already loaded
+      if (_visible && _logoEl) _logoEl.style.opacity = '0.5';
+      return;
+    }
+    _currentGameId = gameId;
+
+    // Resolve path — works from both file:// and http://
+    var basePath = '';
+    if (window._simhubUrlOverride) {
+      // Remote mode: assets served from root
+      basePath = '/';
+    }
+    var url = basePath + 'images/logos/' + file;
+
+    fetch(url)
+      .then(function(r) { return r.ok ? r.text() : ''; })
+      .then(function(svg) {
+        if (!svg || gameId !== _currentGameId) return;
+        _currentSvg = svg;
+        if (_logoEl) {
+          _logoEl.innerHTML = svg;
+          // Style the SVG element
+          var svgEl = _logoEl.querySelector('svg');
+          if (svgEl) {
+            svgEl.style.width = '100%';
+            svgEl.style.height = 'auto';
+            svgEl.style.maxHeight = '80px';
+          }
+          if (_visible) _logoEl.style.opacity = '0.5';
+        }
+      })
+      .catch(function() { /* non-critical */ });
+  }
+
+  /**
+   * Called from poll-engine on each telemetry tick.
+   * @param {string} gameId — current game ID (e.g. 'iracing', 'lmu')
+   * @param {boolean} show — whether the setting is enabled
+   */
+  window.updateGameLogo = function(gameId, show) {
+    createLogoElement();
+    _visible = show;
+
+    if (!show || !gameId || !GAME_LOGO_FILES[gameId]) {
+      if (_logoEl) _logoEl.style.opacity = '0';
+      return;
+    }
+
+    updatePosition();
+    loadSvg(gameId);
+  };
+
+  // Re-position when layout changes
+  var _origApplyLayout = window.applyLayout;
+  if (typeof _origApplyLayout === 'function') {
+    window.applyLayout = function() {
+      _origApplyLayout.apply(this, arguments);
+      updatePosition();
+    };
+  }
+  // Also listen for settings changes
+  window.addEventListener('k10-layout-changed', updatePosition);
+})();
+
+
+// ── modules/js/rating-editor.js ──
+// ═══════════════════════════════════════════════════════════════
+//  RATING EDITOR — Manual iRating, License & Safety Rating entry
+//  Lives in the iRacing settings tab (requires Discord connection).
+//  Persists to disk via Electron IPC (irating-history.json).
+//  Ctrl+Shift+I opens settings and switches to the iRacing tab.
+// ═══════════════════════════════════════════════════════════════
+
+(function() {
+  'use strict';
+
+  let _manualIR = 0;
+  let _manualSR = 0;
+  let _manualLicense = '';
+  let _ratingHistory = [];
+
+  // ── Expose to poll engine ──
+  window._manualIRating = 0;
+  window._manualSafetyRating = 0;
+  window._manualLicense = '';
+
+  // ── DOM refs ──
+  const irInput = document.getElementById('reIRatingInput');
+  const irSlider = document.getElementById('reIRatingSlider');
+  const srInput = document.getElementById('reSRInput');
+  const srSlider = document.getElementById('reSRSlider');
+  const licSelect = document.getElementById('reLicenseSelect');
+  const historyEl = document.getElementById('reHistory');
+
+  // ── Sync input ↔ slider ──
+  if (irInput && irSlider) {
+    irInput.addEventListener('input', function() {
+      irSlider.value = Math.min(+irSlider.max, Math.max(0, +irInput.value));
+    });
+    irSlider.addEventListener('input', function() {
+      irInput.value = (+irSlider.value).toFixed(0);
+    });
+  }
+  if (srInput && srSlider) {
+    srInput.addEventListener('input', function() {
+      srSlider.value = Math.min(+srSlider.max, Math.max(0, +srInput.value));
+    });
+    srSlider.addEventListener('input', function() {
+      srInput.value = (+srSlider.value).toFixed(2);
+    });
+  }
+
+  // ── Toggle: open settings → switch to iRacing tab ──
+  function toggleRatingEditor() {
+    const overlay = document.getElementById('settingsOverlay');
+    const iracingTab = document.getElementById('iracingTab');
+    if (!overlay || !iracingTab) return;
+
+    if (!overlay.classList.contains('open')) {
+      if (typeof toggleSettings === 'function') toggleSettings();
+    }
+    if (typeof switchSettingsTab === 'function') switchSettingsTab(iracingTab);
+
+    _populateInputs();
+    renderHistory();
+  }
+  window.toggleRatingEditor = toggleRatingEditor;
+
+  function _populateInputs() {
+    if (irInput) irInput.value = _manualIR > 0 ? _manualIR.toFixed(0) : '';
+    if (irSlider) irSlider.value = _manualIR || 0;
+    if (srInput) srInput.value = _manualSR > 0 ? _manualSR.toFixed(2) : '';
+    if (srSlider) srSlider.value = _manualSR || 0;
+    if (licSelect) licSelect.value = _manualLicense || 'R';
+  }
+
+  // ── Enable/disable iRacing tab based on Discord connection ──
+  function updateIRacingTabState() {
+    const tab = document.getElementById('iracingTab');
+    if (!tab) return;
+    const connected = !!_discordUser;
+    tab.classList.toggle('disabled', !connected);
+    tab.title = connected ? '' : 'Connect Discord to enable';
+  }
+  window.updateIRacingTabState = updateIRacingTabState;
+
+  // ── License display string ──
+  function _licenseLabel(code) {
+    if (code === 'R') return 'R';
+    if (code === 'P') return 'Pro';
+    return code || '—';
+  }
+
+  // ── Save values ──
+  function saveRatingValues() {
+    const newIR = Math.max(0, +(irInput ? irInput.value : 0));
+    const newSR = Math.max(0, Math.min(4.99, +(srInput ? srInput.value : 0)));
+    const newLic = licSelect ? licSelect.value : _manualLicense;
+
+    const entry = {
+      timestamp: new Date().toISOString(),
+      iRating: +newIR.toFixed(2),
+      safetyRating: +newSR.toFixed(2),
+      license: newLic,
+      prevIR: +_manualIR.toFixed(2),
+      prevSR: +_manualSR.toFixed(2),
+      prevLicense: _manualLicense,
+    };
+
+    _manualIR = newIR;
+    _manualSR = newSR;
+    _manualLicense = newLic;
+    window._manualIRating = _manualIR;
+    window._manualSafetyRating = _manualSR;
+    window._manualLicense = _manualLicense;
+
+    if (entry.iRating !== entry.prevIR || entry.safetyRating !== entry.prevSR || entry.license !== entry.prevLicense) {
+      _ratingHistory.push(entry);
+      if (_ratingHistory.length > 200) _ratingHistory = _ratingHistory.slice(-200);
+    }
+
+    const data = { iRating: _manualIR, safetyRating: _manualSR, license: _manualLicense, history: _ratingHistory };
+    if (window.k10 && window.k10.saveRatingData) {
+      window.k10.saveRatingData(data);
+    }
+    try { localStorage.setItem('k10-rating-data', JSON.stringify(data)); } catch(e) {}
+
+    _applyToDisplay();
+    renderHistory();
+  }
+  window.saveRatingValues = saveRatingValues;
+
+  // ── Reset to saved values ──
+  function resetRatingEditor() {
+    _populateInputs();
+  }
+  window.resetRatingEditor = resetRatingEditor;
+
+  // ── Delete a history entry ──
+  function deleteRatingEntry(idx) {
+    if (idx < 0 || idx >= _ratingHistory.length) return;
+    _ratingHistory.splice(idx, 1);
+    const data = { iRating: _manualIR, safetyRating: _manualSR, license: _manualLicense, history: _ratingHistory };
+    if (window.k10 && window.k10.saveRatingData) window.k10.saveRatingData(data);
+    try { localStorage.setItem('k10-rating-data', JSON.stringify(data)); } catch(e) {}
+    renderHistory();
+  }
+  window.deleteRatingEntry = deleteRatingEntry;
+
+  // ── Apply to dashboard display ──
+  function _applyToDisplay() {
+    if ((_manualIR > 0 || _manualSR > 0) && typeof window.setHasRatingData === 'function') {
+      window.setHasRatingData(true);
+    }
+    const ratVals = document.querySelectorAll('.rating-value');
+    if (ratVals.length >= 2) {
+      ratVals[0].textContent = _manualIR > 0 ? Math.round(_manualIR).toString() : '—';
+      ratVals[1].textContent = _manualSR > 0 ? _manualSR.toFixed(2) : '—';
+    }
+    if (typeof updateIRBar === 'function') updateIRBar(_manualIR);
+    if (typeof updateSRPie === 'function') updateSRPie(_manualSR);
+    // Show license letter in the SR delta slot
+    const ratDeltas = document.querySelectorAll('.rating-delta');
+    if (ratDeltas.length >= 2) {
+      ratDeltas[1].textContent = _manualLicense ? _licenseLabel(_manualLicense) : (_manualSR > 0 ? (_manualSR >= 3.0 ? 'A' : _manualSR >= 2.0 ? 'B' : _manualSR >= 1.0 ? 'C' : 'D') : '—');
+    }
+  }
+
+  // ── Render history ──
+  function renderHistory() {
+    if (!historyEl) return;
+    if (_ratingHistory.length === 0) {
+      historyEl.innerHTML = '<div style="text-align:center;padding:8px 0;color:hsla(0,0%,100%,0.25);">No history yet</div>';
+      return;
+    }
+    const recent = _ratingHistory.slice(-10).reverse();
+    let html = '';
+    for (let ri = 0; ri < recent.length; ri++) {
+      const e = recent[ri];
+      // Real index in _ratingHistory (recent is reversed, so map back)
+      const realIdx = _ratingHistory.length - 1 - ri;
+      const date = new Date(e.timestamp);
+      const dateStr = (date.getMonth()+1) + '/' + date.getDate() + ' ' + date.getHours() + ':' + String(date.getMinutes()).padStart(2, '0');
+      const irDelta = e.iRating - e.prevIR;
+      const srDelta = e.safetyRating - e.prevSR;
+      const irDeltaStr = irDelta !== 0 ? (irDelta > 0 ? '+' : '') + irDelta.toFixed(0) : '';
+      const srDeltaStr = srDelta !== 0 ? (srDelta > 0 ? '+' : '') + srDelta.toFixed(2) : '';
+      const licStr = e.license ? _licenseLabel(e.license) : '';
+      html += '<div class="re-history-entry">'
+        + '<span>' + dateStr + '</span>'
+        + '<span>iR ' + e.iRating + (irDeltaStr ? ' <span style="color:' + (irDelta > 0 ? 'var(--green)' : 'var(--red)') + '">' + irDeltaStr + '</span>' : '') + '</span>'
+        + '<span>' + licStr + ' ' + e.safetyRating.toFixed(2) + (srDeltaStr ? ' <span style="color:' + (srDelta > 0 ? 'var(--green)' : 'var(--red)') + '">' + srDeltaStr + '</span>' : '') + '</span>'
+        + '<button class="re-history-del" onclick="deleteRatingEntry(' + realIdx + ')">&times;</button>'
+        + '</div>';
+    }
+    historyEl.innerHTML = html;
+  }
+
+  // ── Load on startup ──
+  async function initRatingEditor() {
+    let data = null;
+
+    if (window.k10 && window.k10.getRatingData) {
+      try { data = await window.k10.getRatingData(); } catch(e) {}
+    }
+    if (!data || (!data.iRating && !data.safetyRating)) {
+      try { data = JSON.parse(localStorage.getItem('k10-rating-data') || 'null'); } catch(e) {}
+    }
+
+    if (data) {
+      _manualIR = +(data.iRating || 0);
+      _manualSR = +(data.safetyRating || 0);
+      _manualLicense = data.license || '';
+      _ratingHistory = Array.isArray(data.history) ? data.history : [];
+      window._manualIRating = _manualIR;
+      window._manualSafetyRating = _manualSR;
+      window._manualLicense = _manualLicense;
+      if (_manualIR > 0 || _manualSR > 0) _applyToDisplay();
+    }
+
+    if (window.k10 && window.k10.onToggleRatingEditor) {
+      window.k10.onToggleRatingEditor(toggleRatingEditor);
+    }
+
+    updateIRacingTabState();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initRatingEditor);
+  } else {
+    initRatingEditor();
+  }
+})();
+
+
+// ── modules/js/driver-profile.js ──
+// ═══════════════════════════════════════════════════════════════
+//  DRIVER PROFILE — Broadcast-ready ratings overlay.
+//  Ctrl+Shift+V to toggle.
+// ═══════════════════════════════════════════════════════════════
+
+(function() {
+  'use strict';
+
+  let _profileOpen = false;
+  let _carSessions = {};
+
+  const overlay = document.getElementById('driverProfileOverlay');
+
+  // ── Toggle ──
+  function toggleDriverProfile() {
+    if (!overlay) return;
+    _profileOpen = !_profileOpen;
+    overlay.classList.toggle('open', _profileOpen);
+    if (_profileOpen) {
+      _refresh();
+      if (window.k10 && window.k10.requestInteractive) window.k10.requestInteractive();
+    } else {
+      if (window.k10 && window.k10.releaseInteractive) window.k10.releaseInteractive();
+    }
+  }
+  window.toggleDriverProfile = toggleDriverProfile;
+
+  function _refresh() {
+    _showRatings();
+    _showAssessment();
+    _drawIRChart();
+    _drawSRChart();
+    _renderHeatmap();
+  }
+
+  function _licColor(lic) {
+    var c = { R:'hsl(0,65%,55%)', D:'hsl(24,85%,58%)', C:'hsl(48,80%,58%)', B:'hsl(130,55%,52%)', A:'hsl(210,70%,60%)', P:'hsl(270,60%,58%)' };
+    return c[lic] || 'hsla(0,0%,100%,0.5)';
+  }
+
+  // ── Ratings display with live deltas ──
+  function _showRatings() {
+    var ir = window._manualIRating || 0;
+    var sr = window._manualSafetyRating || 0;
+    var lic = window._manualLicense || '';
+
+    var irEl = document.getElementById('dpIRating');
+    var srEl = document.getElementById('dpSR');
+    var licEl = document.getElementById('dpLicense');
+    if (irEl) irEl.textContent = ir > 0 ? Math.round(ir).toLocaleString() : '—';
+    if (srEl) srEl.textContent = sr > 0 ? sr.toFixed(2) : '—';
+    if (licEl) {
+      var labels = { R:'Rookie', D:'D', C:'C', B:'B', A:'A', P:'Pro' };
+      licEl.textContent = labels[lic] || '—';
+      licEl.style.color = _licColor(lic);
+    }
+    // Inline iR bar
+    var dpIRBar = document.getElementById('dpIRBarFill');
+    if (dpIRBar) dpIRBar.style.width = Math.min(100, (ir / 5000) * 100) + '%';
+    // Inline SR pie
+    var dpSRPie = document.getElementById('dpSRPieFill');
+    if (dpSRPie) {
+      var circ = 2 * Math.PI * 15;
+      dpSRPie.setAttribute('stroke-dashoffset', String(circ * (1 - Math.min(1, sr / 4.0))));
+      dpSRPie.setAttribute('stroke', sr >= 3.0 ? 'var(--green)' : sr >= 2.0 ? 'var(--amber)' : 'var(--red)');
+    }
+
+    // Show estimated deltas from current race (pulled from poll engine)
+    var irDeltaEl = document.getElementById('dpIRDelta');
+    var srDeltaEl = document.getElementById('dpSRDelta');
+    // Read the live estimated delta that poll-engine computes
+    var irDelta = window._lastIRDelta || 0;
+    if (irDeltaEl) {
+      if (irDelta !== 0) {
+        irDeltaEl.textContent = (irDelta > 0 ? '+' : '') + irDelta;
+        irDeltaEl.className = 'dp-rating-delta ' + (irDelta > 0 ? 'positive' : 'negative');
+      } else { irDeltaEl.textContent = ''; irDeltaEl.className = 'dp-rating-delta'; }
+    }
+    // SR change estimate from last history entry
+    if (srDeltaEl) {
+      var history = [];
+      try { history = (JSON.parse(localStorage.getItem('k10-rating-data') || '{}')).history || []; } catch(e) {}
+      if (history.length >= 2) {
+        var last = history[history.length - 1];
+        var prev = history[history.length - 2];
+        var d = last.safetyRating - prev.safetyRating;
+        if (d !== 0) {
+          srDeltaEl.textContent = (d > 0 ? '+' : '') + d.toFixed(2);
+          srDeltaEl.className = 'dp-rating-delta ' + (d > 0 ? 'positive' : 'negative');
+        } else { srDeltaEl.textContent = ''; srDeltaEl.className = 'dp-rating-delta'; }
+      } else { srDeltaEl.textContent = ''; }
+    }
+  }
+
+  // ── 3-column broadcast assessment — short, punchy ──
+  function _showAssessment() {
+    var ir = window._manualIRating || 0;
+    var sr = window._manualSafetyRating || 0;
+    var lic = window._manualLicense || '';
+
+    var irCol = document.getElementById('dpAssessIR');
+    var srCol = document.getElementById('dpAssessSR');
+    var licCol = document.getElementById('dpAssessLic');
+    if (!irCol || !srCol || !licCol) return;
+
+    if (!ir && !sr && !lic) {
+      irCol.innerHTML = '<strong>iRating</strong><br>Not set';
+      srCol.innerHTML = '<strong>Safety</strong><br>Not set';
+      licCol.innerHTML = '<strong>License</strong><br>Not set';
+      return;
+    }
+
+    // iRating column
+    var irText = '';
+    if (ir < 1000) irText = 'Learning the fundamentals. Building pace and consistency.';
+    else if (ir < 1500) irText = 'Lower mid-field. Clean racer developing raw speed.';
+    else if (ir < 2000) irText = 'Mid-field. Understands strategy, refining corner speed.';
+    else if (ir < 2500) irText = 'Upper mid-field. Competitive in most splits.';
+    else if (ir < 3500) irText = 'Strong driver. Top-split regular with mature racecraft.';
+    else if (ir < 5000) irText = 'Elite. Competes with the fastest sim racers worldwide.';
+    else irText = 'World-class. Pro-level pace and consistency.';
+    irCol.innerHTML = '<strong>iRating ' + Math.round(ir).toLocaleString() + '</strong><br>' + irText;
+
+    // SR column
+    var srText = '';
+    if (sr < 1.0) srText = 'Frequent incidents. Focus on survival before pace.';
+    else if (sr < 2.0) srText = 'Developing awareness. Patience will close the gap.';
+    else if (sr < 3.0) srText = 'Clean racer. Recovers well from mistakes.';
+    else if (sr < 4.0) srText = 'Rarely makes contact. Trusted on track.';
+    else srText = 'Near-perfect discipline. Incident-free consistency.';
+    srCol.innerHTML = '<strong>SR ' + sr.toFixed(2) + '</strong><br>' + srText;
+
+    // License column
+    var licLabels = { R:'Rookie', D:'Class D', C:'Class C', B:'Class B', A:'Class A', P:'Pro' };
+    var licText = '';
+    if (lic === 'R') licText = 'Building the foundation. Every clean race matters.';
+    else if (lic === 'D') licText = 'Past the learning curve. Real race awareness developing.';
+    else if (lic === 'C') licText = 'Serious content unlocked. Rules of engagement expected.';
+    else if (lic === 'B') licText = 'Trusted in endurance and multi-class events.';
+    else if (lic === 'A') licText = 'Access to the most demanding series. Few reach this.';
+    else if (lic === 'P') licText = 'Elite tier. Pro-series and World Championship eligible.';
+    else licText = '';
+    licCol.innerHTML = '<strong style="color:' + _licColor(lic) + '">' + (licLabels[lic] || '—') + '</strong><br>' + licText;
+  }
+
+  // ── iRating chart ──
+  function _drawIRChart() {
+    var canvas = document.getElementById('dpIRChart');
+    if (!canvas) return;
+    var ctx = canvas.getContext('2d');
+    var dpr = window.devicePixelRatio || 1;
+    canvas.width = canvas.clientWidth * dpr;
+    canvas.height = canvas.clientHeight * dpr;
+    ctx.scale(dpr, dpr);
+    var w = canvas.clientWidth, h = canvas.clientHeight;
+    ctx.clearRect(0, 0, w, h);
+
+    var history = [];
+    try { history = (JSON.parse(localStorage.getItem('k10-rating-data') || '{}')).history || []; } catch(e) {}
+    history = history.filter(function(e) { return e.iRating > 0; });
+
+    if (history.length < 2) {
+      ctx.fillStyle = 'hsla(0,0%,100%,0.2)'; ctx.font = '13px system-ui'; ctx.textAlign = 'center';
+      ctx.fillText('iRating history builds as you save updates', w/2, h/2);
+      return;
+    }
+
+    var vals = history.map(function(e) { return e.iRating; });
+    var mn = Math.min.apply(null, vals) - 50, mx = Math.max.apply(null, vals) + 50;
+    var range = mx - mn || 1, pad = 10;
+
+    ctx.strokeStyle = 'hsla(0,0%,100%,0.06)'; ctx.lineWidth = 0.5;
+    for (var i = 0; i <= 4; i++) { var y = pad + (h - pad*2) * (i/4); ctx.beginPath(); ctx.moveTo(pad,y); ctx.lineTo(w-pad,y); ctx.stroke(); }
+
+    ctx.beginPath();
+    for (var i = 0; i < vals.length; i++) {
+      var x = pad + (i/(vals.length-1)) * (w-pad*2);
+      var y = pad + (1 - (vals[i]-mn)/range) * (h-pad*2);
+      if (i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
+    }
+    ctx.strokeStyle = 'hsl(260,60%,55%)'; ctx.lineWidth = 2.5; ctx.lineJoin = 'round'; ctx.stroke();
+    ctx.lineTo(pad+(w-pad*2), h-pad); ctx.lineTo(pad, h-pad); ctx.closePath();
+    var grad = ctx.createLinearGradient(0,0,0,h); grad.addColorStop(0,'hsla(260,60%,55%,0.15)'); grad.addColorStop(1,'hsla(260,60%,55%,0.0)');
+    ctx.fillStyle = grad; ctx.fill();
+
+    ctx.fillStyle = 'hsla(0,0%,100%,0.6)'; ctx.font = 'bold 12px "JetBrains Mono",monospace'; ctx.textAlign = 'right';
+    ctx.fillText('iR ' + Math.round(vals[vals.length-1]).toLocaleString(), w-pad, pad+14);
+  }
+
+  // ── SR chart ──
+  function _drawSRChart() {
+    var canvas = document.getElementById('dpSRChart');
+    if (!canvas) return;
+    var ctx = canvas.getContext('2d');
+    var dpr = window.devicePixelRatio || 1;
+    canvas.width = canvas.clientWidth * dpr;
+    canvas.height = canvas.clientHeight * dpr;
+    ctx.scale(dpr, dpr);
+    var w = canvas.clientWidth, h = canvas.clientHeight;
+    ctx.clearRect(0, 0, w, h);
+
+    var history = [];
+    try { history = (JSON.parse(localStorage.getItem('k10-rating-data') || '{}')).history || []; } catch(e) {}
+    history = history.filter(function(e) { return e.safetyRating > 0; });
+
+    if (history.length < 2) {
+      ctx.fillStyle = 'hsla(0,0%,100%,0.2)'; ctx.font = '13px system-ui'; ctx.textAlign = 'center';
+      ctx.fillText('Safety Rating history builds as you save updates', w/2, h/2);
+      return;
+    }
+
+    var vals = history.map(function(e) { return e.safetyRating; });
+    var pad = 10;
+    var licColors = ['hsl(24,85%,48%)', 'hsl(48,80%,48%)', 'hsl(130,55%,42%)', 'hsl(210,70%,50%)'];
+    ctx.strokeStyle = 'hsla(0,0%,100%,0.06)'; ctx.lineWidth = 0.5;
+    for (var i = 1; i <= 4; i++) {
+      var y = pad + (1-i/4.99)*(h-pad*2);
+      ctx.beginPath(); ctx.moveTo(pad,y); ctx.lineTo(w-pad,y); ctx.stroke();
+      ctx.fillStyle = licColors[i-1]; ctx.font = '9px system-ui'; ctx.textAlign = 'left'; ctx.globalAlpha = 0.3;
+      ctx.fillText(i+'.00', pad+2, y-2); ctx.globalAlpha = 1;
+    }
+
+    ctx.beginPath();
+    for (var i = 0; i < vals.length; i++) {
+      var x = pad + (i/(vals.length-1))*(w-pad*2);
+      var y = pad + (1-vals[i]/4.99)*(h-pad*2);
+      if (i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
+    }
+    ctx.strokeStyle = 'hsl(145,60%,50%)'; ctx.lineWidth = 2.5; ctx.lineJoin = 'round'; ctx.stroke();
+
+    ctx.fillStyle = 'hsla(0,0%,100%,0.6)'; ctx.font = 'bold 12px "JetBrains Mono",monospace'; ctx.textAlign = 'right';
+    ctx.fillText('SR ' + vals[vals.length-1].toFixed(2), w-pad, pad+14);
+  }
+
+  // ── Car heatmap ──
+  function _renderHeatmap() {
+    var el = document.getElementById('dpCarHeatmap');
+    if (!el) return;
+    if (Object.keys(_carSessions).length === 0) {
+      el.innerHTML = '<div style="color:hsla(0,0%,100%,0.25);padding:12px;text-align:center;">No car data yet</div>';
+      return;
+    }
+    var sorted = Object.entries(_carSessions).sort(function(a,b) { return b[1]-a[1]; });
+    var maxCount = sorted[0][1] || 1;
+    var html = '';
+    for (var i = 0; i < sorted.length; i++) {
+      var car = sorted[i][0], count = sorted[i][1];
+      var mfr = (typeof detectMfr === 'function') ? detectMfr(car) : 'generic';
+      var brandColor = (typeof _mfrBrandColors !== 'undefined' && _mfrBrandColors[mfr]) ? _mfrBrandColors[mfr] : 'hsla(0,0%,100%,0.1)';
+      var intensity = 0.15 + (count/maxCount) * 0.6;
+      html += '<div class="dp-hm-cell" style="background:' + brandColor.replace(/[\d.]+\)$/, intensity.toFixed(2)+')') + '">'
+        + '<span class="dp-hm-count">' + count + '</span>'
+        + '<span class="dp-hm-name">' + car.replace(/&/g,'&amp;').replace(/</g,'&lt;') + '</span></div>';
+    }
+    el.innerHTML = html;
+  }
+
+  // ── Record car session (called by poll engine) ──
+  function recordCarSession(carModel) {
+    if (!carModel) return;
+    _carSessions[carModel] = (_carSessions[carModel] || 0) + 1;
+    _saveProfile();
+  }
+  window.recordCarSession = recordCarSession;
+
+  function _saveProfile() {
+    var data = { carSessions: _carSessions };
+    if (window.k10 && window.k10.saveProfileData) window.k10.saveProfileData(data);
+    try { localStorage.setItem('k10-driver-profile', JSON.stringify(data)); } catch(e) {}
+  }
+
+  // ── Init ──
+  async function initDriverProfile() {
+    var data = null;
+    if (window.k10 && window.k10.getProfileData) {
+      try { data = await window.k10.getProfileData(); } catch(e) {}
+    }
+    if (!data) { try { data = JSON.parse(localStorage.getItem('k10-driver-profile') || 'null'); } catch(e) {} }
+    if (data && data.carSessions) _carSessions = data.carSessions;
+    if (window.k10 && window.k10.onToggleDriverProfile) window.k10.onToggleDriverProfile(toggleDriverProfile);
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initDriverProfile);
+  else initDriverProfile();
+})();
+
+
+// ── modules/js/drive-hud.js ──
+// ═══════════════════════════════════════════════════════════════
+//  DRIVE HUD — Driver-focused full-screen mode
+//  Shows: track map + sectors, lap delta, position, spotter, incidents
+//  Ctrl+Shift+F to toggle. Auto-activates on remote server connections.
+// ═══════════════════════════════════════════════════════════════
+
+(function() {
+  'use strict';
+
+  let _active = false;
+  let _dhHeadingSmooth = 0; // LERP-smoothed heading (degrees) to reduce judder
+  let _dhLastMapTime = 0;   // timestamp for time-based LERP
+
+  function toggleDriveMode() {
+    _active = !_active;
+    _applyDriveMode();
+    _settings.driveMode = _active;
+    saveSettings();
+  }
+  window.toggleDriveMode = toggleDriveMode;
+
+  function setDriveMode(on) {
+    _active = !!on;
+    _applyDriveMode();
+  }
+  window.setDriveMode = setDriveMode;
+
+  function _applyDriveMode() {
+    var hud = document.getElementById('driveHud');
+    document.body.classList.toggle('drive-mode-active', _active);
+    if (hud) hud.style.display = _active ? 'grid' : 'none';
+    // Restore transparent background when exiting
+    if (!_active) document.body.style.background = '';
+  }
+
+  // ── Update drive HUD data (called from poll engine each frame) ──
+  function updateDriveHud(p, isDemo) {
+    if (!_active) return;
+
+    const dsPre = isDemo ? 'K10Motorsports.Plugin.Demo.DS.' : 'K10Motorsports.Plugin.DS.';
+    const v = function(k) { return p[k] != null ? p[k] : 0; };
+
+    // Position
+    const pos = isDemo
+      ? (+v('K10Motorsports.Plugin.Demo.Position') || 0)
+      : (+v('DataCorePlugin.GameData.Position') || 0);
+    const posEl = document.getElementById('dhPosition');
+    if (posEl) posEl.textContent = pos > 0 ? 'P' + pos : 'P—';
+
+    // Lap delta
+    const lapDelta = +(p[dsPre + 'LapDelta']) || 0;
+    const deltaEl = document.getElementById('dhLapDelta');
+    if (deltaEl) {
+      deltaEl.textContent = lapDelta === 0 ? '+0.000' : (lapDelta >= 0 ? '+' : '') + lapDelta.toFixed(3);
+      deltaEl.classList.remove('dh-faster', 'dh-slower', 'dh-neutral');
+      if (lapDelta < -0.05) deltaEl.classList.add('dh-faster');
+      else if (lapDelta > 0.05) deltaEl.classList.add('dh-slower');
+      else deltaEl.classList.add('dh-neutral');
+    }
+
+    // Last / Current lap number
+    var bestLap = isDemo ? (+v('K10Motorsports.Plugin.Demo.BestLapTime') || 0) : (+v('DataCorePlugin.GameData.BestLapTime') || 0);
+    var lastLap = isDemo ? (+v('K10Motorsports.Plugin.Demo.LastLapTime') || 0) : (+v('DataCorePlugin.GameData.LastLapTime') || 0);
+    var curLap = isDemo ? (+v('K10Motorsports.Plugin.Demo.CurrentLap') || 0) : (+v('DataCorePlugin.GameData.CurrentLap') || 0);
+    var lastEl = document.getElementById('dhLastLap');
+    var lapEl = document.getElementById('dhCurrentLap');
+    if (lastEl) lastEl.textContent = lastLap > 0 ? _fmtLapTime(lastLap) : '—';
+    if (lapEl) lapEl.textContent = curLap > 0 ? curLap : '—';
+
+    // Live lap time + delta to best (absolutely positioned, centered)
+    var liveCurrentTime = isDemo
+      ? (+(p['K10Motorsports.Plugin.Demo.CurrentLapTime']) || 0)
+      : (+(p['DataCorePlugin.GameData.CurrentLapTime']) || 0);
+    var liveTimeEl = document.getElementById('dhLiveTime');
+    var liveDeltaEl = document.getElementById('dhLiveDelta');
+    if (liveTimeEl) {
+      liveTimeEl.textContent = liveCurrentTime > 0.5 ? _fmtLapTime(liveCurrentTime) : '—';
+    }
+    if (liveDeltaEl && liveCurrentTime > 0.5) {
+      // Use the real-time delta from the big display (same source, already computed)
+      if (liveCurrentTime > 5 && Math.abs(lapDelta) < 300) {
+        var sign = lapDelta >= 0 ? '+' : '';
+        liveDeltaEl.textContent = sign + lapDelta.toFixed(3);
+        liveDeltaEl.className = 'dh-live-delta';
+        if (lapDelta <= -0.5) liveDeltaEl.classList.add('dh-delta-pb');
+        else if (lapDelta < 0) liveDeltaEl.classList.add('dh-delta-faster');
+        else if (lapDelta < 1.0) liveDeltaEl.classList.add('dh-delta-slower');
+        else liveDeltaEl.classList.add('dh-delta-much-slower');
+      } else {
+        liveDeltaEl.textContent = '';
+      }
+    } else if (liveDeltaEl) {
+      liveDeltaEl.textContent = '';
+    }
+
+    // Sectors (from plugin — N-sector support)
+    var curSector = +(p[dsPre + 'CurrentSector']) || 1;
+    var sectorCount = +(p[dsPre + 'SectorCount']) || 3;
+    var splitsStr = p[dsPre + 'SectorSplits'] || '';
+    var splits, deltas, states;
+    if (splitsStr) {
+      splits = splitsStr.split(',').map(Number);
+      deltas = (p[dsPre + 'SectorDeltas'] || '').split(',').map(Number);
+      states = (p[dsPre + 'SectorStates'] || '').split(',').map(Number);
+    } else {
+      splits = [+(p[dsPre + 'SectorSplitS1']) || 0, +(p[dsPre + 'SectorSplitS2']) || 0, +(p[dsPre + 'SectorSplitS3']) || 0];
+      deltas = [+(p[dsPre + 'SectorDeltaS1']) || 0, +(p[dsPre + 'SectorDeltaS2']) || 0, +(p[dsPre + 'SectorDeltaS3']) || 0];
+      states = [+(p[dsPre + 'SectorStateS1']) || 0, +(p[dsPre + 'SectorStateS2']) || 0, +(p[dsPre + 'SectorStateS3']) || 0];
+    }
+    var stateClass = ['', 'dh-s-pb', 'dh-s-faster', 'dh-s-slower'];
+    var currentLapTime = isDemo
+      ? (+(p['K10Motorsports.Plugin.Demo.CurrentLapTime']) || 0)
+      : (+(p['DataCorePlugin.GameData.CurrentLapTime']) || 0);
+
+    // Dynamically create/update drive HUD sector cells
+    var dhSectorsEl = document.querySelector('.dh-sectors');
+    if (dhSectorsEl) {
+      var existingCells = dhSectorsEl.querySelectorAll('.dh-sector');
+      if (existingCells.length !== sectorCount) {
+        dhSectorsEl.innerHTML = '';
+        for (var ci = 1; ci <= sectorCount; ci++) {
+          var cell = document.createElement('div');
+          cell.className = 'dh-sector';
+          cell.id = 'dhS' + ci;
+          cell.innerHTML = '<div class="dh-sec-label">S' + ci + '</div>' +
+            '<div class="dh-sec-time" id="dhS' + ci + 'Time">—</div>' +
+            '<div class="dh-sec-delta" id="dhS' + ci + 'Delta"></div>';
+          dhSectorsEl.appendChild(cell);
+        }
+      }
+    }
+
+    for (var si = 1; si <= sectorCount; si++) {
+      var cell = document.getElementById('dhS' + si);
+      var timeEl = document.getElementById('dhS' + si + 'Time');
+      var sDeltaEl = document.getElementById('dhS' + si + 'Delta');
+      if (!cell || !timeEl) continue;
+
+      cell.classList.remove('dh-s-pb', 'dh-s-faster', 'dh-s-slower', 'dh-s-invalid', 'dh-s-active');
+
+      // If lap is invalid (incident occurred), mark all sectors red
+      if (_lapInvalid) cell.classList.add('dh-s-invalid');
+
+      if (si === curSector) {
+        cell.classList.add('dh-s-active');
+        // Calculate sector entry time — only if ALL previous splits are valid.
+        // iRacing clears splits at lap-cross in quali; without this guard the
+        // full currentLapTime leaks into the sector cell.
+        var entryTime = 0;
+        var hasPrevSplits = true;
+        for (var k = 0; k < si - 1; k++) {
+          if (!splits[k] || splits[k] <= 0) { hasPrevSplits = false; break; }
+          entryTime += splits[k];
+        }
+        if (hasPrevSplits && currentLapTime > entryTime) {
+          var elapsed = currentLapTime - entryTime;
+          // Extra guard: no single sector should approach full lap length
+          if (bestLap > 0 && elapsed >= bestLap * 0.85) {
+            timeEl.textContent = '—';
+            if (sDeltaEl) sDeltaEl.textContent = '';
+          } else {
+            var em = Math.floor(elapsed / 60);
+            var es = elapsed % 60;
+            timeEl.textContent = (em > 0 ? em + ':' : '') + (em > 0 && es < 10 ? '0' : '') + es.toFixed(1);
+            if (sDeltaEl) {
+              if (lapDelta !== 0) {
+                sDeltaEl.textContent = (lapDelta >= 0 ? '+' : '') + lapDelta.toFixed(2);
+                cell.classList.add(lapDelta < 0 ? 'dh-s-faster' : 'dh-s-slower');
+              } else { sDeltaEl.textContent = ''; }
+            }
+          }
+        } else if (si === 1 && currentLapTime > 0 && currentLapTime < 120) {
+          // S1 is always valid — entry time is lap start (0)
+          var em = Math.floor(currentLapTime / 60);
+          var es = currentLapTime % 60;
+          timeEl.textContent = (em > 0 ? em + ':' : '') + (em > 0 && es < 10 ? '0' : '') + es.toFixed(1);
+          if (sDeltaEl) {
+            if (lapDelta !== 0) {
+              sDeltaEl.textContent = (lapDelta >= 0 ? '+' : '') + lapDelta.toFixed(2);
+              cell.classList.add(lapDelta < 0 ? 'dh-s-faster' : 'dh-s-slower');
+            } else { sDeltaEl.textContent = ''; }
+          }
+        } else {
+          timeEl.textContent = '—';
+          if (sDeltaEl) sDeltaEl.textContent = '';
+        }
+      } else if (splits[si - 1] > 0) {
+        var split = splits[si - 1];
+        // Sanity check: iRacing sometimes sends cumulative lap time as
+        // the final sector split. Never display a full lap time here.
+        var sumOther = 0, otherCount = 0;
+        for (var sc = 0; sc < sectorCount; sc++) {
+          if (sc !== si - 1 && splits[sc] > 0) { sumOther += splits[sc]; otherCount++; }
+        }
+        var exceedsOthers = sumOther > 0 && split >= sumOther;
+        var exceedsBest = bestLap > 0 && split >= bestLap * 0.85;
+        // Also check previous poll's splits — iRacing clears sectors on lap
+        // cross in qualifying, so otherCount can be 0 even for a real split
+        var prevOther = 0;
+        for (var pc = 0; pc < _prevSectorSplits.length; pc++) {
+          if (pc !== si - 1 && _prevSectorSplits[pc] > 0) prevOther++;
+        }
+        var lastNoCtx = si === sectorCount && sectorCount >= 2 && otherCount === 0 && prevOther === 0;
+        if (exceedsOthers || exceedsBest || lastNoCtx) {
+          timeEl.textContent = '—';
+          if (sDeltaEl) sDeltaEl.textContent = '';
+        } else {
+        var m = Math.floor(split / 60);
+        var s = split % 60;
+        timeEl.textContent = (m > 0 ? m + ':' : '') + (m > 0 && s < 10 ? '0' : '') + s.toFixed(1);
+        if (stateClass[states[si - 1]]) cell.classList.add(stateClass[states[si - 1]]);
+        if (sDeltaEl) {
+          var d = deltas[si - 1];
+          if (states[si - 1] === 1) sDeltaEl.textContent = 'PB';
+          else if (d !== 0) sDeltaEl.textContent = (d >= 0 ? '+' : '') + d.toFixed(2);
+          else sDeltaEl.textContent = '';
+        }
+        }
+      } else {
+        timeEl.textContent = '—';
+        if (sDeltaEl) sDeltaEl.textContent = '';
+      }
+    }
+
+    // Incidents
+    var incCount = +(p[dsPre + 'IncidentCount']) || 0;
+    var incEl = document.getElementById('dhIncCount');
+    if (incEl) incEl.innerHTML = incCount + '<span class="dh-inc-x">x</span>';
+    var penEl = document.getElementById('dhIncToPen');
+    var dqEl = document.getElementById('dhIncToDQ');
+    var isNonRace = !!(+(p[dsPre + 'IsNonRaceSession']) || 0);
+    var sdkPen = isNonRace ? 0 : (+(p[dsPre + 'IncidentLimitPenalty']) || 0);
+    var sdkDQ  = isNonRace ? 0 : (+(p[dsPre + 'IncidentLimitDQ']) || 0);
+    var dhThresh = document.querySelector('.dh-inc-thresholds');
+    if (sdkPen > 0 && sdkDQ > 0) {
+      // Both penalty and DQ
+      if (penEl) penEl.textContent = Math.max(0, sdkPen - incCount);
+      if (dqEl) dqEl.textContent = Math.max(0, sdkDQ - incCount);
+      if (dhThresh) dhThresh.style.display = '';
+      if (penEl) penEl.nextSibling.textContent = ' to pen ';
+    } else if (sdkDQ > 0) {
+      // DQ only — hide penalty, show DQ
+      if (penEl) { penEl.textContent = ''; penEl.nextSibling.textContent = ''; }
+      if (dqEl) dqEl.textContent = Math.max(0, sdkDQ - incCount);
+      if (dhThresh) dhThresh.style.display = '';
+    } else {
+      // No limits (practice, test, etc.) — hide thresholds row
+      if (dhThresh) dhThresh.style.display = 'none';
+    }
+
+    // Track map — local zoom view centered on player + opponents
+    var mapReady = +v('K10Motorsports.Plugin.TrackMap.Ready') || 0;
+    if (mapReady) {
+      var svgPath = (p['K10Motorsports.Plugin.TrackMap.SvgPath'] || '');
+      var dhTrack = document.getElementById('dhMapTrack');
+      if (dhTrack && svgPath && dhTrack.getAttribute('d') !== svgPath) {
+        dhTrack.setAttribute('d', svgPath);
+        if (typeof _splitPathIntoSectors === 'function') {
+          var boundaryPcts = Array.isArray(window._sectorBoundaries) ? window._sectorBoundaries : null;
+          var sPaths = _splitPathIntoSectors(svgPath, boundaryPcts);
+          // Dynamically create/update sector paths inside the rotate group
+          var dhRotateGrp = document.getElementById('dhMapRotateGroup');
+          if (dhRotateGrp) {
+            dhRotateGrp.querySelectorAll('.map-sector').forEach(function(el) { el.remove(); });
+            var dhOpp = document.getElementById('dhMapOpponents');
+            for (var i = 0; i < sPaths.length; i++) {
+              var path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+              path.classList.add('map-sector');
+              path.id = 'dhSector' + (i + 1);
+              path.setAttribute('d', sPaths[i]);
+              if (dhOpp) dhRotateGrp.insertBefore(path, dhOpp);
+              else dhRotateGrp.appendChild(path);
+            }
+          }
+        }
+      }
+
+      var px = Math.max(0, Math.min(100, +v('K10Motorsports.Plugin.TrackMap.PlayerX') || 50));
+      var py = Math.max(0, Math.min(100, +v('K10Motorsports.Plugin.TrackMap.PlayerY') || 50));
+
+      // Update player dot
+      var dhPlayer = document.getElementById('dhMapPlayer');
+      if (dhPlayer) {
+        dhPlayer.setAttribute('cx', px.toFixed(1));
+        dhPlayer.setAttribute('cy', py.toFixed(1));
+      }
+
+      // Zoom viewBox: centered on player with expanded radius to accommodate
+      // rotation. A 22-unit visible radius needs ~31 units (22 × √2) so the
+      // rotated track content isn't clipped by the viewBox rectangle.
+      var dhSvg = document.getElementById('dhMapSvg');
+      if (dhSvg) {
+        var zrVisible = 22; // visible zoom radius
+        var zr = Math.ceil(zrVisible * 1.42); // ×√2 for rotation headroom
+        var vx = px - zr;
+        var vy = py - zr;
+        dhSvg.setAttribute('viewBox', vx.toFixed(1) + ' ' + vy.toFixed(1) + ' ' + (zr * 2) + ' ' + (zr * 2));
+
+        // Rotate map so driving direction always points up.
+        // Time-based LERP smoothing eliminates heading judder regardless
+        // of poll rate. Dead-zone ignores sub-degree noise.
+        var rawHeading = +(p['K10Motorsports.Plugin.TrackMap.PlayerHeading']) || 0;
+        var diff = rawHeading - _dhHeadingSmooth;
+        // Normalise diff to [-180, 180] to pick the shortest rotation arc
+        while (diff > 180) diff -= 360;
+        while (diff < -180) diff += 360;
+        // Dead-zone: ignore tiny heading jitter (< 0.5°)
+        if (Math.abs(diff) < 0.5) diff = 0;
+        // Time-based LERP: smooth factor ~0.10 per 33ms (30 FPS baseline)
+        var now = performance.now();
+        var dt = Math.min(100, now - (_dhLastMapTime || now)); // cap at 100ms
+        _dhLastMapTime = now;
+        var alpha = 1 - Math.pow(1 - 0.10, dt / 33);
+        _dhHeadingSmooth += diff * alpha;
+        _dhHeadingSmooth = ((_dhHeadingSmooth % 360) + 360) % 360;
+
+        // Rotate the inner group around the player's SVG coordinate, NOT the
+        // SVG element itself (element rotation caused rectangular crop artefacts).
+        var dhRotateGroup = document.getElementById('dhMapRotateGroup');
+        if (dhRotateGroup) {
+          var rotDeg = (-_dhHeadingSmooth).toFixed(2);
+          dhRotateGroup.setAttribute('transform',
+            'rotate(' + rotDeg + ',' + px.toFixed(1) + ',' + py.toFixed(1) + ')');
+        }
+        // Player dot stays outside the rotate group, so no counter-rotation needed
+        dhSvg.style.transform = '';
+        dhSvg.style.transformOrigin = '';
+      }
+
+      // Opponents
+      var opponentStr = p['K10Motorsports.Plugin.TrackMap.Opponents'] || '';
+      var dhOppG = document.getElementById('dhMapOpponents');
+      if (dhOppG) {
+        var parts = opponentStr ? opponentStr.split(';').filter(function(s) { return s.length > 0; }) : [];
+        var count = Math.min(parts.length, 63);
+
+        // Ensure enough circle elements
+        while (dhOppG.children.length < count) {
+          var c = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+          c.classList.add('map-opponent');
+          c.setAttribute('r', '1.5');
+          dhOppG.appendChild(c);
+        }
+        while (dhOppG.children.length > count) {
+          dhOppG.removeChild(dhOppG.lastChild);
+        }
+
+        for (var oi = 0; oi < count; oi++) {
+          var seg = parts[oi].split(',');
+          if (seg.length < 2) continue;
+          var ox = Math.max(0, Math.min(100, +seg[0]));
+          var oy = Math.max(0, Math.min(100, +seg[1]));
+          var inPit = seg[2] === '1';
+          dhOppG.children[oi].setAttribute('cx', String(ox));
+          dhOppG.children[oi].setAttribute('cy', String(oy));
+          dhOppG.children[oi].style.display = inPit ? 'none' : '';
+          // Highlight nearby opponents
+          var dx = px - ox, dy = py - oy;
+          var close = (dx * dx + dy * dy) < 64;
+          dhOppG.children[oi].classList.toggle('close', close);
+        }
+      }
+
+      // Sector colors
+      if (window._sectorData) {
+        var sd = window._sectorData;
+        var sColors = ['transparent', 'hsl(280,60%,55%)', 'hsl(130,60%,50%)', 'hsl(0,65%,50%)'];
+        for (var j = 1; j <= sd.sectorCount; j++) {
+          var sEl = document.getElementById('dhSector' + j);
+          if (!sEl) continue;
+          sEl.setAttribute('stroke', j === sd.curSector ? 'hsla(0,0%,100%,0.25)' : (sColors[sd.states[j-1]] || 'transparent'));
+        }
+      }
+    }
+
+    // Track name
+    var nameEl = document.getElementById('dhMapName');
+    var trackName = p['DataCorePlugin.GameData.TrackName'] || '';
+    if (nameEl && trackName) nameEl.textContent = trackName;
+  }
+  window.updateDriveHud = updateDriveHud;
+
+  // ── Make _splitPathIntoSectors available globally ──
+  // (it's defined in webgl-helpers.js, exposed here for drive hud)
+
+  // ── Init ──
+  function initDriveHud() {
+    // Listen for Ctrl+Shift+F via Electron
+    if (window.k10 && window.k10.onToggleDriveMode) {
+      window.k10.onToggleDriveMode(toggleDriveMode);
+    }
+
+    // Auto-activate on remote server connections
+    if (window._k10RemoteMode) {
+      setDriveMode(true);
+    }
+
+    // Restore persisted state
+    if (_settings.driveMode) {
+      setDriveMode(true);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initDriveHud);
+  } else {
+    initDriveHud();
+  }
+})();
+
+
+// ── modules/js/poll-engine.js ──
+// SIMHUB HTTP API POLLING ENGINE
+// Depends on: config.js (SIMHUB_URL, POLL_MS, PROP_KEYS)
+
+  // ═══════════════════════════════════════════════════════════════
+  // SIMHUB HTTP API POLLING ENGINE
+  // Self-contained data bridge — polls SimHub's web server directly.
+  // Works as standalone browser overlay or OBS Browser Source.
+  // The JavascriptExtensions file is unused in this mode.
+  //
+  // Config: K10 Motorsports plugin HTTP server (port 8889)
+  // The plugin serves all telemetry, demo, commentary and track map data
+  // as a flat JSON map from its own HTTP server — no SimHub web API needed.
+  // ═══════════════════════════════════════════════════════════════
+
+  // Constants and property keys are defined in config.js
+  // Connection status, fetchProps, applyGameMode are in game-detect.js
+  // Settings persistence and Discord state are in connections.js
+
+  // ─── Fallback demo track map — Sebring International (80-pt Catmull-Rom→Bezier) ──
+  // Generated from bundled CSV: sebring international.csv
+  // Normalised to 0-100 viewBox with 5% padding (same algorithm as C# NormaliseAndBuild)
+  const _DEMO_FALLBACK_MAP = 'M 58.9,71.8 C 64.2,72.1 62.3,72.0 64.0,72.1 C 65.7,72.1 67.3,72.3 69.0,72.2 C 70.6,72.0 72.5,72.0 73.7,71.2 C 75.0,70.3 75.8,68.6 76.3,67.1 C 76.9,65.6 76.9,63.8 77.0,62.1 C 77.0,60.4 76.7,58.7 76.5,56.9 C 76.2,55.2 75.8,53.6 75.5,51.8 C 75.2,50.1 74.9,48.3 74.8,46.5 C 74.7,44.8 75.0,43.0 74.9,41.3 C 74.7,39.7 74.8,37.6 74.0,36.4 C 73.1,35.3 71.2,35.2 69.7,34.5 C 68.2,33.9 66.6,32.9 65.0,32.4 C 63.5,32.0 61.6,31.2 60.3,31.8 C 59.0,32.3 58.2,34.2 57.3,35.6 C 56.5,37.0 56.0,38.7 55.0,40.1 C 54.0,41.5 52.6,42.9 51.3,44.0 C 50.0,45.1 48.7,45.9 47.3,46.8 C 45.8,47.6 44.1,48.4 42.4,49.0 C 40.6,49.5 38.7,49.9 36.8,50.2 C 34.9,50.4 32.9,50.4 30.9,50.4 C 28.9,50.4 26.8,50.3 24.8,50.3 C 22.7,50.3 20.5,50.4 18.5,50.4 C 16.6,50.4 14.7,50.4 12.9,50.4 C 11.2,50.4 9.3,50.9 8.0,50.4 C 6.7,49.8 5.2,48.6 5.1,47.3 C 5.0,46.1 6.6,44.5 7.4,43.0 C 8.2,41.6 8.8,40.0 9.9,38.7 C 11.0,37.4 12.4,36.0 13.9,35.1 C 15.4,34.1 17.1,33.5 18.8,32.8 C 20.4,32.1 22.3,31.5 23.9,30.9 C 25.6,30.2 27.3,29.7 28.7,28.9 C 30.2,28.1 31.3,27.2 32.5,26.2 C 33.8,25.2 34.9,24.0 36.0,22.9 C 37.2,21.8 38.2,20.7 39.4,19.5 C 40.6,18.3 41.9,16.8 43.1,15.7 C 44.4,14.5 45.7,12.9 47.0,12.7 C 48.3,12.6 49.7,13.9 50.9,14.8 C 52.2,15.7 53.2,17.3 54.6,18.0 C 56.0,18.8 57.7,19.2 59.3,19.2 C 61.0,19.1 62.9,18.4 64.5,17.8 C 66.1,17.3 67.4,16.4 69.0,16.0 C 70.5,15.6 72.2,15.6 73.9,15.5 C 75.6,15.4 77.7,15.0 79.1,15.5 C 80.4,16.1 81.7,17.6 82.2,19.0 C 82.7,20.4 82.1,22.2 82.1,24.0 C 82.0,25.8 82.0,27.8 81.9,29.6 C 81.9,31.3 81.8,32.8 81.8,34.5 C 81.7,36.1 81.7,37.9 81.6,39.5 C 81.6,41.1 81.3,42.6 81.3,44.2 C 81.3,45.8 81.3,47.4 81.6,49.0 C 82.0,50.5 82.7,52.1 83.4,53.7 C 84.2,55.2 85.1,56.9 86.2,58.4 C 87.3,59.8 89.0,61.1 90.2,62.4 C 91.5,63.8 93.0,65.0 93.8,66.5 C 94.6,67.9 95.1,69.6 94.9,71.1 C 94.6,72.6 93.0,73.9 92.4,75.4 C 91.8,77.0 91.7,78.7 91.2,80.4 C 90.8,82.0 90.6,84.3 89.6,85.4 C 88.7,86.6 86.8,87.1 85.3,87.4 C 83.7,87.6 82.1,87.1 80.4,87.0 C 78.7,86.9 76.8,86.8 75.1,86.7 C 73.4,86.7 71.9,86.9 70.2,86.9 C 68.5,86.9 66.7,86.9 64.8,86.9 C 63.0,86.9 61.0,86.9 59.1,86.8 C 57.1,86.8 55.1,86.8 53.1,86.8 C 51.1,86.7 48.9,86.7 46.9,86.7 C 44.8,86.7 42.7,86.8 40.8,86.8 C 38.9,86.8 37.3,86.8 35.6,86.8 C 33.8,86.8 32.1,86.8 30.4,86.7 C 28.7,86.7 27.3,86.8 25.6,86.7 C 23.9,86.7 21.8,86.8 20.1,86.5 C 18.3,86.2 16.8,85.7 15.3,84.8 C 13.9,84.0 12.3,82.9 11.4,81.5 C 10.5,80.2 10.0,78.2 10.1,76.7 C 10.3,75.2 11.1,73.5 12.3,72.5 C 13.4,71.5 15.3,71.2 17.0,70.8 C 18.6,70.4 20.4,70.2 22.1,70.1 C 23.8,70.0 25.3,70.0 27.0,70.0 C 28.7,70.0 27.0,69.9 32.3,70.2 C 37.7,70.5 53.7,71.5 58.9,71.8 Z';
+
+  // ─── Time value parser — handles both numeric seconds and TimeSpan strings ───
+  function _parseTimeValue(val) {
+    if (val == null || val === '') return 0;
+    // Try numeric first (most common case)
+    var n = +val;
+    if (!isNaN(n)) return n;
+    // Try TimeSpan string format "HH:MM:SS.fff" or "MM:SS.fff"
+    if (typeof val === 'string') {
+      var parts = val.split(':');
+      if (parts.length === 3) {
+        // HH:MM:SS.fff
+        return (+parts[0] || 0) * 3600 + (+parts[1] || 0) * 60 + (parseFloat(parts[2]) || 0);
+      } else if (parts.length === 2) {
+        // MM:SS.fff
+        return (+parts[0] || 0) * 60 + (parseFloat(parts[1]) || 0);
+      }
+    }
+    return 0;
+  }
+
+  // ─── Main update loop ───
+  async function pollUpdate() {
+    if (_pollActive) return;
+    _pollActive = true;
+    try {
+
+    const p = await fetchProps();
+    if (!p) { _pollActive = false; return; }
+
+    _pollFrame++;
+    _cycleFrameCount++;
+
+    // Diagnostic logging (first 3 frames + every 300 frames ~10s)
+    if (_pollFrame <= 3 || _pollFrame % 300 === 0) {
+      const keys = Object.keys(p).filter(k => p[k] != null && p[k] !== 0 && p[k] !== '');
+      console.log(`[K10 poll #${_pollFrame}] Got ${Object.keys(p).length} keys, ${keys.length} non-empty. DemoMode=${p['K10Motorsports.Plugin.DemoMode']}, GameRunning=${p['DataCorePlugin.GameRunning']}`);
+      if (_pollFrame === 1) console.log('[K10 poll] Sample values:', JSON.stringify(Object.fromEntries(keys.slice(0, 10).map(k => [k, p[k]]))));
+    }
+
+    // ── Plugin version check — warn if old DLL is serving incomplete data ──
+    if (_pollFrame === 1 && !p['DataCorePlugin.GameRunning'] && p['DataCorePlugin.GameRunning'] !== 0) {
+      let dbg = document.createElement('div');
+      dbg.style.cssText = 'position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:rgba(20,20,28,0.95);color:#ff8;font:12px/1.6 system-ui,sans-serif;padding:20px 28px;z-index:99999;border-radius:10px;max-width:420px;text-align:center;border:1px solid rgba(255,255,255,0.12);';
+      dbg.innerHTML = '<div style="font-size:14px;font-weight:600;color:#fff;margin-bottom:8px">Plugin needs rebuild</div>' +
+        '<div style="color:#aaa;font-size:11px;line-height:1.6">The SimHub plugin is an older version that doesn\'t serve telemetry data via HTTP.<br><br>' +
+        'Rebuild the C# project in Visual Studio and restart SimHub.<br>' +
+        `<span style="color:#666;font-size:10px">Got ${Object.keys(p).length} keys, expected 50+</span></div>`;
+      document.body.appendChild(dbg);
+      setTimeout(() => dbg.remove(), 15000);
+    }
+
+    const v = (k) => p[k] != null ? p[k] : 0;
+    const vs = (k) => p[k] != null ? '' + p[k] : '';
+
+    // Demo mode: swap data sources when plugin demo mode is active
+    const _demo = +v('K10Motorsports.Plugin.DemoMode') || 0;
+    const d = (gameKey, demoKey) => _demo ? v('K10Motorsports.Plugin.' + demoKey) : v(gameKey);
+    const ds = (gameKey, demoKey) => _demo ? vs('K10Motorsports.Plugin.' + demoKey) : vs(gameKey);
+
+    // ─── Idle State Detection ───
+    const gameRunning = +v('DataCorePlugin.GameRunning') || 0;
+    const sessionPre = _demo ? 'K10Motorsports.Plugin.Demo.Grid.' : 'K10Motorsports.Plugin.Grid.';
+    const dsPre = _demo ? 'K10Motorsports.Plugin.Demo.DS.' : 'K10Motorsports.Plugin.DS.';
+    const sessNum = parseInt(vs(sessionPre + 'SessionState')) || 0;
+    const _inPitLane = +(p[dsPre + 'IsInPitLane']) > 0;
+
+    // ─── Session change detection — reset per-session state ───
+    const _currSessionTypeName = _demo
+      ? vs('K10Motorsports.Plugin.Demo.SessionTypeName')
+      : vs('K10Motorsports.Plugin.SessionTypeName');
+    if (_currSessionTypeName && _currSessionTypeName !== _prevSessionTypeName && _prevSessionTypeName) {
+      console.log('[K10] Session changed:', _prevSessionTypeName, '→', _currSessionTypeName);
+      if (typeof resetTimeline === 'function') resetTimeline();
+    }
+    if (_currSessionTypeName) _prevSessionTypeName = _currSessionTypeName;
+
+    // Detect game and apply feature gating
+    const rawGameId = v('K10Motorsports.Plugin.GameId') || '';
+    const newGameId = detectGameId(rawGameId);
+    if (newGameId !== _currentGameId) {
+      _currentGameId = newGameId;
+      window._currentGameId = _currentGameId;
+      _isIRacing = (_currentGameId === 'iracing');
+      _isRally = isRallyGame() || _rallyModeEnabled;
+      applyGameMode();
+    }
+    // Game logo overlay
+    if (window.updateGameLogo) window.updateGameLogo(_currentGameId, _settings.showGameLogo !== false);
+
+    // Block non-iRacing games unless Discord connected (demo mode always allowed)
+    if (!_demo && !isGameAllowed()) {
+      // Show "Connect Discord to unlock" message
+      return;
+    }
+
+    // Expose rolling/formation start state for leaderboard sparklines
+    window._isRollingStart = (sessNum === 2 || sessNum === 3); // Warmup or ParadeLaps
+
+    // Idle detection: only idle when no session (sessNum === 0) or game not running
+    // Pre-race states (sessNum 1=GetInCar, 2=Warmup, 3=ParadeLaps) should stay active
+    const nowIdle = !_demo && (!gameRunning || sessNum === 0);
+    const idleLogo = document.getElementById('idleLogo');
+    if (nowIdle !== _isIdle) {
+      _isIdle = nowIdle;
+      if (nowIdle) {
+        document.body.classList.add('idle-state');
+        if (idleLogo) idleLogo.classList.add('idle-visible');
+      } else {
+        document.body.classList.remove('idle-state');
+        if (idleLogo) idleLogo.classList.remove('idle-visible');
+        // Session going active — reveal HUD from logo-only startup
+        if (typeof revealFromLogoOnly === 'function') revealFromLogoOnly();
+      }
+    }
+    // Skip rest of update in idle (except settings remain responsive)
+    if (_isIdle) { _pollActive = false; return; }
+
+    // ─── Gear / Speed / RPM ───
+    const gear = ds('DataCorePlugin.GameData.Gear', 'Demo.Gear') || 'N';
+    const rpm = +d('DataCorePlugin.GameData.Rpms', 'Demo.Rpm') || 0;
+    const maxRpm = +d('DataCorePlugin.GameData.CarSettings_MaxRPM', 'Demo.MaxRpm') || 1;
+    const speed = +d('DataCorePlugin.GameData.SpeedMph', 'Demo.SpeedMph') || 0;
+
+    const gearEl = document.getElementById('gearText');
+    const rpmEl = document.getElementById('rpmText');
+    const speedEl = document.getElementById('speedText');
+    if (gearEl) gearEl.textContent = gear;
+    if (rpmEl) rpmEl.textContent = rpm > 0 ? Math.round(rpm) : '0';
+    if (speedEl) speedEl.textContent = speed > 0 ? Math.round(speed) : '0';
+    // RPM ratio — server-computed (DS.RpmRatio), fallback to client math
+    const rpmRatio = +(p[dsPre + 'RpmRatio']) || (maxRpm > 0 ? Math.min(1, rpm / maxRpm) : 0);
+    updateTacho(rpmRatio);
+    // Redline flash on entire tacho block
+    const tachoBlock = document.querySelector('.tacho-block');
+    if (tachoBlock) {
+      if (rpmRatio >= 0.91) tachoBlock.classList.add('tacho-redline');
+      else tachoBlock.classList.remove('tacho-redline');
+    }
+
+    // ─── Pedals — server-normalized (DS.ThrottleNorm etc.), fallback to client math ───
+    let thr = +(p[dsPre + 'ThrottleNorm']);
+    let brk = +(p[dsPre + 'BrakeNorm']);
+    let clt = +(p[dsPre + 'ClutchNorm']);
+    // Fallback: normalize client-side if server values not available
+    if (!(thr >= 0)) {
+      thr = +d('DataCorePlugin.GameData.Throttle', 'Demo.Throttle') || 0;
+      while (thr > 1.01) thr /= 100;
+      thr = Math.min(1, Math.max(0, thr));
+    }
+    if (!(brk >= 0)) {
+      brk = +d('DataCorePlugin.GameData.Brake', 'Demo.Brake') || 0;
+      while (brk > 1.01) brk /= 100;
+      brk = Math.min(1, Math.max(0, brk));
+    }
+    if (!(clt >= 0)) {
+      clt = +d('DataCorePlugin.GameData.Clutch', 'Demo.Clutch') || 0;
+      while (clt > 1.01) clt /= 100;
+      clt = Math.min(1, Math.max(0, clt));
+    }
+
+    // Auto-hide clutch for cars with autoclutch/DCT/no manual clutch pedal
+    if (clt > 0.03) _clutchSeenActive = true;
+    if (!_clutchSeenActive && _pollFrame > 60 && speed > 10) {
+      if (!_clutchHidden) {
+        _clutchHidden = true;
+        const cltLabel = document.getElementById('clutchLabelGroup');
+        const cltLayer = document.querySelector('.clutch-layer');
+        if (cltLabel) cltLabel.style.display = 'none';
+        if (cltLayer) cltLayer.style.display = 'none';
+      }
+    } else if (_clutchSeenActive && _clutchHidden) {
+      _clutchHidden = false;
+      const cltLabel = document.getElementById('clutchLabelGroup');
+      const cltLayer = document.querySelector('.clutch-layer');
+      if (cltLabel) cltLabel.style.display = '';
+      if (cltLayer) cltLayer.style.display = '';
+    }
+
+    // Push every sample — rAF gate in webgl-helpers coalesces to display rate
+    renderPedalTrace(thr, brk, _clutchHidden ? 0 : clt);
+
+    // ─── Pedal curve overlay (response curves from active profile) ───
+    if (window.updatePedalCurves) window.updatePedalCurves(p);
+
+    // ─── WebGL FX update ───
+    if (window.updateGLFX) window.updateGLFX(rpmRatio, thr, brk, clt);
+    // Post-processing pipeline — feed smoothed telemetry for screen effects
+    if (window.updatePostFX) window.updatePostFX({
+      speed: speed,
+      rpm: rpmRatio,
+      latG: +(p[dsPre + 'LatG']) || 0,
+      longG: +(p[dsPre + 'LongG']) || 0,
+      yawRate: +(p[dsPre + 'YawRate']) || 0,
+      steer: Math.max(-1, Math.min(1, +(p['DataCorePlugin.GameRawData.Telemetry.SteeringWheelAngle']) || 0))
+    });
+
+    // ─── Fuel — bar shows current fuel vs full tank capacity ───
+    const fuel = +d('DataCorePlugin.GameData.Fuel', 'Demo.Fuel') || 0;
+    const maxFuel = +d('DataCorePlugin.GameData.MaxFuel', 'Demo.MaxFuel') || 0;
+    // Bar percentage: current fuel / full tank capacity (not starting fuel)
+    const fuelPct = maxFuel > 0 ? (fuel / maxFuel) * 100 : 0;
+    const fuelRem = document.querySelector('.fuel-remaining');
+    // Respect DisplayUnits for fuel label (0=imperial/gal, 1=metric/L)
+    const _rawFuelUnits = p[dsPre + 'DisplayUnits'];
+    const _fuelImperial = _rawFuelUnits !== '' && _rawFuelUnits != null && parseInt(_rawFuelUnits) === 0;
+    const fuelDisplay = _fuelImperial ? fuel / 3.78541 : fuel;
+    const fuelUnitLabel = _fuelImperial ? 'gal' : 'L';
+    if (fuelRem) fuelRem.innerHTML = fuelDisplay > 0 ? fuelDisplay.toFixed(1) + ' <span class="unit">' + fuelUnitLabel + '</span>' : '— <span class="unit">' + fuelUnitLabel + '</span>';
+    updateFuelBar(fuelPct, 0);
+
+    const fuelPerLapRaw = _demo ? (+v('K10Motorsports.Plugin.Demo.FuelPerLap') || 0) : (+v('DataCorePlugin.Computed.Fuel_LitersPerLap') || 0);
+    const fuelPerLap = _fuelImperial ? fuelPerLapRaw / 3.78541 : fuelPerLapRaw;
+    const fuelLapsEst = +(p[dsPre + 'FuelLapsRemaining']) || (fuelPerLapRaw > 0 ? fuel / fuelPerLapRaw : 0);
+    const completedLaps = +(p[dsPre + 'CompletedLaps']) || 0;
+    const fuelVals = document.querySelectorAll('.fuel-stats .val');
+    if (fuelVals.length >= 2) {
+      // Show "calculating..." during lap 1 when fuelPerLap hasn't stabilized yet
+      if (fuelPerLap > 0) {
+        fuelVals[0].textContent = fuelPerLap.toFixed(2);
+      } else if (completedLaps < 2 && fuel > 0) {
+        fuelVals[0].textContent = 'calc...';
+      } else {
+        fuelVals[0].textContent = '—';
+      }
+      // Fix #10: Show "—" instead of "0" when fuelPerLap is 0 (no data yet)
+      fuelVals[1].textContent = fuelLapsEst > 0.1 ? fuelLapsEst.toFixed(1) : '—';
+    }
+    const pitSug = document.querySelector('.fuel-pit-suggest');
+    if (pitSug) {
+      const remLaps = +d('DataCorePlugin.GameData.RemainingLaps', 'Demo.RemainingLaps') || 0;
+      pitSug.textContent = (fuelLapsEst > 0 && remLaps > 0 && fuelLapsEst < remLaps)
+        ? 'PIT in ~' + Math.ceil(fuelLapsEst) + ' laps' : '';
+    }
+
+    // ─── Tyres ───
+    // Backend sends wear as 0=new, 1=gone. Convert to remaining % for display
+    // (100 = full life, 0 = destroyed) so bar width + color thresholds are correct.
+    if (_demo) {
+      updateTyreCell(0, +v('K10Motorsports.Plugin.Demo.TyreTempFL'), (1 - (+v('K10Motorsports.Plugin.Demo.TyreWearFL') || 0)) * 100);
+      updateTyreCell(1, +v('K10Motorsports.Plugin.Demo.TyreTempFR'), (1 - (+v('K10Motorsports.Plugin.Demo.TyreWearFR') || 0)) * 100);
+      updateTyreCell(2, +v('K10Motorsports.Plugin.Demo.TyreTempRL'), (1 - (+v('K10Motorsports.Plugin.Demo.TyreWearRL') || 0)) * 100);
+      updateTyreCell(3, +v('K10Motorsports.Plugin.Demo.TyreTempRR'), (1 - (+v('K10Motorsports.Plugin.Demo.TyreWearRR') || 0)) * 100);
+    } else {
+      updateTyreCell(0, +v('DataCorePlugin.GameData.TyreTempFrontLeft'), (p['DataCorePlugin.GameData.TyreWearFrontLeft'] != null ? (1 - +p['DataCorePlugin.GameData.TyreWearFrontLeft']) * 100 : -1));
+      updateTyreCell(1, +v('DataCorePlugin.GameData.TyreTempFrontRight'), (p['DataCorePlugin.GameData.TyreWearFrontRight'] != null ? (1 - +p['DataCorePlugin.GameData.TyreWearFrontRight']) * 100 : -1));
+      updateTyreCell(2, +v('DataCorePlugin.GameData.TyreTempRearLeft'), (p['DataCorePlugin.GameData.TyreWearRearLeft'] != null ? (1 - +p['DataCorePlugin.GameData.TyreWearRearLeft']) * 100 : -1));
+      updateTyreCell(3, +v('DataCorePlugin.GameData.TyreTempRearRight'), (p['DataCorePlugin.GameData.TyreWearRearRight'] != null ? (1 - +p['DataCorePlugin.GameData.TyreWearRearRight']) * 100 : -1));
+    }
+
+    // ─── Controls (BB / TC / ABS) ───
+    const bb = _demo ? +v('K10Motorsports.Plugin.Demo.BrakeBias') : (+v('DataCorePlugin.GameRawData.Telemetry.dcBrakeBias') || 0);
+    const tc = _demo ? +v('K10Motorsports.Plugin.Demo.TC') : p['DataCorePlugin.GameRawData.Telemetry.dcTractionControl'];
+    const abs = _demo ? +v('K10Motorsports.Plugin.Demo.ABS') : p['DataCorePlugin.GameRawData.Telemetry.dcABS'];
+    const absActive = +v(dsPre + 'AbsActive') || 0;
+    const tcActive  = +v(dsPre + 'TcActive')  || 0;
+    const carModel = ds('DataCorePlugin.GameData.CarModel', 'Demo.CarModel');
+    if (carModel !== _lastCarModel) {
+      _tcSeen = false; _absSeen = false;
+      _lastCarModel = carModel;
+      _carAdj = getCarAdjustability(carModel);
+      setCarLogo(detectMfr(carModel), carModel);
+      // Track car usage for driver profile heatmap
+      if (carModel && !_demo && typeof recordCarSession === 'function') recordCarSession(carModel);
+    }
+    if (_demo) { _tcSeen = true; _absSeen = true; }
+    else {
+      // Once we see any valid value (even 0), the car has this system
+      if (tc != null && +tc >= 0) _tcSeen = true;
+      if (abs != null && +abs >= 0) _absSeen = true;
+    }
+    // If car is in the no-adjust list, hide the module entirely for absent systems
+    // tcNoAdjust / absNoAdjust: electronic exists but isn't driver-adjustable → show "Fixed" + flash when active
+    // Adjustable car with value 0 → driver turned it off → show "Off"
+    const tcOk = _demo || (_carAdj && _carAdj.noTC ? false : (_tcSeen || (_carAdj && _carAdj.tcNoAdjust && tcActive > 0)));
+    const absOk = _demo || (_carAdj && _carAdj.noABS ? false : (_absSeen || (_carAdj && _carAdj.absNoAdjust && absActive > 0)));
+    const bbOk = _demo || (_carAdj && _carAdj.noBB ? false : (bb > 0));
+    setCtrlVisibility(bbOk, tcOk, absOk);
+
+    const bbEl = document.querySelector('#ctrlBB .ctrl-value');
+    if (bbEl && bbOk) { bbEl.textContent = bb > 0 ? bb.toFixed(1) : '—'; document.getElementById('ctrlBB').style.setProperty('--ctrl-pct', (bb > 0 ? Math.min(100, ((bb-30)/40)*100) : 0) + '%'); }
+    if (tcOk) {
+      const el = document.querySelector('#ctrlTC .ctrl-value');
+      const tcBox = document.getElementById('ctrlTC');
+      if (el) {
+        if (_carAdj && _carAdj.tcNoAdjust) {
+          // TC exists but not adjustable — show "Fixed", flash when active
+          el.textContent = 'Fixed';
+          el.classList.add('ctrl-value-fixed');
+          tcBox.style.setProperty('--ctrl-pct', tcActive > 0 ? '100%' : '0%');
+        } else if (+tc === 0) {
+          el.textContent = 'Off';
+          el.classList.remove('ctrl-value-fixed');
+          tcBox.style.setProperty('--ctrl-pct', '0%');
+        } else {
+          el.textContent = Math.round(+tc);
+          el.classList.remove('ctrl-value-fixed');
+          tcBox.style.setProperty('--ctrl-pct', Math.min(100, (+tc/12)*100) + '%');
+        }
+      }
+    }
+    if (absOk) {
+      const el = document.querySelector('#ctrlABS .ctrl-value');
+      const absBox = document.getElementById('ctrlABS');
+      if (el) {
+        if (_carAdj && _carAdj.absNoAdjust) {
+          // ABS exists but not adjustable — show "Fixed", flash when active
+          el.textContent = 'Fixed';
+          el.classList.add('ctrl-value-fixed');
+          absBox.style.setProperty('--ctrl-pct', absActive > 0 ? '100%' : '0%');
+        } else if (+abs === 0) {
+          el.textContent = 'Off';
+          el.classList.remove('ctrl-value-fixed');
+          absBox.style.setProperty('--ctrl-pct', '0%');
+        } else {
+          el.textContent = Math.round(+abs);
+          el.classList.remove('ctrl-value-fixed');
+          absBox.style.setProperty('--ctrl-pct', Math.min(100, (+abs/12)*100) + '%');
+        }
+      }
+    }
+    // TC / ABS active flash — runs on main dashboard, not gated behind datastream visibility
+    const tcBoxEl = document.getElementById('ctrlTC');
+    const absBoxEl = document.getElementById('ctrlABS');
+    if (tcActive > 0) _tcFlashFrames = 8;
+    if (absActive > 0) _absFlashFrames = 8;
+    if (tcBoxEl) { tcBoxEl.classList.toggle('ctrl-active', _tcFlashFrames > 0); if (_tcFlashFrames > 0) _tcFlashFrames--; }
+    if (absBoxEl) { absBoxEl.classList.toggle('ctrl-active', _absFlashFrames > 0); if (_absFlashFrames > 0) _absFlashFrames--; }
+
+    // Flash control bars on value change + announce via spotter
+    if (_prevBB >= 0 && bb > 0 && Math.abs(bb - _prevBB) > 0.05) {
+      flashCtrlBar('ctrlBB');
+      if (window.announceAdjustment) window.announceAdjustment('bb', bb, bb > _prevBB ? 1 : -1);
+    }
+    if (_prevTC >= 0 && +tc !== _prevTC) {
+      flashCtrlBar('ctrlTC');
+      if (window.announceAdjustment) window.announceAdjustment('tc', +tc, +tc > _prevTC ? 1 : -1);
+    }
+    if (_prevABS >= 0 && +abs !== _prevABS) {
+      flashCtrlBar('ctrlABS');
+      if (window.announceAdjustment) window.announceAdjustment('abs', +abs, +abs > _prevABS ? 1 : -1);
+    }
+    if (bb > 0) _prevBB = bb;
+    if (tcOk) _prevTC = +tc;
+    if (absOk) _prevABS = +abs;
+
+    // ─── Manufacturer country flag trigger ───
+    // Shows 5-second aurora wisps in manufacturer's country colors on:
+    //   Practice: leaving pit lane (entering the car)
+    //   Qualifying: first timed lap (completedLaps 0 → 1)
+    //   Race: green lights (Grid.SessionState transitions to 4)
+    if (window.showMfrFlag && _currentCarLogo && _currentCarLogo !== 'generic' && _currentCarLogo !== 'none') {
+      const sessType = (_demo ? (p['K10Motorsports.Plugin.Demo.SessionTypeName'] || '')
+                              : (p['K10Motorsports.Plugin.SessionTypeName'] || '')).toLowerCase();
+      const isPractice = sessType.includes('practice') || sessType.includes('test') || sessType.includes('warmup');
+      const isQuali = sessType.includes('qualify') || sessType.includes('qual');
+      const isRace = !isPractice && !isQuali && sessType.length > 0;
+
+      let shouldFire = false;
+
+      // Practice: pit → track transition
+      if (isPractice && _mfrFlagPrevInPit && !_inPitLane) {
+        shouldFire = true;
+      }
+      // Qualifying: first completed lap (outlap done, first timed lap begins)
+      if (isQuali && _mfrFlagPrevCompletedLaps === 0 && completedLaps === 1) {
+        shouldFire = true;
+      }
+      // Race: green lights — Grid.SessionState transitions from parade (3) to racing (4)
+      if (isRace && _mfrFlagPrevSessState === 3 && sessNum === 4) {
+        shouldFire = true;
+      }
+
+      // Reset flag when session changes (new practice/quali/race)
+      if (sessNum !== _mfrFlagPrevSessState && (sessNum === 1 || sessNum === 2 || sessNum === 3)) {
+        _mfrFlagShownThisSession = false;
+      }
+
+      if (shouldFire && !_mfrFlagShownThisSession) {
+        _mfrFlagShownThisSession = true;
+        const countryCode = _mfrCountry[_currentCarLogo];
+        if (countryCode && _countryFlags[countryCode]) {
+          const fc = _countryFlags[countryCode];
+          window.showMfrFlag(fc[0], fc[1], fc[2]);
+        }
+      }
+
+      _mfrFlagPrevSessState = sessNum;
+      _mfrFlagPrevInPit = _inPitLane;
+      _mfrFlagPrevCompletedLaps = completedLaps;
+    }
+
+    // ─── Position / Lap / Current Lap Time ───
+    // Snapshot previous position BEFORE it gets overwritten (used by grid viz)
+    const _vizSnapPrevPos = _lastPosition;
+    const pos = +d('DataCorePlugin.GameData.Position', 'Demo.Position') || 0;
+    const lap = +d('DataCorePlugin.GameData.CurrentLap', 'Demo.CurrentLap') || 0;
+    const bestLap = +d('DataCorePlugin.GameData.BestLapTime', 'Demo.BestLapTime') || 0;
+    // Parse CurrentLapTime robustly — SimHub may send this as a number
+    // (seconds), a TimeSpan string ("00:01:23.456"), or null. Fall back
+    // to iRacing raw telemetry LapCurrentLapTime if GameData fails.
+    const curLapTime = _demo
+      ? (+(p['K10Motorsports.Plugin.Demo.CurrentLapTime']) || 0)
+      : (_parseTimeValue(p['DataCorePlugin.GameData.CurrentLapTime'])
+         || +(p['DataCorePlugin.GameRawData.Telemetry.LapCurrentLapTime']) || 0);
+    document.querySelectorAll('.pos-number').forEach(el => {
+      const sp = el.querySelector('.skew-accent');
+      if (sp) sp.textContent = pos > 0 ? 'P' + pos : 'P—';
+    });
+    // Use server-computed LapDelta (cumulative sector delta at current track position)
+    const lapDelta = +(p[dsPre + 'LapDelta']) || 0;
+    document.querySelectorAll('.pos-meta-row .val').forEach(el => {
+      const row = el.closest('.pos-meta-row');
+      if (row.classList.contains('delta-row')) {
+        // Delta row: show cumulative lap delta vs best lap
+        if (curLapTime > 0.5 && bestLap > 0) {
+          el.textContent = (lapDelta >= 0 ? '+' : '') + lapDelta.toFixed(3);
+          el.classList.remove('delta-faster', 'delta-slower', 'delta-pb');
+          if (lapDelta <= -0.5) el.classList.add('delta-pb');
+          else if (lapDelta < 0) el.classList.add('delta-faster');
+          else if (lapDelta > 0) el.classList.add('delta-slower');
+        } else {
+          el.textContent = '';
+          el.classList.remove('delta-faster', 'delta-slower', 'delta-pb');
+        }
+      } else if (row.classList.contains('current-row')) {
+        // Current lap time (no delta appended — that's in the delta row now)
+        if (curLapTime > 0.5) {
+          el.textContent = fmtLap(curLapTime);
+          el.classList.remove('purple', 'green');
+          if (bestLap > 0 && lapDelta < 0) el.classList.add('green');
+        } else {
+          // Between laps: show best lap for reference
+          el.textContent = bestLap > 0 ? fmtLap(bestLap) : '—:——.———';
+          const sb = window._sessionBestLap || 0;
+          const isSessionBest = bestLap > 0 && sb > 0 && Math.abs(bestLap - sb) < 0.05;
+          el.classList.remove('purple', 'green');
+          if (bestLap > 0) el.classList.add(isSessionBest ? 'purple' : 'green');
+        }
+        row.style.textAlign = 'left';
+      }
+      else el.textContent = lap > 0 ? lap : '—';
+    });
+    if (pos !== _lastPosition && _lastPosition > 0 && pos > 0) {
+      document.querySelectorAll('.pos-number').forEach(el => flashElement(el, pos < _lastPosition ? 'ahead-changed' : 'behind-changed'));
+      // WebGL leaderboard event animation on position change
+      if (window.triggerLBEvent) {
+        if (pos === 1 && pos < _lastPosition) {
+          window.triggerLBEvent('p1');   // P1 gold celebration
+        } else {
+          window.triggerLBEvent(pos < _lastPosition ? 'gain' : 'lose');
+        }
+      }
+    }
+    // Start position — prefer server-computed, fallback to client-side
+    const serverStartPos = +(p[dsPre + 'StartPosition']) || 0;
+    if (serverStartPos > 0) _startPosition = serverStartPos;
+    else if (_startPosition === 0 && pos > 0) _startPosition = pos;
+    _lastPosition = pos;
+    // Position delta indicator — prefer server-computed DS.PositionDelta
+    document.querySelectorAll('.pos-delta').forEach(el => {
+      const delta = +(p[dsPre + 'PositionDelta']) || (_startPosition > 0 && pos > 0 ? _startPosition - pos : 0);
+      if (delta > 0) {
+        el.textContent = '▲ ' + delta;
+        el.className = 'pos-delta visible delta-up';
+      } else if (delta < 0) {
+        el.textContent = '▼ ' + Math.abs(delta);
+        el.className = 'pos-delta visible delta-down';
+      } else {
+        el.textContent = '';
+        el.className = 'pos-delta delta-same';
+      }
+    });
+    // Update player highlight: 0=blue(same), 1=green(ahead), 2=red(behind), 3=gold(P1)
+    if (window.setLBHighlightMode) {
+      if (pos === 1) {
+        window.setLBHighlightMode(3);
+      } else if (_startPosition > 0 && pos > 0) {
+        if (pos < _startPosition) window.setLBHighlightMode(1);      // ahead of start
+        else if (pos > _startPosition) window.setLBHighlightMode(2); // behind start
+        else window.setLBHighlightMode(0);                           // same as start
+      } else {
+        window.setLBHighlightMode(0);
+      }
+    }
+
+    // ─── Race Timer + Last Lap + End-of-Race Logic ───
+    const sessionTime = +d('DataCorePlugin.GameData.SessionTimeSpan', 'Demo.SessionTime') || 0;
+    const lastLapTime = +d('DataCorePlugin.GameData.LastLapTime', 'Demo.LastLapTime') || 0;
+    const remTime = +d('DataCorePlugin.GameData.RemainingTime', 'Demo.RemainingTime') || 0;
+    const totalLaps = +d('DataCorePlugin.GameData.TotalLaps', 'Demo.TotalLaps') || 0;
+    const remLaps = +d('DataCorePlugin.GameData.RemainingLaps', 'Demo.RemainingLaps') || 0;
+    const timerEl = document.getElementById('raceTimerValue');
+    const timerRow = document.querySelector('.timer-row');
+    // Determine if this is a lap-limited race (not timed)
+    const isLapRace = totalLaps > 0 && totalLaps <= 9999 && !(+(p[dsPre + 'IsTimedRace']) > 0);
+    if (timerEl) {
+      if (isLapRace && remLaps >= 0) {
+        // Lap-limited race: show remaining laps instead of time
+        if (remLaps === 1) timerEl.textContent = 'Final Lap';
+        else if (remLaps === 0) timerEl.textContent = 'Finish';
+        else timerEl.textContent = remLaps + (remLaps === 1 ? ' Lap' : ' Laps');
+      } else {
+        // Timed race: show remaining time
+        const serverFmt = p[dsPre + 'RemainingTimeFormatted'] || '';
+        if (serverFmt) {
+          timerEl.textContent = serverFmt;
+        } else {
+          const displayTime = remTime > 0 ? remTime : sessionTime;
+          if (displayTime > 0) {
+            const h = Math.floor(displayTime / 3600);
+            const m = Math.floor((displayTime % 3600) / 60);
+            const s = Math.floor(displayTime % 60);
+            timerEl.textContent = h + ':' + (m < 10 ? '0' : '') + m + ':' + (s < 10 ? '0' : '') + s;
+          } else {
+            timerEl.textContent = '0:00:00';
+          }
+        }
+      }
+    }
+    const lastLapEl = document.getElementById('lastLapTimeValue');
+    if (lastLapEl) { lastLapEl.textContent = fmtLap(lastLapTime); }
+
+    // Detect lap change → show timer block + force position page
+    if (lap > 0 && lap !== _prevLap && _prevLap > 0 && timerRow) {
+      timerRow.classList.add('timer-visible');
+      showPositionPage();
+      // Clear any pending hide
+      if (_timerHideTimeout) clearTimeout(_timerHideTimeout);
+      // Auto-hide after 30s unless pinned for end-of-race
+      if (!_timerPinned) {
+        _timerHideTimeout = setTimeout(() => {
+          if (!_timerPinned) timerRow.classList.remove('timer-visible');
+        }, 30000);
+      }
+    }
+    // ── Lap validity: detect incidents added during this lap ──
+    const _incCount = +(p[dsPre + 'IncidentCount']) || 0;
+    if (lap > 0 && lap !== _prevLap) {
+      _lapStartIncidents = _incCount;
+      _lapInvalid = false;
+    }
+    if (_incCount > _lapStartIncidents) _lapInvalid = true;
+
+    _prevLap = lap;
+
+    // End-of-race: pin timer visible for final 3 laps or final 5 minutes
+    const serverEndOfRace = +(p[dsPre + 'IsEndOfRace']) > 0;  // checkered flag
+    const isEndOfRace = serverEndOfRace || (isLapRace
+      ? (remLaps > 0 && remLaps <= 3)     // final 3 laps for lap races
+      : (remTime > 0 && remTime <= 300)); // final 5 minutes for timed races
+    if (isEndOfRace && timerRow) {
+      _timerPinned = true;
+      showPositionPage();
+      if (_timerHideTimeout) { clearTimeout(_timerHideTimeout); _timerHideTimeout = null; }
+      timerRow.classList.add('timer-visible');
+    } else if (_timerPinned && !isEndOfRace) {
+      _timerPinned = false; // race ended or data reset
+    }
+
+    // ─── iRating / Safety ───
+    // Priority: manual entry (always wins when set) → telemetry
+    let ir = window._manualIRating > 0 ? window._manualIRating
+      : (_demo ? (+v('K10Motorsports.Plugin.Demo.IRating') || 0) : (+v('IRacingExtraProperties.iRacing_DriverInfo_IRating') || 0));
+    let sr = window._manualSafetyRating > 0 ? window._manualSafetyRating
+      : (_demo ? (+v('K10Motorsports.Plugin.Demo.SafetyRating') || 0) : (+v('IRacingExtraProperties.iRacing_DriverInfo_SafetyRating') || 0));
+    _hasRatingData = (ir > 0 || sr > 0);
+    const ratVals = document.querySelectorAll('.rating-value');
+    if (ratVals.length >= 2) { ratVals[0].textContent = ir > 0 ? ir : '—'; ratVals[1].textContent = sr > 0 ? sr.toFixed(2) : '—'; }
+    updateIRBar(ir);
+    updateSRPie(sr);
+
+    // ─── Estimated iRating Delta ───
+    // Fix #3: Server sends int.MinValue (-2147483648) as sentinel for "no data".
+    // Distinguish that from an actual delta of 0 (perfectly average finish).
+    const irDeltaRaw = +(p[dsPre + 'EstimatedIRatingDelta']);
+    const IR_NO_DATA = -2147483648;
+    const irDeltaHasData = !isNaN(irDeltaRaw) && irDeltaRaw !== IR_NO_DATA;
+    const irDelta = irDeltaHasData ? irDeltaRaw : 0;
+    window._lastIRDelta = irDelta; // expose for driver profile modal
+    const ratDeltas = document.querySelectorAll('.rating-delta');
+    if (ratDeltas.length >= 1) {
+      const el = ratDeltas[0];
+      if (irDeltaHasData && ir > 0) {
+        el.textContent = (irDelta > 0 ? '+' : '') + irDelta;
+        el.className = 'rating-delta ' + (irDelta > 0 ? 'positive' : irDelta < 0 ? 'negative' : 'neutral');
+      } else {
+        el.textContent = '—';
+        el.className = 'rating-delta';
+      }
+    }
+    // SR delta: show manual license letter if set, otherwise derive from SR value
+    if (ratDeltas.length >= 2) {
+      const srEl = ratDeltas[1];
+      const lic = window._manualLicense || '';
+      if (lic) {
+        srEl.textContent = lic === 'R' ? 'R' : lic === 'P' ? 'Pro' : lic;
+        srEl.className = 'rating-delta';
+      } else if (sr > 0) {
+        srEl.textContent = sr >= 3.0 ? 'A' : sr >= 2.0 ? 'B' : sr >= 1.0 ? 'C' : 'D';
+        srEl.className = 'rating-delta';
+      } else {
+        srEl.textContent = '—';
+        srEl.className = 'rating-delta';
+      }
+    }
+
+    // ─── Gaps / Lap Timing ───
+    // Prefer server-computed DS.IsNonRaceSession, fallback to client-side string check
+    const nonRace = +(p[dsPre + 'IsNonRaceSession']) > 0 || _isNonRaceSession(
+      _demo ? (p['K10Motorsports.Plugin.Demo.SessionTypeName'] || '')
+            : (p['K10Motorsports.Plugin.SessionTypeName'] || ''));
+
+    const gapLabels = document.querySelectorAll('.gaps-block .panel-label');
+    const gapTimes = document.querySelectorAll('.gap-time');
+    const gapDrivers = document.querySelectorAll('.gap-driver');
+    const gapIRs = document.querySelectorAll('.gap-ir');
+    const gapItems = document.querySelectorAll('.gap-item');
+
+    if (nonRace) {
+      // ── Non-race: show F1-style sector indicator (data from plugin SectorTracker) ──
+      const sectorEl = document.getElementById('sectorIndicator');
+      const gapAhead = document.getElementById('gapAheadItem');
+      const gapBehind = document.getElementById('gapBehindItem');
+      if (sectorEl) sectorEl.style.display = '';
+      if (gapAhead) gapAhead.style.display = 'none';
+      if (gapBehind) gapBehind.style.display = 'none';
+
+      const curSector = +(p[dsPre + 'CurrentSector']) || 1;
+      const lapDelta = +(p[dsPre + 'LapDelta']) || 0;
+      const sectorCount = 3; // Always 3 sectors, equal thirds — matches CrewChief
+
+      // Build sector arrays from plugin data
+      const splits = [+(p[dsPre + 'SectorSplitS1']) || 0, +(p[dsPre + 'SectorSplitS2']) || 0, +(p[dsPre + 'SectorSplitS3']) || 0];
+      const deltas = [+(p[dsPre + 'SectorDeltaS1']) || 0, +(p[dsPre + 'SectorDeltaS2']) || 0, +(p[dsPre + 'SectorDeltaS3']) || 0];
+      const states = [+(p[dsPre + 'SectorStateS1']) || 0, +(p[dsPre + 'SectorStateS2']) || 0, +(p[dsPre + 'SectorStateS3']) || 0];
+      // state: 0=none, 1=pb (session best / purple), 2=faster (green), 3=slower (yellow)
+      const stateClass = ['', 'sector-pb', 'sector-faster', 'sector-slower'];
+
+      // Store for track map sector coloring + boundaries for path splitting
+      window._sectorData = { curSector, splits, deltas, states, sectorCount };
+      // Equal thirds boundaries for track map
+      window._sectorBoundaries = [1/3, 2/3];
+
+      // Read current lap time for live sector elapsed
+      const currentLapTime = _demo
+        ? (+(p['K10Motorsports.Plugin.Demo.CurrentLapTime']) || 0)
+        : (+(p['DataCorePlugin.GameData.CurrentLapTime']) || 0);
+
+      // ── Dynamic sector cell management ──
+      // Ensure sectorIndicator has the right number of cells
+      if (sectorEl) {
+        const existing = sectorEl.querySelectorAll('.sector-cell');
+        if (existing.length !== sectorCount) {
+          sectorEl.innerHTML = '';
+          for (let i = 1; i <= sectorCount; i++) {
+            const cell = document.createElement('div');
+            cell.className = 'sector-cell';
+            cell.id = 'sector' + i;
+            cell.innerHTML = '<div class="sector-label">S' + i + '</div>' +
+              '<div class="sector-time" id="sector' + i + 'Time">—</div>' +
+              '<div class="sector-delta" id="sector' + i + 'Delta"></div>';
+            sectorEl.appendChild(cell);
+          }
+        }
+      }
+
+      for (let si = 1; si <= sectorCount; si++) {
+        const cell = document.getElementById('sector' + si);
+        const timeEl = document.getElementById('sector' + si + 'Time');
+        const deltaEl = document.getElementById('sector' + si + 'Delta');
+        if (!cell || !timeEl) continue;
+
+        cell.classList.remove('sector-pb', 'sector-faster', 'sector-slower', 'sector-invalid', 'sector-active');
+
+        // If lap is invalid (incident occurred), mark all sectors red
+        if (_lapInvalid) {
+          cell.classList.add('sector-invalid');
+        }
+
+        if (si === curSector) {
+          // Active sector: show running sector elapsed time, delta below
+          cell.classList.add('sector-active');
+          // Calculate sector entry time from completed previous sectors
+          let entryTime = 0;
+          let hasPrevSplits = true;
+          for (let k = 0; k < si - 1; k++) {
+            if (!splits[k] || splits[k] <= 0) { hasPrevSplits = false; break; }
+            entryTime += splits[k];
+          }
+          // Only show sector elapsed if we have valid entry time data
+          // Otherwise show dash to avoid displaying the full lap time
+          if (hasPrevSplits && currentLapTime > entryTime) {
+            const elapsed = currentLapTime - entryTime;
+            const em = Math.floor(elapsed / 60);
+            const es = elapsed % 60;
+            timeEl.textContent = (em > 0 ? em + ':' : '') + (em > 0 && es < 10 ? '0' : '') + es.toFixed(1);
+          } else if (si === 1 && currentLapTime > 0 && currentLapTime < 120) {
+            // S1 is always valid since entry = lap start (time 0)
+            const em = Math.floor(currentLapTime / 60);
+            const es = currentLapTime % 60;
+            timeEl.textContent = (em > 0 ? em + ':' : '') + (em > 0 && es < 10 ? '0' : '') + es.toFixed(1);
+          } else {
+            timeEl.textContent = '—';
+          }
+          if (deltaEl) {
+            if (lapDelta !== 0) {
+              deltaEl.textContent = (lapDelta >= 0 ? '+' : '') + lapDelta.toFixed(2);
+              if (!_lapInvalid) cell.classList.add(lapDelta < 0 ? 'sector-faster' : 'sector-slower');
+            } else {
+              deltaEl.textContent = '';
+            }
+          }
+        } else if (splits[si - 1] > 0) {
+          // Completed sector: show sector time + delta to my best.
+          // Multi-layered sanity check: iRacing sometimes sends the
+          // cumulative lap time as the final sector split. We must
+          // never display a full lap time inside a sector cell.
+          const split = splits[si - 1];
+          let sumOtherSplits = 0;
+          let otherSplitCount = 0;
+          for (let k = 0; k < sectorCount; k++) {
+            if (k !== si - 1 && splits[k] > 0) {
+              sumOtherSplits += splits[k];
+              otherSplitCount++;
+            }
+          }
+          // Check 1: split >= sum of all other known sectors (original check)
+          const exceedsOthers = sumOtherSplits > 0 && split >= sumOtherSplits;
+          // Check 2: split >= 85% of best lap — no single sector should be
+          // that large relative to the full lap
+          const exceedsBestLap = bestLap > 0 && split >= bestLap * 0.85;
+          // Check 3: last sector with no other splits populated yet —
+          // this is the classic case where iRacing sends cumulative time
+          // before the earlier sectors are filled in.
+          // BUT: in qualifying, iRacing clears previous sectors on lap cross
+          // right as the final split arrives. Use _prevSectorSplits to avoid
+          // false positives — if the previous poll had other sectors filled,
+          // this is a real split, not a cumulative time.
+          let prevOtherCount = 0;
+          for (let k = 0; k < _prevSectorSplits.length; k++) {
+            if (k !== si - 1 && _prevSectorSplits[k] > 0) prevOtherCount++;
+          }
+          const lastSectorNoContext = si === sectorCount && sectorCount >= 2
+            && otherSplitCount === 0 && prevOtherCount === 0;
+          const looksLikeFullLap = exceedsOthers || exceedsBestLap || lastSectorNoContext;
+          if (looksLikeFullLap) {
+            // Suppress — never show a full lap time inside a sector cell
+            timeEl.textContent = '—';
+            if (deltaEl) deltaEl.textContent = '';
+          } else {
+            const m = Math.floor(split / 60);
+            const s = (split % 60);
+            timeEl.textContent = (m > 0 ? m + ':' : '') + (m > 0 && s < 10 ? '0' : '') + s.toFixed(1);
+            if (!_lapInvalid && stateClass[states[si - 1]]) cell.classList.add(stateClass[states[si - 1]]);
+            if (deltaEl) {
+              const d = deltas[si - 1];
+              if (d !== 0) deltaEl.textContent = (d >= 0 ? '+' : '') + d.toFixed(2);
+              else if (states[si - 1] === 1) deltaEl.textContent = 'PB';
+              else deltaEl.textContent = '';
+            }
+          }
+        } else {
+          timeEl.textContent = '—';
+          if (deltaEl) deltaEl.textContent = '';
+        }
+      }
+
+      // Cache this poll's splits so next poll can distinguish a real final
+      // sector from a bogus cumulative time (iRacing clears splits on lap cross)
+      _prevSectorSplits = splits.slice();
+
+      _gapsNonRaceMode = true;
+    } else {
+      // ── Race: show ahead / behind gaps ──
+      if (_gapsNonRaceMode) {
+        // Restore gaps, hide sectors
+        if (gapLabels.length >= 2) { gapLabels[0].textContent = 'Ahead'; gapLabels[1].textContent = 'Behind'; }
+        const sectorEl = document.getElementById('sectorIndicator');
+        const gapAhead = document.getElementById('gapAheadItem');
+        const gapBehind = document.getElementById('gapBehindItem');
+        if (sectorEl) sectorEl.style.display = 'none';
+        if (gapAhead) gapAhead.style.display = '';
+        if (gapBehind) gapBehind.style.display = '';
+        // Clear sector map highlights (dynamic N-sector support)
+        window._sectorData = null;
+        const mapSectorEls = document.querySelectorAll('.map-sector');
+        mapSectorEls.forEach(el => el.setAttribute('stroke', 'transparent'));
+        _gapsNonRaceMode = false;
+        _gapsWorstLap = 0;
+        _gapsLastLap = 0;
+      }
+      const gAhead  = _demo ? (+v('K10Motorsports.Plugin.Demo.GapAhead') || 0)  : (+v('IRacingExtraProperties.iRacing_Opponent_Ahead_Gap') || 0);
+      const gBehind = _demo ? (+v('K10Motorsports.Plugin.Demo.GapBehind') || 0) : (+v('IRacingExtraProperties.iRacing_Opponent_Behind_Gap') || 0);
+      const dAhead  = _demo ? vs('K10Motorsports.Plugin.Demo.DriverAhead')  : vs('IRacingExtraProperties.iRacing_Opponent_Ahead_Name');
+      const dBehind = _demo ? vs('K10Motorsports.Plugin.Demo.DriverBehind') : vs('IRacingExtraProperties.iRacing_Opponent_Behind_Name');
+      const irA     = _demo ? (+v('K10Motorsports.Plugin.Demo.IRAhead') || 0)   : (+v('IRacingExtraProperties.iRacing_Opponent_Ahead_IRating') || 0);
+      const irB     = _demo ? (+v('K10Motorsports.Plugin.Demo.IRBehind') || 0)  : (+v('IRacingExtraProperties.iRacing_Opponent_Behind_IRating') || 0);
+      if (gapTimes.length >= 2) { gapTimes[0].textContent = (gAhead && Math.abs(gAhead) >= 0.05) ? fmtGap(-Math.abs(gAhead)) : '—'; gapTimes[1].textContent = (gBehind && Math.abs(gBehind) >= 0.05) ? fmtGap(Math.abs(gBehind)) : '—'; }
+      if (gapDrivers.length >= 2) { gapDrivers[0].textContent = dAhead || '—'; gapDrivers[1].textContent = dBehind || '—'; }
+      if (gapIRs.length >= 2) { gapIRs[0].textContent = irA > 0 ? irA + ' iR' : ''; gapIRs[1].textContent = irB > 0 ? irB + ' iR' : ''; }
+      if (gapItems.length >= 2) {
+        if (dAhead !== _lastDriverAhead && _lastDriverAhead) flashElement(gapItems[0], 'ahead-changed');
+        if (dBehind !== _lastDriverBehind && _lastDriverBehind) flashElement(gapItems[1], 'behind-changed');
+      }
+      _lastDriverAhead = dAhead; _lastDriverBehind = dBehind;
+    }
+
+    // ─── Flag Status → Gaps Block ───
+    const rawFlag = (_forceFlagState && _demo) ? _forceFlagState : (vs('currentFlagState') || 'none');
+    const flagState = (!rawFlag || rawFlag === '0' || rawFlag === 0) ? 'none' : rawFlag;
+    const gapsBlock = document.getElementById('gapsBlock');
+    if (gapsBlock) {
+      const flagLabels = { yellow: 'CAUTION', red: 'RED FLAG', blue: 'BLUE FLAG', white: 'LAST LAP', debris: 'DEBRIS', checkered: 'FINISH', black: 'BLACK FLAG', green: 'GREEN', meatball: 'MEATBALL', orange: 'LAPPED CAR' };
+      const flagContexts = { yellow: 'Full course caution — hold position', red: 'Session stopped — return to pits', blue: 'Faster car approaching — yield', white: 'Last lap — push to the line', debris: 'Debris on track — stay alert', checkered: 'Checkered flag — race complete', black: 'Penalty — report to pit lane', green: 'Green flag — racing resumes', meatball: 'Repair required — pit immediately', orange: 'Car ahead must yield — make the pass' };
+
+      // Minimum hold durations per flag type (ms) — prevents flicker from rapid state changes
+      const FLAG_HOLD_MS = { yellow: 8000, red: 10000, blue: 4000, white: 6000, debris: 5000, checkered: 10000, black: 8000, green: 5000, meatball: 10000, orange: 4000 };
+
+      let showFlag = flagState;
+      const now = Date.now();
+
+      // When a new flag appears, set minimum hold time
+      if (flagState !== 'none' && flagState !== _flagHoldState) {
+        _flagHoldState = flagState;
+        _flagHoldUntil = now + (FLAG_HOLD_MS[flagState] || 5000);
+      }
+
+      // Green flag: show briefly when transitioning from caution, then clear
+      if (flagState === 'green' && _lastFlagState !== 'green' && _lastFlagState !== 'none') {
+        if (_greenFlagTimeout) clearTimeout(_greenFlagTimeout);
+        _greenFlagTimeout = setTimeout(() => {
+          const gb = document.getElementById('gapsBlock');
+          if (gb) gb.className = gb.className.replace(/\bflag-\S+/g, '').trim() + ' panel gaps-block';
+          if (window.setFlagGLColors) window.setFlagGLColors(null);
+          _greenFlagTimeout = null;
+          _flagHoldState = 'none';
+        }, FLAG_HOLD_MS.green);
+      } else if (flagState === 'green' && !_greenFlagTimeout) {
+        showFlag = 'none'; // green with no active timer = steady state, don't show
+      } else if (flagState === 'none') {
+        // Flag cleared — but hold the overlay if minimum duration hasn't elapsed
+        if (now < _flagHoldUntil && _flagHoldState !== 'none') {
+          showFlag = _flagHoldState; // keep showing previous flag
+        } else {
+          if (_greenFlagTimeout) { clearTimeout(_greenFlagTimeout); _greenFlagTimeout = null; }
+          showFlag = 'none';
+          _flagHoldState = 'none';
+        }
+      }
+
+      // Remove all flag-* classes
+      gapsBlock.className = gapsBlock.className.replace(/\bflag-\S+/g, '').trim();
+      if (showFlag !== 'none') {
+        gapsBlock.classList.add('flag-active', 'flag-' + showFlag);
+        const lbl = flagLabels[showFlag] || showFlag.toUpperCase();
+        const ctx = flagContexts[showFlag] || '';
+        const fl1 = document.getElementById('flagLabel1');
+        const fc1 = document.getElementById('flagCtx1');
+        if (fl1) fl1.textContent = lbl;
+        if (fc1) fc1.textContent = ctx;
+        // Set WebGL flag icon colors
+        if (window.setFlagGLColors) window.setFlagGLColors(showFlag);
+      } else {
+        if (window.setFlagGLColors) window.setFlagGLColors(null);
+      }
+      // ── Race Control banner — only for critical events ──
+      // Minor flags (blue, white, green, debris) are handled by the flag module on the gaps block.
+      // Race Control only fires for session-altering events: red, black, yellow (full course), checkered.
+      const RC_FLAGS = { red: true, black: true, yellow: true, checkered: true, meatball: true };
+      if (flagState !== _lastFlagState) {
+        if (RC_FLAGS[flagState]) {
+          showRaceControl(flagState);
+        }
+        // Only hide RC banner when flag hold has also expired — don't yank it early
+        else if ((flagState === 'none' || !RC_FLAGS[flagState]) && now >= _flagHoldUntil) {
+          hideRaceControl();
+        }
+      }
+
+      // ── Leaderboard event animations for race start / finish ──
+      if (flagState !== _lastFlagState && window.triggerLBEvent) {
+        // Green flag transition from non-green = race start (or restart)
+        if (flagState === 'green' && _lastFlagState !== 'green' && _lastFlagState !== 'none') {
+          window.triggerLBEvent('green');
+        }
+        // Checkered flag = race finish
+        if (flagState === 'checkered' && _lastFlagState !== 'checkered') {
+          window.triggerLBEvent('finish');
+        }
+      }
+      _lastFlagState = flagState;
+      // Expose for ambient-light.js polled color source
+      window._currentFlagState = flagState;
+    }
+
+    // ─── Ambient light — feed screen color from C# plugin ───
+    {
+      const ambHas = +v('K10Motorsports.Plugin.DS.AmbientHasData') || 0;
+      if (ambHas && typeof window.updateAmbientFromPoll === 'function') {
+        const ambR = +v('K10Motorsports.Plugin.DS.AmbientR') || 0;
+        const ambG = +v('K10Motorsports.Plugin.DS.AmbientG') || 0;
+        const ambB = +v('K10Motorsports.Plugin.DS.AmbientB') || 0;
+        window.updateAmbientFromPoll(ambR, ambG, ambB);
+      }
+    }
+
+    // ─── Commentary ───
+    const cmVis = +v('K10Motorsports.Plugin.CommentaryVisible') || 0;
+    if (cmVis && !_commentaryWasVisible) {
+      const cmTopicId = vs('K10Motorsports.Plugin.CommentaryTopicId');
+      // In pit lane: only allow pit-related commentary through
+      const pitAllowedTopics = ['pit_entry', 'low_fuel', 'tyre_wear_high'];
+      const suppressInPit = _inPitLane && !pitAllowedTopics.includes(cmTopicId);
+      if (!suppressInPit) {
+        const hue = colorToHue(vs('K10Motorsports.Plugin.CommentarySentimentColor'));
+        const severity = +v('K10Motorsports.Plugin.CommentarySeverity') || 0;
+        const trackImg = vs('K10Motorsports.Plugin.CommentaryTrackImage') || '';
+        const carImg = vs('K10Motorsports.Plugin.CommentaryCarImage') || '';
+        const commentaryImg = trackImg || carImg;  // track image takes priority, car image as fallback
+        showCommentary(hue, vs('K10Motorsports.Plugin.CommentaryTopicTitle'), vs('K10Motorsports.Plugin.CommentaryText'), vs('K10Motorsports.Plugin.CommentaryCategory'), cmTopicId, severity, commentaryImg);
+      }
+    } else if (!cmVis && _commentaryWasVisible) {
+      hideCommentary();
+    }
+    _commentaryWasVisible = !!cmVis;
+
+    // ─── Strategy calls (displayed via commentary panel with amber hue) ───
+    var stVis = +v('K10Motorsports.Plugin.Strategy.Visible') || 0;
+    if (stVis && !_strategyWasVisible && !cmVis) {
+      // Show strategy call through the commentary panel with amber hue (45)
+      var stLabel = vs('K10Motorsports.Plugin.Strategy.Label') || 'STRATEGY';
+      var stText  = vs('K10Motorsports.Plugin.Strategy.Text') || '';
+      var stSev   = +v('K10Motorsports.Plugin.Strategy.Severity') || 1;
+      if (stText) {
+        showCommentary(45, stLabel, stText, 'strategy', 'strategy_call', stSev);
+      }
+    } else if (!stVis && _strategyWasVisible && !cmVis) {
+      hideCommentary();
+    }
+    _strategyWasVisible = !!stVis;
+
+    // ─── Commentary visualization data feed ───
+    if (cmVis && window.updateCommentaryVizData) {
+      window.updateCommentaryVizData({
+        brake: brk,
+        throttle: thr,
+        rpmRatio: rpmRatio,
+        speed: speed,
+        brakeBias: bb,
+        tc: +(tc || 0),
+        abs: +(abs || 0),
+        fuelPct: fuelPct,
+        lapDelta: +(v(dsPre + 'LapDelta') || 0),
+        gapAhead: _demo ? +(v('K10Motorsports.Plugin.Demo.GapAhead') || 0) : +(v('IRacingExtraProperties.iRacing_Opponent_Ahead_Gap') || 0),
+        latG: +(v(dsPre + 'LatG') || 0),
+        longG: +(v(dsPre + 'LongG') || 0),
+        steerTorque: +(v(dsPre + 'SteerTorque') || 0),
+        position: pos,
+        prevPosition: _vizSnapPrevPos || 0,
+        startPosition: _startPosition || 0,
+        totalCars: +(v(sessionPre + 'TotalCars')) || 0,
+        incidents: +(v(dsPre + 'IncidentCount') || 0),
+        incidentLimitPenalty: +(v(dsPre + 'IncidentLimitPenalty') || 0),
+        incidentLimitDQ: +(v(dsPre + 'IncidentLimitDQ') || 0),
+        lap: lap,
+        sessionTime: vs('DataCorePlugin.GameData.RemainingTime') || '',
+        trackTemp: +(v(dsPre + 'TrackTemp') || 0),
+        tyreTemps: _demo
+          ? [+v('K10Motorsports.Plugin.Demo.TyreTempFL'), +v('K10Motorsports.Plugin.Demo.TyreTempFR'), +v('K10Motorsports.Plugin.Demo.TyreTempRL'), +v('K10Motorsports.Plugin.Demo.TyreTempRR')]
+          : [+v('DataCorePlugin.GameData.TyreTempFrontLeft'), +v('DataCorePlugin.GameData.TyreTempFrontRight'), +v('DataCorePlugin.GameData.TyreTempRearLeft'), +v('DataCorePlugin.GameData.TyreTempRearRight')],
+        tyreWears: _demo
+          ? [(1 - (+v('K10Motorsports.Plugin.Demo.TyreWearFL') || 0)) * 100, (1 - (+v('K10Motorsports.Plugin.Demo.TyreWearFR') || 0)) * 100, (1 - (+v('K10Motorsports.Plugin.Demo.TyreWearRL') || 0)) * 100, (1 - (+v('K10Motorsports.Plugin.Demo.TyreWearRR') || 0)) * 100]
+          : [(p['DataCorePlugin.GameData.TyreWearFrontLeft'] != null ? (1 - +p['DataCorePlugin.GameData.TyreWearFrontLeft']) * 100 : 100), (p['DataCorePlugin.GameData.TyreWearFrontRight'] != null ? (1 - +p['DataCorePlugin.GameData.TyreWearFrontRight']) * 100 : 100), (p['DataCorePlugin.GameData.TyreWearRearLeft'] != null ? (1 - +p['DataCorePlugin.GameData.TyreWearRearLeft']) * 100 : 100), (p['DataCorePlugin.GameData.TyreWearRearRight'] != null ? (1 - +p['DataCorePlugin.GameData.TyreWearRearRight']) * 100 : 100)]
+      });
+    }
+
+    // ─── Driver display name (for leaderboard) ───
+    const dfn = vs('K10Motorsports.Plugin.DriverFirstName') || '';
+    const dln = vs('K10Motorsports.Plugin.DriverLastName') || '';
+    if (dfn || dln) {
+      _driverDisplayName = (dfn && dln) ? dfn.charAt(0) + '. ' + dln : (dfn || dln);
+    }
+    // Zoom map label: first initial + last name, fallback "Local"
+    const _zoomLbl = document.getElementById('zoomMapLabel');
+    if (_zoomLbl) {
+      _zoomLbl.textContent = (dfn && dln) ? dfn.charAt(0) + '. ' + dln : (dln || 'Local');
+    }
+
+    // ─── Track map ───
+    const mapReady = +v('K10Motorsports.Plugin.TrackMap.Ready') || 0;
+    const mapPath = mapReady ? (vs('K10Motorsports.Plugin.TrackMap.SvgPath') || '') : '';
+    const mapPX   = +v('K10Motorsports.Plugin.TrackMap.PlayerX') || 50;
+    const mapPY   = +v('K10Motorsports.Plugin.TrackMap.PlayerY') || 50;
+    const mapOpp  = vs('K10Motorsports.Plugin.TrackMap.Opponents') || '';
+    const mapHeading = +v('K10Motorsports.Plugin.TrackMap.PlayerHeading') || 0;
+    // Use plugin path if available; show no track when map isn't ready
+    updateTrackMap(mapPath, mapPX, mapPY, mapOpp, speed, mapHeading);
+    // Full map label: show track name instead of "Full"
+    const fullMapLbl = document.getElementById('fullMapLabel');
+    if (fullMapLbl) {
+      const trackName = vs('K10Motorsports.Plugin.TrackMap.TrackName')
+                     || vs('DataCorePlugin.GameData.TrackName')
+                     || '';
+      if (trackName && trackName !== fullMapLbl.textContent) fullMapLbl.textContent = trackName;
+    }
+
+    // ─── Datastream ───
+    try { updateDatastream(p, _demo); } catch(e) { console.error('[K10] Datastream error:', e); }
+
+    // ─── Pit Box ───
+    try { updatePitBox(p); } catch(e) { console.error('[K10] PitBox error:', e); }
+
+    // ─── Incidents ───
+    try { updateIncidents(p, _demo); } catch(e) { console.error('[K10] Incidents error:', e); }
+
+    // ─── Leaderboard ───
+    try { updateLeaderboard(p); } catch(e) { console.error('[K10] Leaderboard error:', e); }
+
+    // ─── Pit Limiter ───
+    try { updatePitLimiter(p, _demo); } catch(e) { console.error('[K10] Pit limiter error:', e); }
+
+    // ─── Race End Screen ───
+    try {
+      const isCheckered = flagState === 'checkered';
+      if (isCheckered && !_prevCheckered) {
+        showRaceEnd(p, _demo);
+      } else if (!isCheckered && _prevCheckered && _raceEndVisible) {
+        hideRaceEnd();
+      }
+      _prevCheckered = isCheckered;
+    } catch(e) { console.error('[K10] Race end error:', e); }
+
+    // ─── Grid / Formation ───
+    try { updateGrid(p, _demo); } catch(e) { console.error('[K10] Grid error:', e); }
+
+    // ─── Spotter (disabled in pit lane — no close racing alerts) ───
+    try { if (!_inPitLane) updateSpotter(p, _demo); } catch(e) { console.error('[K10] Spotter error:', e); }
+
+    // ─── Tire / Track Condition Mismatch ───
+    try { if (typeof checkTyreMismatch === 'function' && !_inPitLane) checkTyreMismatch(p, _demo); } catch(e) { console.error('[K10] Tire mismatch check error:', e); }
+
+    // ─── Race Timeline ───
+    try {
+      const rtIncidents = +(v('K10Motorsports.Plugin.DS.IncidentCount')) || 0;
+      const rtInPit = +(v('K10Motorsports.Plugin.DS.IsInPitLane')) > 0;
+      updateRaceTimeline(pos, lap, flagState, rtIncidents, rtInPit);
+    } catch(e) { console.error('[K10] Timeline error:', e); }
+
+    // ─── Cycling timer ───
+    // Suppress cycling while timer row is visible — keep position page showing
+    const _timerShowing = timerRow && timerRow.classList.contains('timer-visible');
+    // Asymmetric cycle: 60s on position page, 15s on rating page
+    const _posFrames = Math.round(60000 / POLL_MS);   // 60s
+    const _ratFrames = Math.round(15000 / POLL_MS);    // 15s
+    const _onRatingPage = window._isRatingPageActive ? window._isRatingPageActive() : false;
+    const _cycleTarget = _onRatingPage ? _ratFrames : _posFrames;
+    if (_cycleFrameCount >= _cycleTarget) { _cycleFrameCount = 0; if (!_timerShowing) cycleRatingPos(); }
+
+    // ─── FPS counter (game API framerate, not browser) ───
+    setApiFps(+v('DataCorePlugin.GameRawData.Telemetry.FrameRate') || 0);
+    updateFps();
+
+    // ─── Drive HUD ───
+    try { if (window.updateDriveHud) window.updateDriveHud(p, !!_demo); } catch(e) { console.error('[K10] Drive HUD error:', e); }
+
+    } catch (err) {
+      console.error('[K10 poll] Error in poll frame #' + _pollFrame + ':', err);
+    } finally {
+      _pollActive = false;
+    }
+  }
+
+  // ─── Start polling ───
+  // Always poll the plugin's HTTP API (port 8889) for telemetry data.
+  // This works in all contexts: SimHub DashTemplate overlay, standalone browser,
+  // OBS Browser Source, or any web view. The plugin's HTTP server serves all
+  // telemetry, demo, commentary, and track map data as a single JSON blob.
+  // Load external assets before starting the poll loop
+  Promise.all([loadCarLogos(), loadCountryFlags()]).then(() => {
+    console.log('[K10 Motorsports] Assets loaded, polling SimHub HTTP API at ' + SIMHUB_URL);
+
+    // Initialize logo cycling (before we connect, the logos will cycle to be visible)
+    _logoCycleTimer = setInterval(() => {
+      if (!_hasEverConnected) cycleCarLogo();
+    }, 3000);
+    setCarLogo(carLogoOrder[0], _demoModels[carLogoOrder[0]]);
+
+    // Settings and Discord state are loaded by connections.js on script load
+
+    // Start polling
+    const _pollIntervalId = setInterval(pollUpdate, POLL_MS);
+    window.addEventListener('beforeunload', function() {
+      clearInterval(_pollIntervalId);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════
+
+</script>
+
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Plugin sends `currentFlagState` as numeric `0` when no flag is active
- `vs()` returns the string `"0"` which is truthy in JS, so `|| 'none'` never triggers
- This activated the flag overlay with label "0", hiding the Ahead/Behind gaps panel on k10motorsports.racing
- Fix: normalize both `"0"` and `0` to `'none'` before flag processing

## Test plan
- [ ] Verify gaps panel shows Ahead/Behind data on k10motorsports.racing (no more "0")
- [ ] Verify real flags (yellow, red, blue, etc.) still display correctly in overlay
- [ ] Verify forced flag in demo mode still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)