### PR TITLE
Feature showcase with live isolated dashboard modules

### DIFF
--- a/scripts/build-web-demo.mjs
+++ b/scripts/build-web-demo.mjs
@@ -132,6 +132,18 @@ const SHIM = `
   var _pmData = null;
   var _pmAmbient = null;
 
+  // Module isolation map — CSS class for each named module
+  var _moduleMap = {
+    'tacho':    '.tacho-block',
+    'pedals':   '.controls-pedals-block',
+    'fuel':     '.fuel-tyres-col',
+    'maps':     '.maps-col',
+    'position': '.pos-gaps-col',
+    'logo':     '.logo-col',
+    'timer':    '.timer-row'
+  };
+  var _isolateStyle = null;
+
   window.addEventListener('message', function(e) {
     if (!e.data || !e.data.type) return;
     if (e.data.type === 'k10-telemetry') {
@@ -139,6 +151,25 @@ const SHIM = `
     }
     if (e.data.type === 'k10-ambient') {
       _pmAmbient = e.data;
+    }
+    if (e.data.type === 'k10-isolate') {
+      // Show only the specified module, hide everything else
+      if (_isolateStyle) _isolateStyle.remove();
+      var mod = e.data.module;
+      if (!mod || mod === 'all') return; // 'all' = restore full dashboard
+      var sel = _moduleMap[mod];
+      if (!sel) return;
+      // Build CSS: hide all columns, show only the target
+      var allCols = Object.values(_moduleMap).join(',\\n');
+      var css = allCols + ' { display: none !important; }\\n' +
+        sel + ' { display: flex !important; visibility: visible !important; opacity: 1 !important; }\\n' +
+        // Center the isolated module
+        '.main-area { justify-content: center !important; }\\n' +
+        // Hide timer row in isolation mode (unless explicitly shown)
+        '.timer-row { display: ' + (mod === 'timer' ? 'flex' : 'none') + ' !important; }';
+      _isolateStyle = document.createElement('style');
+      _isolateStyle.textContent = css;
+      document.head.appendChild(_isolateStyle);
     }
   });
 

--- a/web/public/_demo/dashboard-embed.html
+++ b/web/public/_demo/dashboard-embed.html
@@ -6639,6 +6639,18 @@ function _fmtLapTime(secs) {
   var _pmData = null;
   var _pmAmbient = null;
 
+  // Module isolation map — CSS class for each named module
+  var _moduleMap = {
+    'tacho':    '.tacho-block',
+    'pedals':   '.controls-pedals-block',
+    'fuel':     '.fuel-tyres-col',
+    'maps':     '.maps-col',
+    'position': '.pos-gaps-col',
+    'logo':     '.logo-col',
+    'timer':    '.timer-row'
+  };
+  var _isolateStyle = null;
+
   window.addEventListener('message', function(e) {
     if (!e.data || !e.data.type) return;
     if (e.data.type === 'k10-telemetry') {
@@ -6646,6 +6658,25 @@ function _fmtLapTime(secs) {
     }
     if (e.data.type === 'k10-ambient') {
       _pmAmbient = e.data;
+    }
+    if (e.data.type === 'k10-isolate') {
+      // Show only the specified module, hide everything else
+      if (_isolateStyle) _isolateStyle.remove();
+      var mod = e.data.module;
+      if (!mod || mod === 'all') return; // 'all' = restore full dashboard
+      var sel = _moduleMap[mod];
+      if (!sel) return;
+      // Build CSS: hide all columns, show only the target
+      var allCols = Object.values(_moduleMap).join(',\n');
+      var css = allCols + ' { display: none !important; }\n' +
+        sel + ' { display: flex !important; visibility: visible !important; opacity: 1 !important; }\n' +
+        // Center the isolated module
+        '.main-area { justify-content: center !important; }\n' +
+        // Hide timer row in isolation mode (unless explicitly shown)
+        '.timer-row { display: ' + (mod === 'timer' ? 'flex' : 'none') + ' !important; }';
+      _isolateStyle = document.createElement('style');
+      _isolateStyle.textContent = css;
+      document.head.appendChild(_isolateStyle);
     }
   });
 

--- a/web/src/app/marketing/page.tsx
+++ b/web/src/app/marketing/page.tsx
@@ -4,6 +4,7 @@ import { ChannelBanner } from '@/components/youtube/ChannelBanner'
 import { VideoGrid } from '@/components/youtube/VideoGrid'
 import { TelemetryStatus } from '@/components/telemetry/TelemetryStatus'
 import { DashboardEmbed } from '@/components/telemetry/DashboardEmbed'
+import { FeatureShowcase } from '@/components/telemetry/FeatureShowcase'
 
 export default async function HomePage() {
   // Fetch YouTube data at build time / ISR (revalidates every 30 min)
@@ -50,56 +51,8 @@ export default async function HomePage() {
       {/* Live dashboard demo — full bleed, no margins */}
       <DashboardEmbed />
 
-      {/* Features grid */}
-      <section id="features" className="px-6 py-20 max-w-6xl mx-auto w-full">
-        <h2 className="text-3xl font-black mb-10 text-center">What&apos;s Inside</h2>
-        <div className="grid md:grid-cols-3 gap-6">
-          {[
-            {
-              title: 'Live Telemetry HUD',
-              desc: 'Gear, speed, RPM with color-coded tachometer. Pedal traces. Fuel with pit window estimates. Four-corner tyre temps. BB/TC/ABS. Live lap timer with delta-to-best. All at 30fps.',
-              accent: 'var(--k10-red)',
-            },
-            {
-              title: 'Race Strategy Engine',
-              desc: 'Real-time tire lifecycle tracking with composite grip scoring, fuel burn analysis with pit window calculation, stint-aware evaluation, and severity-graded coaching calls.',
-              accent: 'var(--amber)',
-            },
-            {
-              title: 'AI Commentary',
-              desc: '33 telemetry-driven triggers with 240+ prompt combinations. Composable sentence fragments. Severity-based interruption with cooldowns. Contextual to your car and circuit.',
-              accent: 'var(--green)',
-            },
-            {
-              title: 'Track Map & Sectors',
-              desc: 'SVG minimap with heading-up rotation. Per-sector timing with native iRacing boundaries (up to 7+ sectors). Live delta, split times, PB tracking.',
-              accent: 'var(--blue)',
-            },
-            {
-              title: 'WebGL Visual Effects',
-              desc: 'Fragment shader post-processing: glare, bloom, light sweep, g-force vignette, RPM redline. Ambient light engine samples your screen and drives glass refraction effects.',
-              accent: 'var(--cyan)',
-            },
-            {
-              title: 'Smart Lighting & Drive Mode',
-              desc: 'HomeKit integration maps flags, proximity, and strategy calls to smart light colors. Fullscreen Drive HUD mode for focused racing without production elements.',
-              accent: 'var(--purple)',
-            },
-          ].map((f) => (
-            <div
-              key={f.title}
-              className="group p-6 rounded-xl bg-[var(--bg-surface)] border border-[var(--border-subtle)] hover:border-[var(--border)] transition"
-            >
-              <div
-                className="w-1 h-6 rounded-full mb-4"
-                style={{ background: f.accent }}
-              />
-              <h3 className="text-lg font-bold mb-2">{f.title}</h3>
-              <p className="text-base text-[var(--text-dim)] leading-relaxed">{f.desc}</p>
-            </div>
-          ))}
-        </div>
-      </section>
+      {/* Features — live dashboard modules, one at a time */}
+      <FeatureShowcase />
 
       {/* Installation */}
       <section id="install" className="px-6 py-20 max-w-4xl mx-auto w-full">

--- a/web/src/components/telemetry/FeatureShowcase.tsx
+++ b/web/src/components/telemetry/FeatureShowcase.tsx
@@ -1,0 +1,206 @@
+'use client'
+
+import { useEffect, useRef, useState, useCallback } from 'react'
+import { useTelemetry } from './TelemetryProvider'
+
+/**
+ * Features mapped to dashboard modules.
+ * `module` matches the key in the embed's _moduleMap (postMessage shim).
+ */
+const FEATURES = [
+  {
+    module: 'tacho',
+    title: 'Live Telemetry HUD',
+    desc: 'Gear, speed, RPM with color-coded tachometer. Redline flash at 91%+ RPM ratio. All rendered at display refresh rate.',
+    accent: 'var(--k10-red)',
+  },
+  {
+    module: 'pedals',
+    title: 'Driver Inputs',
+    desc: 'Layered throttle, brake, and clutch pedal traces with real-time percentage readout. BB/TC/ABS controls with adjustability detection per car.',
+    accent: 'var(--green)',
+  },
+  {
+    module: 'fuel',
+    title: 'Race Strategy',
+    desc: 'Fuel burn rate, estimated laps remaining, pit window suggestions. Four-corner tyre temps with wear bars and degradation tracking.',
+    accent: 'var(--amber)',
+  },
+  {
+    module: 'maps',
+    title: 'Track Map & Sectors',
+    desc: 'SVG minimap with heading-up rotation. Opponent dots with proximity glow. Per-sector timing with live delta and PB tracking.',
+    accent: 'var(--blue)',
+  },
+  {
+    module: 'position',
+    title: 'Race Position',
+    desc: 'Live position with delta-to-start. iRating and Safety Rating with sparkline charts. Ahead/behind gaps with driver names and iRating.',
+    accent: 'var(--cyan)',
+  },
+] as const
+
+const CYCLE_MS = 8000
+
+export function FeatureShowcase() {
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const { data, status } = useTelemetry()
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [isHovered, setIsHovered] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  // ── Cycle through features ──
+  useEffect(() => {
+    if (isHovered) return
+    timerRef.current = setInterval(() => {
+      setActiveIndex((i) => (i + 1) % FEATURES.length)
+    }, CYCLE_MS)
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current)
+    }
+  }, [isHovered])
+
+  // ── Send telemetry data to iframe ──
+  useEffect(() => {
+    const iframe = iframeRef.current
+    if (!iframe?.contentWindow || !data) return
+    iframe.contentWindow.postMessage(
+      { type: 'k10-telemetry', snapshot: data },
+      '*',
+    )
+  }, [data])
+
+  // ── Send isolate command when active feature changes ──
+  const sendIsolate = useCallback((module: string) => {
+    const iframe = iframeRef.current
+    if (!iframe?.contentWindow) return
+    iframe.contentWindow.postMessage(
+      { type: 'k10-isolate', module },
+      '*',
+    )
+  }, [])
+
+  useEffect(() => {
+    sendIsolate(FEATURES[activeIndex].module)
+  }, [activeIndex, sendIsolate])
+
+  // Also re-send isolate after iframe loads (it needs time to initialize)
+  const handleIframeLoad = useCallback(() => {
+    // Small delay to let the embed's JS initialize
+    setTimeout(() => {
+      sendIsolate(FEATURES[activeIndex].module)
+    }, 500)
+  }, [activeIndex, sendIsolate])
+
+  const selectFeature = (index: number) => {
+    setActiveIndex(index)
+    // Reset the cycle timer when manually selecting
+    if (timerRef.current) clearInterval(timerRef.current)
+    timerRef.current = setInterval(() => {
+      setActiveIndex((i) => (i + 1) % FEATURES.length)
+    }, CYCLE_MS)
+  }
+
+  const active = FEATURES[activeIndex]
+
+  return (
+    <section id="features" className="px-6 py-20 max-w-6xl mx-auto w-full">
+      <h2 className="text-3xl font-black mb-10 text-center">What&apos;s Inside</h2>
+
+      <div className="flex flex-col lg:flex-row gap-8 items-stretch">
+        {/* Left: live module preview */}
+        <div
+          className="relative flex-1 min-h-[300px] rounded-xl overflow-hidden border border-[var(--border-subtle)]"
+          style={{ background: '#0a0a14' }}
+        >
+          {status !== 'live' && (
+            <div className="absolute inset-0 flex items-center justify-center z-10">
+              <span className="text-sm text-[var(--text-dim)] animate-pulse">
+                Connecting to telemetry…
+              </span>
+            </div>
+          )}
+          <iframe
+            ref={iframeRef}
+            src="/_demo/dashboard-embed.html"
+            title="K10 Feature Preview"
+            className="border-0 block w-full h-full"
+            sandbox="allow-scripts allow-same-origin"
+            onLoad={handleIframeLoad}
+            style={{
+              background: '#0a0a14',
+              minHeight: '300px',
+              opacity: status === 'live' ? 1 : 0,
+              transition: 'opacity 0.5s ease',
+            }}
+          />
+        </div>
+
+        {/* Right: feature list */}
+        <div
+          className="flex flex-col gap-2 lg:w-[340px] flex-shrink-0"
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+        >
+          {FEATURES.map((f, i) => {
+            const isActive = i === activeIndex
+            return (
+              <button
+                key={f.module}
+                onClick={() => selectFeature(i)}
+                className={`
+                  text-left p-4 rounded-xl border transition-all duration-300 cursor-pointer
+                  ${isActive
+                    ? 'bg-[var(--bg-surface)] border-[var(--border)]'
+                    : 'bg-transparent border-transparent hover:bg-[var(--bg-surface)]/50 hover:border-[var(--border-subtle)]'
+                  }
+                `}
+              >
+                <div className="flex items-center gap-3 mb-1">
+                  <div
+                    className={`w-1 rounded-full transition-all duration-300 ${isActive ? 'h-5' : 'h-3'}`}
+                    style={{ background: isActive ? f.accent : 'var(--text-muted)' }}
+                  />
+                  <h3 className={`text-base font-bold transition-colors ${isActive ? 'text-[var(--text)]' : 'text-[var(--text-secondary)]'}`}>
+                    {f.title}
+                  </h3>
+                </div>
+                <div
+                  className="overflow-hidden transition-all duration-300"
+                  style={{
+                    maxHeight: isActive ? '120px' : '0px',
+                    opacity: isActive ? 1 : 0,
+                  }}
+                >
+                  <p className="text-sm text-[var(--text-dim)] leading-relaxed pl-4 pt-1">
+                    {f.desc}
+                  </p>
+                  {/* Progress bar */}
+                  {isActive && !isHovered && (
+                    <div className="mt-3 ml-4 h-[2px] rounded-full bg-[var(--border-subtle)] overflow-hidden">
+                      <div
+                        className="h-full rounded-full"
+                        style={{
+                          background: f.accent,
+                          animation: `feature-progress ${CYCLE_MS}ms linear`,
+                        }}
+                      />
+                    </div>
+                  )}
+                </div>
+              </button>
+            )
+          })}
+
+          {/* Inline keyframe for the progress bar */}
+          <style>{`
+            @keyframes feature-progress {
+              from { width: 0%; }
+              to { width: 100%; }
+            }
+          `}</style>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/web/src/components/telemetry/index.ts
+++ b/web/src/components/telemetry/index.ts
@@ -1,3 +1,4 @@
 export { TelemetryProvider, useTelemetry, useTelemetryValue } from './TelemetryProvider'
 export { TelemetryStatus } from './TelemetryStatus'
 export { DashboardEmbed } from './DashboardEmbed'
+export { FeatureShowcase } from './FeatureShowcase'


### PR DESCRIPTION
## Summary
- **Module isolation via postMessage**: embed shim now handles `k10-isolate` messages — hides all dashboard columns except the specified one, then centers it. Supports `tacho`, `pedals`, `fuel`, `maps`, `position`, `logo`, `timer`, or `all` (restore full dashboard).
- **FeatureShowcase component**: replaces the static 6-card features grid. Cycles through 5 features every 8 seconds, each showing its corresponding live dashboard module in an isolated iframe. Click to select, hover to pause auto-cycle. Progress bar shows time until next feature.
- **Module → Feature mapping**:
  - Live Telemetry HUD → tachometer (gear/speed/RPM)
  - Driver Inputs → pedals + controls (throttle/brake traces, BB/TC/ABS)
  - Race Strategy → fuel + tyres (fuel bar, tyre temps/wear)
  - Track Map → maps (full map + heading-up zoom)
  - Race Position → position column (iRating, SR, gaps)
- Full dashboard embed above the fold is unchanged.

## Test plan
- [ ] Verify each feature tab shows its isolated module
- [ ] Confirm auto-cycling advances every ~8s
- [ ] Hover pauses cycling; click selects immediately
- [ ] Mobile/narrow viewports stack vertically
- [ ] Full dashboard embed at top of page unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)