### PR TITLE
feat: K10 Pro Drive members area + OAuth2 plugin auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ dashboard-overlay/dist/
 
 # ── Claude / MCP config (may contain API tokens) ─────────────────
 .claude/
+.vercel
+.env*.local

--- a/dashboard-overlay/dashboard.html
+++ b/dashboard-overlay/dashboard.html
@@ -195,16 +195,14 @@
     <div class="maps-col">
       <div class="panel map-panel">
         <svg class="map-svg" id="fullMapSvg" viewBox="0 0 100 100">
+          <path class="map-track-outer" id="fullMapTrackOuter" d="" />
           <path class="map-track" id="fullMapTrack" d="" />
+          <path class="map-track-inner on-track" id="fullMapTrackInner" d="" />
           <path class="map-sector" id="mapSector1" d="" />
           <path class="map-sector" id="mapSector2" d="" />
           <path class="map-sector" id="mapSector3" d="" />
           <g id="fullMapSF" class="map-sf" style="display:none;">
-            <line x1="0" y1="-3.5" x2="0" y2="3.5" stroke="#fff" stroke-width="1.2" stroke-linecap="round"/>
-            <rect x="-5" y="-2.5" width="5" height="2.5" fill="#fff" opacity="0.9"/>
-            <rect x="0" y="-2.5" width="5" height="2.5" fill="#111" stroke="#fff" stroke-width="0.3"/>
-            <rect x="-5" y="0" width="5" height="2.5" fill="#111" stroke="#fff" stroke-width="0.3"/>
-            <rect x="0" y="0" width="5" height="2.5" fill="#fff" opacity="0.9"/>
+            <line x1="0" y1="-3.5" x2="0" y2="3.5" stroke="hsla(0,0%,100%,0.6)" stroke-width="1.5" stroke-linecap="round"/>
           </g>
           <g id="fullMapOpponents"></g>
           <circle class="map-player" id="fullMapPlayer" cx="50" cy="50" r="4" />
@@ -217,13 +215,11 @@
                driving direction always points up. Player dot is OUTSIDE
                this group so it stays upright and visually centered. -->
           <g id="zoomMapRotateGroup">
-            <path class="map-track" id="zoomMapTrack" d="" style="stroke-width:1.5;" />
+            <path class="map-track-outer" id="zoomMapTrackOuter" d="" />
+            <path class="map-track" id="zoomMapTrack" d="" />
+            <path class="map-track-inner on-track" id="zoomMapTrackInner" d="" />
             <g id="zoomMapSF" class="map-sf" style="display:none;">
-              <line x1="0" y1="-2" x2="0" y2="2" stroke="#fff" stroke-width="0.6" stroke-linecap="round"/>
-              <rect x="-2.5" y="-1.25" width="2.5" height="1.25" fill="#fff" opacity="0.9"/>
-              <rect x="0" y="-1.25" width="2.5" height="1.25" fill="#111" stroke="#fff" stroke-width="0.15"/>
-              <rect x="-2.5" y="0" width="2.5" height="1.25" fill="#111" stroke="#fff" stroke-width="0.15"/>
-              <rect x="0" y="0" width="2.5" height="1.25" fill="#fff" opacity="0.9"/>
+              <line x1="0" y1="-2" x2="0" y2="2" stroke="hsla(0,0%,100%,0.6)" stroke-width="0.8" stroke-linecap="round"/>
             </g>
             <g id="zoomMapOpponents"></g>
           </g>
@@ -807,9 +803,9 @@
         <div class="settings-sidebar-item active" data-tab="sections" onclick="switchSettingsTab(this)">Dashboard</div>
         <div class="settings-sidebar-item" data-tab="branding" onclick="switchSettingsTab(this)">Branding</div>
         <div class="settings-sidebar-item" data-tab="layout" onclick="switchSettingsTab(this)">Layout</div>
-        <div class="settings-sidebar-item" data-tab="commentary" onclick="switchSettingsTab(this)">Commentary</div>
+        <div class="settings-sidebar-item" data-tab="commentary" data-pro-tab="commentary" onclick="switchSettingsTab(this)">Commentary</div>
         <div class="settings-sidebar-item" data-tab="connections" onclick="switchSettingsTab(this)">Connections</div>
-        <div class="settings-sidebar-item disabled" data-tab="iracing" id="iracingTab" onclick="switchSettingsTab(this)">iRacing</div>
+        <div class="settings-sidebar-item disabled" data-tab="iracing" id="iracingTab" data-pro-tab="modules" onclick="switchSettingsTab(this)">iRacing</div>
         <div class="settings-sidebar-item" data-tab="pedals" onclick="switchSettingsTab(this)">Pedals</div>
         <div class="settings-sidebar-item" data-tab="keys" onclick="switchSettingsTab(this)">Keys</div>
         <div class="settings-sidebar-item" data-tab="system" onclick="switchSettingsTab(this)">System</div>
@@ -847,14 +843,14 @@
         <div class="settings-row"><span class="settings-label">Tyres</span><div class="settings-toggle on" data-section="tyres-block" data-key="showTyres" onclick="toggleSetting(this)"></div></div>
         <div class="settings-row"><span class="settings-label">Controls (BB/TC/ABS)</span><div class="settings-toggle on" data-section="car-controls" data-key="showControls" onclick="toggleSetting(this)"></div></div>
         <div class="settings-row"><span class="settings-label">Pedals</span><div class="settings-toggle on" data-section="pedals-area" data-key="showPedals" onclick="toggleSetting(this)"></div></div>
-        <div class="settings-row"><span class="settings-label">Commentary</span><div class="settings-toggle on" data-section="commentary-col" data-key="showCommentary" onclick="toggleSetting(this)"></div></div>
+        <div class="settings-row"><span class="settings-label">Commentary</span><div class="settings-toggle on" data-section="commentary-col" data-key="showCommentary" data-pro-feature="commentary" onclick="toggleSetting(this)"></div></div>
         </div>
       </div>
 
       <!-- Subtab: Leaderboard -->
       <div class="settings-subtab-page" data-subtab-page="leaderboard">
         <div class="settings-two-col">
-        <div class="settings-row"><span class="settings-label">Show</span><div class="settings-toggle on" data-section="leaderboardPanel" data-key="showLeaderboard" onclick="toggleSetting(this)"></div></div>
+        <div class="settings-row"><span class="settings-label">Show</span><div class="settings-toggle on" data-section="leaderboardPanel" data-key="showLeaderboard" data-pro-feature="leaderboard" onclick="toggleSetting(this)"></div></div>
         <div class="settings-row settings-sub"><span class="settings-label">Focus</span>
           <select class="settings-select" id="settingsLbFocus" onchange="updateLbFocus(this.value)">
             <option value="me">Focus on Me</option>
@@ -885,7 +881,7 @@
       <!-- Subtab: Datastream -->
       <div class="settings-subtab-page" data-subtab-page="datastream">
         <div class="settings-two-col">
-        <div class="settings-row"><span class="settings-label">Show</span><div class="settings-toggle on" data-section="datastreamPanel" data-key="showDatastream" onclick="toggleSetting(this)"></div></div>
+        <div class="settings-row"><span class="settings-label">Show</span><div class="settings-toggle on" data-section="datastreamPanel" data-key="showDatastream" data-pro-feature="datastream" onclick="toggleSetting(this)"></div></div>
         <div class="settings-row settings-sub"><span class="settings-label">G-Force</span><div class="settings-toggle on" data-key="dsShowGforce" onclick="toggleDsSetting(this)"></div></div>
         <div class="settings-row settings-sub"><span class="settings-label">Yaw Rate</span><div class="settings-toggle on" data-key="dsShowYaw" onclick="toggleDsSetting(this)"></div></div>
         <div class="settings-row settings-sub"><span class="settings-label">FFB / Steer</span><div class="settings-toggle on" data-key="dsShowFfb" onclick="toggleDsSetting(this)"></div></div>
@@ -898,8 +894,8 @@
       <!-- Subtab: Overlays -->
       <div class="settings-subtab-page" data-subtab-page="overlays">
         <div class="settings-two-col">
-        <div class="settings-row"><span class="settings-label">Incidents</span><div class="settings-toggle on" data-section="incidentsPanel" data-key="showIncidents" onclick="toggleSetting(this)"></div></div>
-        <div class="settings-row"><span class="settings-label">Spotter</span><div class="settings-toggle on" data-section="spotterPanel" data-key="showSpotter" onclick="toggleSetting(this)"></div></div>
+        <div class="settings-row"><span class="settings-label">Incidents</span><div class="settings-toggle on" data-section="incidentsPanel" data-key="showIncidents" data-pro-feature="incidents" onclick="toggleSetting(this)"></div></div>
+        <div class="settings-row"><span class="settings-label">Spotter</span><div class="settings-toggle on" data-section="spotterPanel" data-key="showSpotter" data-pro-feature="spotter" onclick="toggleSetting(this)"></div></div>
         <div class="settings-row"><span class="settings-label">Pit Limiter Animation</span><div class="settings-toggle on" data-key="showBonkers" id="bonkersToggle" onclick="toggleBonkers(this)"></div></div>
         </div>
       </div>
@@ -912,9 +908,9 @@
       <div class="settings-row"><span class="settings-label">K10 Logo</span><div class="settings-toggle on" data-section="k10LogoSquare" data-key="showK10Logo" onclick="toggleSetting(this)"></div></div>
       <div class="settings-row"><span class="settings-label">Car Manufacturer</span><div class="settings-toggle on" data-section="carLogoSquare" data-key="showCarLogo" onclick="toggleSetting(this)"></div></div>
       <div class="settings-row"><span class="settings-label">Game Logo</span><div class="settings-toggle on" data-key="showGameLogo" onclick="toggleGameLogo(this)"></div></div>
-      <div class="settings-row"><span class="settings-label">WebGL Effects</span><div class="settings-toggle on" data-key="showWebGL" onclick="toggleWebGL(this)"></div></div>
+      <div class="settings-row"><span class="settings-label">WebGL Effects</span><div class="settings-toggle on" data-key="showWebGL" data-pro-feature="webgl" onclick="toggleWebGL(this)"></div></div>
       <div class="settings-row"><span class="settings-label">Ambient Light</span>
-        <select class="settings-select" id="settingsAmbientMode" onchange="updateAmbientMode(this.value)">
+        <select class="settings-select" id="settingsAmbientMode" data-pro-feature="reflections" onchange="updateAmbientMode(this.value)">
           <option value="reflective">Reflective</option>
           <option value="matte">Matte</option>
           <option value="plastic">Plastic</option>
@@ -964,7 +960,7 @@
         <span class="settings-label">Rally Mode</span>
         <div class="settings-toggle disabled" id="layoutRallyToggle" data-key="rallyMode" onclick="toggleLayoutRally(this)"></div>
       </div>
-      <div class="settings-hint" id="layoutRallyHint">Connect Discord to enable</div>
+      <div class="settings-hint" id="layoutRallyHint">Connect K10 Pro to enable</div>
 
       </div><!-- /settings-two-col -->
     </div>
@@ -972,80 +968,73 @@
     <!-- ── Tab: Connections ── -->
     <div class="settings-tab-content" id="settingsTabConnections">
 
-      <!-- SimHub Connection Card -->
-      <div class="conn-card">
+      <!-- ═══ K10 Pro Drive Connection Card (primary) ═══ -->
+      <div class="conn-card conn-card-primary" id="k10ProCard">
         <div class="conn-card-header">
-          <div class="conn-card-icon simhub">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:hsl(210,60%,55%)"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8"/><path d="M12 17v4"/><path d="M7 8h2"/><path d="M15 8h2"/><path d="M7 12h10"/></svg>
+          <div class="conn-card-icon k10pro">
+            <img src="images/branding/logomark.png" alt="K10" style="width:20px;height:20px;object-fit:contain;" />
           </div>
           <div>
-            <div class="conn-card-title">SimHub Plugin</div>
-            <div class="conn-card-subtitle">K10 Motorsports telemetry server</div>
-          </div>
-        </div>
-        <div class="conn-card-status">
-          <div class="conn-dot orange" id="connSimhubDot"></div>
-          <div class="conn-status-text" id="connSimhubText">Connecting...</div>
-        </div>
-        <div class="conn-card-detail" id="connSimhubDetail">
-          URL: <span id="connSimhubUrl">http://localhost:8889/k10mediabroadcaster/</span>
-        </div>
-        <div class="conn-card-actions">
-          <input class="settings-input" id="settingsSimhubUrl" type="text" value="http://localhost:8889/k10mediabroadcaster/" onchange="updateSimhubUrl(this.value)" style="flex:1;"/>
-        </div>
-      </div>
-
-      <!-- Discord Connection Card -->
-      <div class="conn-card">
-        <div class="conn-card-header">
-          <div class="conn-card-icon discord">
-            <svg viewBox="0 0 24 24" fill="currentColor" style="color:#5865F2"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.947 2.418-2.157 2.418z"/></svg>
-          </div>
-          <div>
-            <div class="conn-card-title">Discord</div>
-            <div class="conn-card-subtitle">Connect to the K10 community server</div>
+            <div class="conn-card-title">K10 Pro Drive</div>
+            <div class="conn-card-subtitle">Connect to unlock all Pro features</div>
           </div>
         </div>
 
         <!-- Not connected state -->
-        <div id="discordNotConnected">
+        <div id="k10NotConnected">
           <div class="conn-card-status">
-            <div class="conn-dot red" id="connDiscordDot"></div>
-            <div class="conn-status-text" id="connDiscordText">Not connected</div>
+            <div class="conn-dot red" id="connK10Dot"></div>
+            <div class="conn-status-text" id="connK10Text">Not connected</div>
           </div>
           <div class="conn-card-detail">
-            Connect your Discord account to join the K10 Motorsports community and unlock future features for authenticated users.
+            Sign in with your K10 Pro Drive account to enable Commentary, Incidents, Spotter, Leaderboard, Datastream, WebGL effects, Reflections, and module customization.
           </div>
           <div class="conn-card-actions">
-            <button class="conn-btn discord-btn" id="discordConnectBtn" onclick="connectDiscord()">
-              <svg viewBox="0 0 24 24" fill="currentColor" style="width:12px;height:12px;vertical-align:-1px;margin-right:4px"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.947 2.418-2.157 2.418z"/></svg>
-              Connect Discord
+            <button class="conn-btn k10-btn" id="k10ConnectBtn" onclick="connectK10Pro()">
+              <img src="images/branding/logomark.png" alt="" style="width:12px;height:12px;vertical-align:-2px;margin-right:4px;filter:brightness(10);" />
+              Connect to K10 Pro Drive
             </button>
-            <button class="conn-btn invite-btn" onclick="openDiscordInvite()">Join Server</button>
           </div>
         </div>
 
         <!-- Connected state -->
-        <div id="discordConnected" style="display:none;">
+        <div id="k10Connected" style="display:none;">
           <div class="conn-card-status">
             <div class="conn-dot green"></div>
-            <div class="conn-status-text"><strong>Connected</strong></div>
+            <div class="conn-status-text"><strong>Connected</strong> — all Pro features enabled</div>
           </div>
           <div class="conn-user-info">
-            <div class="conn-user-avatar" id="discordAvatarWrap">
-              <img id="discordAvatar" src="" alt="" />
+            <div class="conn-user-avatar" id="k10AvatarWrap">
+              <img id="k10Avatar" src="" alt="" />
             </div>
             <div>
-              <div class="conn-user-name" id="discordDisplayName"></div>
-              <div class="conn-user-id" id="discordUserId"></div>
+              <div class="conn-user-name" id="k10DisplayName"></div>
+              <div class="conn-user-id" id="k10UserId"></div>
             </div>
           </div>
+          <div class="conn-pro-features" id="k10FeatureList"></div>
           <div class="conn-card-actions">
-            <button class="conn-btn invite-btn" onclick="openDiscordInvite()">Join Server</button>
-            <button class="conn-btn disconnect-btn" onclick="disconnectDiscord()">Disconnect</button>
+            <button class="conn-btn disconnect-btn" onclick="disconnectK10Pro()">Disconnect</button>
           </div>
         </div>
       </div>
+
+      <!-- Pro features info (shown when not connected) -->
+      <div class="conn-pro-info" id="k10ProInfo">
+        <div class="conn-pro-info-title">Pro Features</div>
+        <div class="conn-pro-info-text">Connect your K10 Pro Drive account to enable all premium features. Visit <strong>drive.k10motorsports.racing</strong> to create your account.</div>
+        <div class="conn-pro-feature-grid">
+          <div class="conn-pro-feature-item"><span class="conn-pro-feature-icon">🎙️</span> Commentary</div>
+          <div class="conn-pro-feature-item"><span class="conn-pro-feature-icon">⚠️</span> Incidents</div>
+          <div class="conn-pro-feature-item"><span class="conn-pro-feature-icon">👁️</span> Spotter</div>
+          <div class="conn-pro-feature-item"><span class="conn-pro-feature-icon">🏆</span> Leaderboard</div>
+          <div class="conn-pro-feature-item"><span class="conn-pro-feature-icon">📊</span> Datastream</div>
+          <div class="conn-pro-feature-item"><span class="conn-pro-feature-icon">✨</span> WebGL Effects</div>
+          <div class="conn-pro-feature-item"><span class="conn-pro-feature-icon">🔮</span> Reflections</div>
+          <div class="conn-pro-feature-item"><span class="conn-pro-feature-icon">⚙️</span> Module Config</div>
+        </div>
+      </div>
+
       <!-- Remote Dashboard (stream to iPad / any browser on LAN) -->
       <div id="remoteDashSection" style="display:none;">
         <div class="settings-group-label" style="margin-top:12px;">Remote Dashboard</div>
@@ -1080,6 +1069,56 @@
       <div class="settings-row" style="margin-top:12px;">
         <span class="settings-label">Rally Mode</span>
         <div class="settings-toggle" data-key="rallyMode" onclick="toggleLayoutRally(this)"></div>
+      </div>
+
+      <!-- ═══ SimHub Connection (secondary, less prominent) ═══ -->
+      <div class="settings-group-label" style="margin-top:16px;font-size:10px;color:hsla(0,0%,100%,0.3);">Telemetry Source</div>
+      <div class="conn-card conn-card-secondary">
+        <div class="conn-card-header" style="margin-bottom:6px;">
+          <div class="conn-card-icon simhub" style="width:24px;height:24px;">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:hsl(210,60%,55%);width:14px;height:14px;"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8"/><path d="M12 17v4"/><path d="M7 8h2"/><path d="M15 8h2"/><path d="M7 12h10"/></svg>
+          </div>
+          <div>
+            <div class="conn-card-title" style="font-size:11px;">SimHub Plugin</div>
+            <div class="conn-card-subtitle" style="font-size:9px;">Telemetry server</div>
+          </div>
+          <div style="margin-left:auto;display:flex;align-items:center;gap:6px;">
+            <div class="conn-dot orange" id="connSimhubDot" style="width:6px;height:6px;"></div>
+            <div class="conn-status-text" id="connSimhubText" style="font-size:10px;">Connecting...</div>
+          </div>
+        </div>
+        <div class="conn-card-actions" style="margin-top:4px;">
+          <input class="settings-input" id="settingsSimhubUrl" type="text" value="http://localhost:8889/k10mediabroadcaster/" onchange="updateSimhubUrl(this.value)" style="flex:1;font-size:10px;padding:4px 8px;"/>
+        </div>
+      </div>
+
+      <!-- Discord (secondary, community only) -->
+      <div class="conn-card conn-card-secondary" style="margin-top:6px;">
+        <div class="conn-card-header" style="margin-bottom:6px;">
+          <div class="conn-card-icon discord" style="width:24px;height:24px;">
+            <svg viewBox="0 0 24 24" fill="currentColor" style="color:#5865F2;width:14px;height:14px;"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.947 2.418-2.157 2.418z"/></svg>
+          </div>
+          <div>
+            <div class="conn-card-title" style="font-size:11px;">Discord</div>
+            <div class="conn-card-subtitle" style="font-size:9px;">Community server</div>
+          </div>
+          <div style="margin-left:auto;" id="discordStatusInline">
+            <!-- Not connected state (inline) -->
+            <div id="discordNotConnected">
+              <button class="conn-btn discord-btn" id="discordConnectBtn" onclick="connectDiscord()" style="font-size:10px;padding:4px 10px;">
+                Connect
+              </button>
+            </div>
+            <!-- Connected state (inline) -->
+            <div id="discordConnected" style="display:none;">
+              <div style="display:flex;align-items:center;gap:6px;">
+                <div class="conn-dot green" style="width:6px;height:6px;"></div>
+                <span class="conn-user-name" id="discordDisplayName" style="font-size:10px;"></span>
+                <button class="conn-btn disconnect-btn" onclick="disconnectDiscord()" style="font-size:9px;padding:2px 8px;">×</button>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
 
     </div>

--- a/dashboard-overlay/main.js
+++ b/dashboard-overlay/main.js
@@ -953,6 +953,223 @@ ipcMain.handle('get-discord-user', async () => {
   };
 });
 
+// ═══════════════════════════════════════════════════════════════
+// K10 PRO DRIVE OAUTH2 INTEGRATION
+// Opens the user's browser to the K10 website for authorization,
+// reuses the same localhost callback server (port 18492),
+// exchanges the auth code for a K10 access token.
+// ═══════════════════════════════════════════════════════════════
+
+const K10_API_BASE = process.env.K10_API_BASE || 'https://drive.k10motorsports.racing';
+
+function getK10Path() {
+  return path.join(app.getPath('userData'), 'k10-pro-user.json');
+}
+
+function loadK10User() {
+  try {
+    return JSON.parse(fs.readFileSync(getK10Path(), 'utf8'));
+  } catch (e) {
+    return null;
+  }
+}
+
+function saveK10User(data) {
+  fs.writeFileSync(getK10Path(), JSON.stringify(data, null, 2));
+}
+
+function clearK10User() {
+  try { fs.unlinkSync(getK10Path()); } catch (e) { /* ok */ }
+}
+
+async function httpsPostJson(url, body) {
+  return new Promise((resolve, reject) => {
+    const urlObj = new URL(url);
+    const postData = JSON.stringify(body);
+    const options = {
+      hostname: urlObj.hostname,
+      port: urlObj.port || 443,
+      path: urlObj.pathname,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(postData),
+      },
+    };
+    // Use http for localhost dev, https for production
+    const lib = urlObj.protocol === 'http:' ? http : https;
+    const req = lib.request(options, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => {
+        try { resolve(JSON.parse(data)); }
+        catch (e) { reject(new Error('Invalid JSON: ' + data.slice(0, 200))); }
+      });
+    });
+    req.on('error', reject);
+    req.setTimeout(15000, () => { req.destroy(); reject(new Error('Timeout')); });
+    req.write(postData);
+    req.end();
+  });
+}
+
+async function httpsGetWithAuth(url, token) {
+  return new Promise((resolve, reject) => {
+    const urlObj = new URL(url);
+    const lib = urlObj.protocol === 'http:' ? http : https;
+    const req = lib.get(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    }, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => {
+        try { resolve({ status: res.statusCode, data: JSON.parse(data) }); }
+        catch (e) { reject(new Error('Invalid JSON: ' + data.slice(0, 200))); }
+      });
+    });
+    req.on('error', reject);
+    req.setTimeout(15000, () => { req.destroy(); reject(new Error('Timeout')); });
+  });
+}
+
+ipcMain.handle('k10-connect', async () => {
+  try {
+    // Generate PKCE verifier + challenge
+    const codeVerifier = generateCodeVerifier();
+    const codeChallenge = generateCodeChallenge(codeVerifier);
+    const state = crypto.randomBytes(16).toString('hex');
+
+    // Start listening for the callback BEFORE opening the browser
+    const callbackPromise = startCallbackServer();
+
+    // Build the K10 Pro Drive authorization URL
+    const authUrl = `${K10_API_BASE}/api/plugin-auth/authorize?code_challenge=${codeChallenge}&code_challenge_method=S256&state=${state}&redirect_uri=${encodeURIComponent(DISCORD_REDIRECT_URI)}`;
+
+    // Temporarily lower z-level so the browser window is visible above the overlay
+    if (overlayWindow && !overlayWindow.isDestroyed()) {
+      overlayWindow.setAlwaysOnTop(false);
+    }
+
+    await shell.openExternal(authUrl);
+    console.log('[K10] K10 Pro OAuth2: opened browser for authorization');
+
+    // Wait for the callback
+    const result = await callbackPromise;
+
+    // Restore z-level
+    if (overlayWindow && !overlayWindow.isDestroyed()) {
+      overlayWindow.setAlwaysOnTop(true, 'screen-saver');
+    }
+
+    if (result.error) {
+      return { success: false, error: result.error };
+    }
+
+    // Exchange code for K10 access token
+    const tokenData = await httpsPostJson(`${K10_API_BASE}/api/plugin-auth/token`, {
+      grant_type: 'authorization_code',
+      code: result.code,
+      code_verifier: codeVerifier,
+    });
+
+    if (tokenData.error) {
+      return { success: false, error: tokenData.error };
+    }
+
+    // Verify token and get user profile + features
+    const verifyResult = await httpsGetWithAuth(`${K10_API_BASE}/api/plugin-auth/verify`, tokenData.access_token);
+    if (verifyResult.status !== 200 || !verifyResult.data.user) {
+      return { success: false, error: 'Token verification failed' };
+    }
+
+    const userData = {
+      ...verifyResult.data.user,
+      features: verifyResult.data.features || [],
+      accessToken: tokenData.access_token,
+      refreshToken: tokenData.refresh_token,
+      expiresAt: tokenData.expires_at,
+      connectedAt: new Date().toISOString(),
+    };
+
+    saveK10User(userData);
+    console.log(`[K10] K10 Pro connected: ${userData.discordDisplayName || userData.discordUsername} (${userData.discordId})`);
+
+    return {
+      success: true,
+      user: {
+        id: userData.id,
+        discordId: userData.discordId,
+        discordUsername: userData.discordUsername,
+        discordDisplayName: userData.discordDisplayName,
+        discordAvatar: userData.discordAvatar,
+        features: userData.features,
+      },
+    };
+  } catch (err) {
+    console.error('[K10] K10 Pro connect error:', err);
+    if (overlayWindow && !overlayWindow.isDestroyed() && !overlayWindow.isAlwaysOnTop()) {
+      overlayWindow.setAlwaysOnTop(true, 'screen-saver');
+    }
+    return { success: false, error: err.message };
+  }
+});
+
+ipcMain.handle('k10-disconnect', async () => {
+  clearK10User();
+  console.log('[K10] K10 Pro disconnected');
+  return { success: true };
+});
+
+ipcMain.handle('get-k10-user', async () => {
+  const user = loadK10User();
+  if (!user) return null;
+  // Return only safe fields (no tokens)
+  return {
+    id: user.id,
+    discordId: user.discordId,
+    discordUsername: user.discordUsername,
+    discordDisplayName: user.discordDisplayName,
+    discordAvatar: user.discordAvatar,
+    features: user.features || [],
+    connectedAt: user.connectedAt,
+  };
+});
+
+ipcMain.handle('verify-k10-token', async () => {
+  const user = loadK10User();
+  if (!user || !user.accessToken) return { valid: false };
+
+  try {
+    const result = await httpsGetWithAuth(`${K10_API_BASE}/api/plugin-auth/verify`, user.accessToken);
+    if (result.status === 200 && result.data.user) {
+      // Update stored features
+      user.features = result.data.features || [];
+      saveK10User(user);
+      return { valid: true, features: user.features };
+    }
+
+    // Try refresh
+    if (user.refreshToken) {
+      const refreshResult = await httpsPostJson(`${K10_API_BASE}/api/plugin-auth/token`, {
+        grant_type: 'refresh_token',
+        refresh_token: user.refreshToken,
+      });
+      if (refreshResult.access_token) {
+        user.accessToken = refreshResult.access_token;
+        user.refreshToken = refreshResult.refresh_token;
+        user.expiresAt = refreshResult.expires_at;
+        saveK10User(user);
+        return { valid: true, features: user.features };
+      }
+    }
+
+    return { valid: false };
+  } catch (err) {
+    console.warn('[K10] Token verification failed:', err.message);
+    return { valid: false };
+  }
+});
+
 // ── IPC: Remote Dashboard Server ──
 ipcMain.handle('get-remote-server-info', async () => {
   return remoteServer.getInfo();

--- a/dashboard-overlay/modules/js/config.js
+++ b/dashboard-overlay/modules/js/config.js
@@ -585,6 +585,11 @@ let _settings = Object.assign({}, _defaultSettings);
 // Discord state
 let _discordUser = null;
 
+// K10 Pro Drive state (set by connections.js on startup)
+// Declared here so game-detect.js and other early scripts can reference it
+let _k10User = null;
+let _k10Features = [];
+
 // Logo cycling
 let _currentCarLogoIdx = 0;
 let _currentCarLogo = '';

--- a/dashboard-overlay/modules/js/connections.js
+++ b/dashboard-overlay/modules/js/connections.js
@@ -1,27 +1,198 @@
 // Connections tab
 
   // ═══════════════════════════════════════════════════════════════
-  //  CONNECTIONS TAB — SimHub & Discord status
+  //  CONNECTIONS TAB — K10 Pro, SimHub, Discord
   // ═══════════════════════════════════════════════════════════════
 
   const DISCORD_GUILD_INVITE = 'https://discord.gg/k10mediabroadcaster';
   // _discordUser declared in config.js
   let _discordConnecting = false;
 
+  // K10 Pro Drive connection state (_k10User, _k10Features declared in config.js)
+  let _k10Connecting = false;
+
+  // Pro features — keys map to setting toggles and sidebar items
+  const PRO_FEATURE_KEYS = ['commentary','incidents','spotter','leaderboard','datastream','webgl','reflections','modules'];
+
+  function isProFeature(key) {
+    const map = {
+      'showCommentary': 'commentary',
+      'showIncidents': 'incidents',
+      'showSpotter': 'spotter',
+      'showLeaderboard': 'leaderboard',
+      'showDatastream': 'datastream',
+      'showWebGL': 'webgl',
+      'ambientMode': 'reflections',
+    };
+    return map[key] || null;
+  }
+
+  function isProEnabled(featureKey) {
+    return _k10User && _k10Features.includes(featureKey);
+  }
+
   function updateConnectionsTab() {
     updateSimhubConnectionCard();
     updateDiscordConnectionCard();
+    updateK10ConnectionCard();
+  }
+
+  // ── K10 Pro Drive connection card ──
+  function updateK10ConnectionCard() {
+    const notConn = document.getElementById('k10NotConnected');
+    const conn = document.getElementById('k10Connected');
+    const info = document.getElementById('k10ProInfo');
+    if (!notConn || !conn) return;
+
+    if (_k10User) {
+      notConn.style.display = 'none';
+      conn.style.display = '';
+      if (info) info.style.display = 'none';
+
+      const nameEl = document.getElementById('k10DisplayName');
+      const idEl = document.getElementById('k10UserId');
+      const avatarEl = document.getElementById('k10Avatar');
+      if (nameEl) nameEl.textContent = _k10User.discordDisplayName || _k10User.discordUsername || 'Connected';
+      if (idEl) idEl.textContent = _k10User.discordId || '';
+      if (avatarEl && _k10User.discordAvatar && _k10User.discordId) {
+        avatarEl.src = `https://cdn.discordapp.com/avatars/${_k10User.discordId}/${_k10User.discordAvatar}.png?size=64`;
+        avatarEl.alt = _k10User.discordDisplayName || '';
+      }
+
+      // Show feature list
+      const featureList = document.getElementById('k10FeatureList');
+      if (featureList) {
+        featureList.innerHTML = _k10Features.map(f =>
+          '<span class="conn-pro-feature-badge">' + f + '</span>'
+        ).join('');
+      }
+    } else {
+      notConn.style.display = '';
+      conn.style.display = 'none';
+      if (info) info.style.display = '';
+    }
+
+    // Update pro feature gating across all settings
+    updateProFeatureGating();
+
+    // Remote dashboard — visible when K10 connected (was Discord)
+    updateRemoteDashVisibility();
+
+    // iRacing tab — enabled when K10 connected (was Discord)
+    if (typeof updateIRacingTabState === 'function') updateIRacingTabState();
+  }
+
+  async function connectK10Pro() {
+    if (_k10Connecting) return;
+    if (!window.k10 || !window.k10.k10Connect) {
+      // Fallback: open website in browser
+      if (window.k10 && window.k10.openExternal) {
+        window.k10.openExternal('https://drive.k10motorsports.racing');
+      }
+      return;
+    }
+
+    _k10Connecting = true;
+    const btn = document.getElementById('k10ConnectBtn');
+    if (btn) { btn.disabled = true; btn.textContent = 'Connecting...'; }
+
+    try {
+      const result = await window.k10.k10Connect();
+      if (result && result.success && result.user) {
+        _k10User = result.user;
+        _k10Features = result.user.features || [];
+        _settings.k10User = result.user;
+        _settings.k10Features = result.user.features || [];
+        saveSettings();
+        updateK10ConnectionCard();
+      } else {
+        const errMsg = result?.error || 'Connection failed';
+        console.warn('[K10] Pro connect failed:', errMsg);
+        const text = document.getElementById('connK10Text');
+        if (text) text.innerHTML = '<strong style="color:hsl(0,75%,60%)">Failed</strong> — ' + errMsg;
+        setTimeout(() => {
+          if (text) text.innerHTML = 'Not connected';
+        }, 3000);
+      }
+    } catch (err) {
+      console.error('[K10] Pro connect error:', err);
+    } finally {
+      _k10Connecting = false;
+      if (btn) {
+        btn.disabled = false;
+        btn.innerHTML = '<img src="images/branding/logomark.png" alt="" style="width:12px;height:12px;vertical-align:-2px;margin-right:4px;filter:brightness(10);" /> Connect to K10 Pro Drive';
+      }
+    }
+  }
+
+  async function disconnectK10Pro() {
+    if (window.k10 && window.k10.k10Disconnect) {
+      await window.k10.k10Disconnect();
+    }
+    _k10User = null;
+    _k10Features = [];
+    delete _settings.k10User;
+    delete _settings.k10Features;
+    saveSettings();
+    updateK10ConnectionCard();
+  }
+
+  // ── Pro Feature Gating ──
+  // Add disabled state + K10 badge to toggles that require Pro
+  function updateProFeatureGating() {
+    const isPro = !!_k10User;
+
+    // Toggle elements with pro gating
+    document.querySelectorAll('[data-pro-feature]').forEach(el => {
+      const featureKey = el.dataset.proFeature;
+      const enabled = isPro && _k10Features.includes(featureKey);
+
+      if (enabled) {
+        el.classList.remove('pro-locked');
+        // Remove pro badge if present
+        const badge = el.parentElement?.querySelector('.pro-badge');
+        if (badge) badge.style.display = 'none';
+      } else {
+        el.classList.add('pro-locked');
+        // Show pro badge
+        let badge = el.parentElement?.querySelector('.pro-badge');
+        if (!badge && el.parentElement) {
+          badge = document.createElement('span');
+          badge.className = 'pro-badge';
+          badge.innerHTML = '<img src="images/branding/logomark.png" alt="Pro" />';
+          badge.title = 'K10 Pro feature — connect to enable';
+          badge.onclick = function(e) { e.stopPropagation(); navigateToConnections(); };
+          el.parentElement.appendChild(badge);
+        }
+        if (badge) badge.style.display = '';
+      }
+    });
+
+    // Sidebar items gating
+    document.querySelectorAll('[data-pro-tab]').forEach(tab => {
+      const featureKey = tab.dataset.proTab;
+      const enabled = isPro && _k10Features.includes(featureKey);
+      tab.classList.toggle('disabled', !enabled);
+      tab.title = enabled ? '' : 'K10 Pro feature — connect to enable';
+    });
+
+    // Update layout rally toggle (now based on K10 Pro, not Discord)
+    updateLayoutRallyToggle();
+    syncRallyToggles();
+  }
+
+  function navigateToConnections() {
+    const tab = document.querySelector('.settings-sidebar-item[data-tab="connections"]');
+    if (tab) switchSettingsTab(tab);
   }
 
   // ── SimHub connection card ──
   function updateSimhubConnectionCard() {
     const dot = document.getElementById('connSimhubDot');
     const text = document.getElementById('connSimhubText');
-    const urlEl = document.getElementById('connSimhubUrl');
     const urlInput = document.getElementById('settingsSimhubUrl');
     const currentUrl = window._simhubUrlOverride || SIMHUB_URL;
 
-    if (urlEl) urlEl.textContent = currentUrl;
     if (urlInput) urlInput.value = currentUrl;
 
     // Derive state from the existing connection status
@@ -33,8 +204,8 @@
       dot.className = 'conn-dot ' + (state === 'connected' ? 'green' : state === 'disconnected' ? 'red' : 'orange');
     }
     if (text) {
-      if (state === 'connected') text.innerHTML = '<strong>Connected</strong> — receiving telemetry';
-      else if (state === 'disconnected') text.innerHTML = '<strong>Disconnected</strong> — check SimHub is running';
+      if (state === 'connected') text.innerHTML = '<strong>Connected</strong>';
+      else if (state === 'disconnected') text.innerHTML = '<strong>Disconnected</strong>';
       else text.innerHTML = 'Connecting...';
     }
   }
@@ -49,32 +220,15 @@
       notConn.style.display = 'none';
       conn.style.display = '';
       const nameEl = document.getElementById('discordDisplayName');
-      const idEl = document.getElementById('discordUserId');
-      const avatarEl = document.getElementById('discordAvatar');
       if (nameEl) nameEl.textContent = _discordUser.globalName || _discordUser.username;
-      if (idEl) idEl.textContent = _discordUser.id;
-      if (avatarEl && _discordUser.avatar) {
-        avatarEl.src = `https://cdn.discordapp.com/avatars/${_discordUser.id}/${_discordUser.avatar}.png?size=64`;
-        avatarEl.alt = _discordUser.globalName || _discordUser.username;
-      }
     } else {
       notConn.style.display = '';
       conn.style.display = 'none';
     }
 
-    // Show game features card when Discord is connected
+    // Show game features card when Discord is connected (legacy)
     const gameCard = document.getElementById('gameFeatureCard');
     if (gameCard) gameCard.style.display = _discordUser ? '' : 'none';
-
-    // Update layout section rally toggle
-    updateLayoutRallyToggle();
-    syncRallyToggles();
-
-    // Remote dashboard — visible when Discord connected
-    updateRemoteDashVisibility();
-
-    // iRacing tab — enabled when Discord connected
-    if (typeof updateIRacingTabState === 'function') updateIRacingTabState();
   }
 
   async function connectDiscord() {
@@ -99,18 +253,12 @@
       } else {
         const errMsg = result?.error || 'Connection failed';
         console.warn('[K10] Discord connect failed:', errMsg);
-        const text = document.getElementById('connDiscordText');
-        if (text) text.innerHTML = '<strong style="color:hsl(0,75%,60%)">Failed</strong> — ' + errMsg;
-        // Reset after 3s
-        setTimeout(() => {
-          if (text) text.innerHTML = 'Not connected';
-        }, 3000);
       }
     } catch (err) {
       console.error('[K10] Discord connect error:', err);
     } finally {
       _discordConnecting = false;
-      if (btn) { btn.disabled = false; btn.innerHTML = '<svg viewBox="0 0 24 24" fill="currentColor" style="width:12px;height:12px;vertical-align:-1px;margin-right:4px"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.947 2.418-2.157 2.418z"/></svg> Connect Discord'; }
+      if (btn) { btn.disabled = false; btn.textContent = 'Connect'; }
     }
   }
 
@@ -145,7 +293,7 @@
   }
 
   function toggleLayoutRally(el) {
-    // Ignore clicks when disabled (no Discord connection)
+    // Ignore clicks when disabled (no K10 Pro connection)
     if (el.classList.contains('disabled')) return;
     const isOn = el.classList.contains('on');
     el.classList.toggle('on', !isOn);
@@ -166,19 +314,19 @@
     if (connToggle) connToggle.classList.toggle('on', _rallyModeEnabled);
   }
 
-  /** Enable/disable the layout rally toggle based on Discord state */
+  /** Enable/disable the layout rally toggle based on K10 Pro state */
   function updateLayoutRallyToggle() {
     const el = document.getElementById('layoutRallyToggle');
     const hint = document.getElementById('layoutRallyHint');
     if (!el) return;
-    if (_discordUser) {
+    if (_k10User) {
       el.classList.remove('disabled');
       if (hint) hint.style.display = 'none';
     } else {
       el.classList.add('disabled');
       el.classList.remove('on');
       if (hint) hint.style.display = '';
-      // Force rally off when Discord disconnects
+      // Force rally off when disconnected
       _rallyModeEnabled = false;
       _settings.rallyMode = false;
       _isRally = isRallyGame();
@@ -220,7 +368,7 @@
     const section = document.getElementById('remoteDashSection');
     if (!section) return;
     if (window._k10RemoteMode) { section.style.display = 'none'; return; }
-    section.style.display = _discordUser ? '' : 'none';
+    section.style.display = _k10User ? '' : 'none';
   }
 
   async function initRemoteDashState() {
@@ -263,7 +411,52 @@
     }
   }
 
+  // Load K10 Pro user on startup
+  async function initK10State() {
+    // Try loading from Electron's persisted file first
+    if (window.k10 && window.k10.getK10User) {
+      try {
+        const user = await window.k10.getK10User();
+        if (user && user.id) {
+          _k10User = user;
+          _k10Features = user.features || [];
+          updateK10ConnectionCard();
+
+          // Verify token in background
+          if (window.k10.verifyK10Token) {
+            window.k10.verifyK10Token().then(result => {
+              if (result && !result.valid) {
+                console.warn('[K10] Pro token invalid — clearing session');
+                _k10User = null;
+                _k10Features = [];
+                delete _settings.k10User;
+                delete _settings.k10Features;
+                saveSettings();
+                updateK10ConnectionCard();
+              } else if (result && result.features) {
+                _k10Features = result.features;
+                updateK10ConnectionCard();
+              }
+            }).catch(() => {});
+          }
+          return;
+        }
+      } catch (e) { /* ok */ }
+    }
+    // Fallback: check settings
+    if (_settings.k10User && _settings.k10User.id) {
+      _k10User = _settings.k10User;
+      _k10Features = _settings.k10Features || [];
+      updateK10ConnectionCard();
+    }
+  }
+
   function toggleSetting(el) {
+    // Check if this is a pro-locked toggle
+    if (el.classList.contains('pro-locked')) {
+      navigateToConnections();
+      return;
+    }
     const key = el.dataset.key;
     const isOn = el.classList.contains('on');
     _settings[key] = !isOn;
@@ -281,6 +474,11 @@
   }
 
   function toggleWebGL(el) {
+    // Check if this is a pro-locked toggle
+    if (el.classList.contains('pro-locked')) {
+      navigateToConnections();
+      return;
+    }
     const isOn = el.classList.contains('on');
     const newVal = !isOn;
     el.classList.toggle('on', newVal);
@@ -603,6 +801,7 @@
   // Load settings on startup
   loadSettings();
   initDiscordState();
+  initK10State();
   initRemoteDashState();
 
   // ═══════════════════════════════════════════════════════════════

--- a/dashboard-overlay/modules/js/game-detect.js
+++ b/dashboard-overlay/modules/js/game-detect.js
@@ -31,10 +31,10 @@
     return GAME_FEATURES[_currentGameId] || GAME_FEATURES.iracing;
   }
 
-  // Returns true if the current game is allowed (iRacing always allowed; others require Discord)
+  // Returns true if the current game is allowed (iRacing always allowed; others require K10 Pro)
   function isGameAllowed() {
     if (_currentGameId === 'iracing') return true;
-    return !!_discordUser;
+    return !!_k10User;
   }
 
   function isRallyGame() {

--- a/dashboard-overlay/modules/js/rating-editor.js
+++ b/dashboard-overlay/modules/js/rating-editor.js
@@ -68,13 +68,13 @@
     if (licSelect) licSelect.value = _manualLicense || 'R';
   }
 
-  // ── Enable/disable iRacing tab based on Discord connection ──
+  // ── Enable/disable iRacing tab based on K10 Pro connection ──
   function updateIRacingTabState() {
     const tab = document.getElementById('iracingTab');
     if (!tab) return;
-    const connected = !!_discordUser;
+    const connected = !!_k10User;
     tab.classList.toggle('disabled', !connected);
-    tab.title = connected ? '' : 'Connect Discord to enable';
+    tab.title = connected ? '' : 'Connect K10 Pro to enable';
   }
   window.updateIRacingTabState = updateIRacingTabState;
 

--- a/dashboard-overlay/modules/js/settings.js
+++ b/dashboard-overlay/modules/js/settings.js
@@ -79,7 +79,7 @@
     _rallyModeEnabled = _settings.rallyMode || false;
     _isRally = isRallyGame() || _rallyModeEnabled;
 
-    // Sync layout rally toggle (will be updated again when Discord state loads)
+    // Sync layout rally toggle (will be updated again when K10 state loads)
     const layoutRallyToggle = document.getElementById('layoutRallyToggle');
     if (layoutRallyToggle) layoutRallyToggle.classList.toggle('on', _rallyModeEnabled);
 
@@ -143,6 +143,11 @@
 
   function switchSettingsTab(tab) {
     const tabName = tab.dataset.tab;
+    // Check if this tab requires pro and is disabled
+    if (tab.classList.contains('disabled') && tab.dataset.proTab) {
+      navigateToConnections();
+      return;
+    }
     // Update both sidebar items and legacy tab bar
     document.querySelectorAll('.settings-sidebar-item').forEach(t => t.classList.toggle('active', t.dataset.tab === tabName));
     document.querySelectorAll('.settings-tab').forEach(t => t.classList.toggle('active', t.dataset.tab === tabName));

--- a/dashboard-overlay/modules/js/webgl-helpers.js
+++ b/dashboard-overlay/modules/js/webgl-helpers.js
@@ -666,6 +666,10 @@
   let _fullMapTrailEl = null;
   let _zoomMapTrailEl = null;
 
+  // Parsed track path coordinates for snapping and off-track detection
+  let _trackPathCoords = []; // [{x, y}, ...]
+  const _OFF_TRACK_DIST = 4.0; // SVG units — beyond this, player is off-track
+
   function _ensureTrailElement(parentId, refElId) {
     const parent = document.getElementById(parentId);
     if (!parent) return null;
@@ -710,15 +714,46 @@
     trailEl.setAttribute('stroke-width', String(strokeWidth));
   }
 
+  // Parse SVG path string into an array of {x, y} coordinates
+  function _parsePathCoords(svgPath) {
+    const raw = svgPath.match(/[\d.]+[,\s]+[\d.]+/g);
+    if (!raw) return [];
+    return raw.map(function(pair) {
+      var parts = pair.split(/[,\s]+/);
+      return { x: +parts[0], y: +parts[1] };
+    });
+  }
+
+  // Find the nearest point on the parsed track path to (px, py)
+  // Returns {x, y, dist} of the closest path coordinate
+  function _nearestTrackPoint(px, py) {
+    var best = { x: px, y: py, dist: Infinity };
+    for (var i = 0; i < _trackPathCoords.length; i++) {
+      var c = _trackPathCoords[i];
+      var dx = px - c.x, dy = py - c.y;
+      var d = dx * dx + dy * dy;
+      if (d < best.dist) { best.x = c.x; best.y = c.y; best.dist = d; }
+    }
+    best.dist = Math.sqrt(best.dist);
+    return best;
+  }
+
   // Reset track map — clears recorded data and restarts capture
   function resetTrackMap() {
     fetch((window._simhubUrlOverride || SIMHUB_URL) + '?action=resetmap').catch(() => {});
     _mapLastPath = '';
     _mapHasInit = false;
-    const fullTrack = document.getElementById('fullMapTrack');
-    const zoomTrack = document.getElementById('zoomMapTrack');
-    if (fullTrack) fullTrack.setAttribute('d', '');
-    if (zoomTrack) zoomTrack.setAttribute('d', '');
+    _trackPathCoords = [];
+    _mapTrailCount = 0;
+    _mapTrailIdx = 0;
+    ['fullMapTrack', 'fullMapTrackOuter', 'fullMapTrackInner',
+     'zoomMapTrack', 'zoomMapTrackOuter', 'zoomMapTrackInner'].forEach(function(id) {
+      var el = document.getElementById(id);
+      if (el) el.setAttribute('d', '');
+    });
+    // Clear trail polylines
+    if (_fullMapTrailEl) _fullMapTrailEl.setAttribute('points', '');
+    if (_zoomMapTrailEl) _zoomMapTrailEl.setAttribute('points', '');
     // Clear opponent dots
     const fg = document.getElementById('fullMapOpponents');
     const zg = document.getElementById('zoomMapOpponents');
@@ -772,10 +807,12 @@
     if (!svgPath && _mapLastPath !== '') {
       _mapLastPath = '';
       _mapHasInit = false;
-      const fullTrack = document.getElementById('fullMapTrack');
-      const zoomTrack = document.getElementById('zoomMapTrack');
-      if (fullTrack) fullTrack.setAttribute('d', '');
-      if (zoomTrack) zoomTrack.setAttribute('d', '');
+      _trackPathCoords = [];
+      ['fullMapTrack', 'fullMapTrackOuter', 'fullMapTrackInner',
+       'zoomMapTrack', 'zoomMapTrackOuter', 'zoomMapTrackInner'].forEach(function(id) {
+        var el = document.getElementById(id);
+        if (el) el.setAttribute('d', '');
+      });
 
       // Remove sector sub-paths
       const fullSvg = document.getElementById('fullMapSvg');
@@ -792,10 +829,14 @@
     if (svgPath && svgPath !== _mapLastPath) {
       _mapLastPath = svgPath;
       _mapHasInit = false;
-      const fullTrack = document.getElementById('fullMapTrack');
-      const zoomTrack = document.getElementById('zoomMapTrack');
-      if (fullTrack) fullTrack.setAttribute('d', svgPath);
-      if (zoomTrack) zoomTrack.setAttribute('d', svgPath);
+      // Parse coordinates for snapping and off-track detection
+      _trackPathCoords = _parsePathCoords(svgPath);
+      // Set path on all three layers (outer, gap, inner) for both maps
+      ['fullMapTrack', 'fullMapTrackOuter', 'fullMapTrackInner',
+       'zoomMapTrack', 'zoomMapTrackOuter', 'zoomMapTrackInner'].forEach(function(id) {
+        var el = document.getElementById(id);
+        if (el) el.setAttribute('d', svgPath);
+      });
 
       // Split path into N sector sub-paths using native iRacing boundaries
       const boundaryPcts = Array.isArray(window._sectorBoundaries) ? window._sectorBoundaries : null;
@@ -854,6 +895,18 @@
     playerX = Math.max(0, Math.min(100, playerX));
     playerY = Math.max(0, Math.min(100, playerY));
 
+    // Snap player position to nearest track point when path is available
+    // This keeps the demo car (and live car) visually on the track
+    if (_trackPathCoords.length > 10) {
+      var snap = _nearestTrackPoint(playerX, playerY);
+      // Only snap if reasonably close (within ~6 SVG units) — prevents
+      // warping from completely wrong coordinates
+      if (snap.dist < 6) {
+        playerX = snap.x;
+        playerY = snap.y;
+      }
+    }
+
     // Smoothing: reject large jumps, low-pass filter coordinates
     if (!_mapHasInit) {
       _mapSmoothedX = playerX;
@@ -871,6 +924,21 @@
 
     const sx = _mapSmoothedX;
     const sy = _mapSmoothedY;
+
+    // Off-track detection: check distance from smoothed position to track path
+    let isOffTrack = false;
+    if (_trackPathCoords.length > 10) {
+      var nearest = _nearestTrackPoint(sx, sy);
+      isOffTrack = nearest.dist > _OFF_TRACK_DIST;
+    }
+
+    // Update track line highlighting based on on/off-track state
+    document.querySelectorAll('.map-track-outer').forEach(function(el) {
+      el.classList.toggle('off-track', isOffTrack);
+    });
+    document.querySelectorAll('.map-track-inner').forEach(function(el) {
+      el.classList.toggle('on-track', !isOffTrack);
+    });
 
     // Update player dot
     const fullPlayer = document.getElementById('fullMapPlayer');
@@ -903,20 +971,23 @@
     _mapTrailCount++;
 
     // Ensure trail SVG elements exist and render
+    // Full map: trail as sibling before player dot
     if (!_fullMapTrailEl)  _fullMapTrailEl  = _ensureTrailElement('fullMapSvg', 'fullMapPlayer');
-    if (!_zoomMapTrailEl) _zoomMapTrailEl = _ensureTrailElement('zoomMapSvg', 'zoomMapPlayer');
+    // Zoom map: trail INSIDE the rotate group so it rotates with the track
+    if (!_zoomMapTrailEl) _zoomMapTrailEl = _ensureTrailElement('zoomMapRotateGroup', 'zoomMapOpponents');
     _renderMapTrail(_fullMapTrailEl, 3);
     _renderMapTrail(_zoomMapTrailEl, 1.8);
 
     // Update zoom map — player always centered, track rotates so
-    // driving direction always points UP. Zoom out when slow to
-    // reveal nearby opponents; zoom in when fast for detail.
+    // driving direction always points UP. Zoom in when slow (corners),
+    // zoom out when fast (straights) for a dynamic camera effect.
     const zoomSvg = document.getElementById('zoomMapSvg');
     if (zoomSvg) {
       const spd = typeof speedMph === 'number' ? speedMph : 0;
-      // Zoom: slow → wider view (radius 24) to see nearby/oncoming cars,
-      //        fast → still fairly wide (radius 16) so you see oncoming traffic
-      const targetZR = 24 - Math.min(spd / 150, 1.0) * 8;
+      // Dynamic zoom: slow → tight (radius 16) for corner detail,
+      //               fast → wide (radius 38) to see track ahead.
+      // Creates a natural zoom-in effect when braking into corners.
+      const targetZR = 16 + Math.min(spd / 150, 1.0) * 22;
       _mapZoomRadius += (targetZR - _mapZoomRadius) * 0.15;
       const zr = _mapZoomRadius;
 
@@ -1052,7 +1123,7 @@
       // Create glow circle overlay — tight radius, pulsing via CSS
       glow = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
       glow.id = 'trackPlayerGlow';
-      glow.setAttribute('r', '10');
+      glow.setAttribute('r', '7');
       glow.setAttribute('fill', 'url(#trackGlowGrad)');
       glow.style.pointerEvents = 'none';
       glow.style.mixBlendMode = 'screen';

--- a/dashboard-overlay/modules/styles/connections.css
+++ b/dashboard-overlay/modules/styles/connections.css
@@ -128,4 +128,136 @@
     font-variant-numeric: tabular-nums;
   }
 
+  /* ── K10 Pro Drive Card (primary) ─────────────────────────── */
+  .conn-card-primary {
+    background: hsla(0, 60%, 40%, 0.08);
+    border: 1px solid hsla(0, 60%, 50%, 0.18);
+  }
+  .conn-card-icon.k10pro {
+    background: hsla(0, 60%, 40%, 0.25);
+    border-radius: 8px;
+  }
+  .conn-btn.k10-btn {
+    background: #e53935;
+    color: #fff;
+    font-weight: 700;
+  }
+  .conn-btn.k10-btn:disabled {
+    background: hsla(0, 50%, 35%, 0.5);
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+  .conn-pro-features {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin: 6px 0;
+  }
+  .conn-pro-feature-badge {
+    font-size: 9px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    padding: 2px 8px;
+    border-radius: 10px;
+    background: hsla(0, 60%, 45%, 0.2);
+    color: hsla(0, 60%, 70%, 0.9);
+    border: 1px solid hsla(0, 60%, 50%, 0.15);
+  }
+
+  /* Pro feature info panel (when not connected) */
+  .conn-pro-info {
+    background: hsla(0,0%,100%,0.02);
+    border: 1px solid hsla(0,0%,100%,0.06);
+    border-radius: 8px;
+    padding: 12px;
+    margin-bottom: 10px;
+  }
+  .conn-pro-info-title {
+    font-size: 11px;
+    font-weight: 700;
+    color: hsla(0,0%,100%,0.6);
+    margin-bottom: 4px;
+  }
+  .conn-pro-info-text {
+    font-size: 10px;
+    color: hsla(0,0%,100%,0.35);
+    line-height: 1.5;
+    margin-bottom: 8px;
+  }
+  .conn-pro-info-text strong { color: hsla(0,0%,100%,0.5); }
+  .conn-pro-feature-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 4px;
+  }
+  .conn-pro-feature-item {
+    font-size: 10px;
+    color: hsla(0,0%,100%,0.45);
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+  .conn-pro-feature-icon { font-size: 11px; }
+
+  /* Secondary cards (SimHub, Discord) — less prominent */
+  .conn-card-secondary {
+    background: hsla(0,0%,100%,0.02);
+    border: 1px solid hsla(0,0%,100%,0.05);
+    border-radius: 6px;
+    padding: 10px;
+    margin-bottom: 0;
+  }
+  .conn-card-secondary .conn-card-header {
+    margin-bottom: 0;
+  }
+
+  /* ── Pro Feature Gating — locked toggles ─────────────────── */
+  .settings-toggle.pro-locked {
+    opacity: 0.3;
+    cursor: pointer;
+    position: relative;
+  }
+  .settings-toggle.pro-locked::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+  }
+  .pro-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    margin-left: 4px;
+    cursor: pointer;
+    opacity: 0.6;
+    transition: opacity 0.2s;
+    vertical-align: middle;
+    flex-shrink: 0;
+  }
+  .pro-badge:hover { opacity: 1; }
+  .pro-badge img {
+    width: 12px;
+    height: 12px;
+    object-fit: contain;
+  }
+
+  /* Disabled sidebar item (pro-gated tab) */
+  .settings-sidebar-item.disabled {
+    opacity: 0.35;
+    cursor: pointer;
+  }
+  .settings-sidebar-item.disabled::after {
+    content: '';
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    background: url('../../images/branding/logomark.png') center/contain no-repeat;
+    margin-left: 4px;
+    opacity: 0.5;
+    vertical-align: -1px;
+  }
+
   /* ── Rally Mode ─────────────────────────────────────────────── */

--- a/dashboard-overlay/modules/styles/dashboard.css
+++ b/dashboard-overlay/modules/styles/dashboard.css
@@ -1276,13 +1276,40 @@
     position: relative;
   }
   .map-svg { width: 92%; height: 92%; }
+  /* Track outline — three-layer rendering: thick outer edges, dark gap, thin center line */
+  .map-track-outer {
+    fill: none;
+    stroke: hsla(0,0%,100%,0.18);
+    stroke-width: 5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    transition: stroke 0.4s ease;
+  }
+  .map-track-outer.off-track {
+    stroke: hsla(0,60%,55%,0.45);
+  }
   .map-track {
     fill: none;
-    stroke: hsla(0,0%,100%,0.35);
+    stroke: hsla(220,15%,8%,0.95);
     stroke-width: 3;
     stroke-linecap: round;
     stroke-linejoin: round;
   }
+  .map-track-inner {
+    fill: none;
+    stroke: hsla(0,0%,100%,0.08);
+    stroke-width: 0.6;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    transition: stroke 0.4s ease;
+  }
+  .map-track-inner.on-track {
+    stroke: hsla(185,60%,55%,0.35);
+  }
+  /* Zoom map uses thinner strokes */
+  .map-zoom-svg .map-track-outer { stroke-width: 2.5; }
+  .map-zoom-svg .map-track { stroke-width: 1.5; }
+  .map-zoom-svg .map-track-inner { stroke-width: 0.3; }
   .map-sector {
     fill: none;
     stroke: transparent;
@@ -1296,18 +1323,18 @@
     fill: var(--map-player-color, var(--cyan));
     transition: fill 0.4s ease;
     filter: drop-shadow(0 0 2px hsla(0,0%,100%,0.7))
-            drop-shadow(0 0 4px var(--map-player-color, var(--cyan)));
+            drop-shadow(0 0 3px var(--map-player-color, var(--cyan)));
     animation: map-player-pulse 2s ease-in-out infinite;
   }
   @keyframes map-player-pulse {
     0%, 100% {
       filter: drop-shadow(0 0 2px hsla(0,0%,100%,0.7))
-              drop-shadow(0 0 4px var(--map-player-color, var(--cyan)));
+              drop-shadow(0 0 3px var(--map-player-color, var(--cyan)));
     }
     50% {
-      filter: drop-shadow(0 0 3px hsla(0,0%,100%,0.9))
-              drop-shadow(0 0 6px var(--map-player-color, var(--cyan)))
-              drop-shadow(0 0 10px var(--map-player-color, var(--cyan)));
+      filter: drop-shadow(0 0 2px hsla(0,0%,100%,0.9))
+              drop-shadow(0 0 5px var(--map-player-color, var(--cyan)))
+              drop-shadow(0 0 7px var(--map-player-color, var(--cyan)));
     }
   }
   .map-gforce-trail {
@@ -1333,10 +1360,10 @@
     animation: map-opponent-pulse 1.5s ease-in-out infinite;
   }
 
-  /* SVG radial glow pulse behind player dot */
+  /* SVG radial glow pulse behind player dot — tighter radius */
   @keyframes map-glow-pulse {
-    0%, 100% { r: 10; opacity: 0.8; }
-    50% { r: 14; opacity: 1; }
+    0%, 100% { r: 7; opacity: 0.8; }
+    50% { r: 10; opacity: 1; }
   }
 
   .map-zoom-panel {

--- a/dashboard-overlay/preload.js
+++ b/dashboard-overlay/preload.js
@@ -45,10 +45,15 @@ contextBridge.exposeInMainWorld('k10', {
   onToggleDriveMode: (callback) => {
     ipcRenderer.on('toggle-drive-mode', () => callback());
   },
-  // Discord OAuth2
+  // Discord OAuth2 (legacy — still works for community features)
   discordConnect: () => ipcRenderer.invoke('discord-connect'),
   discordDisconnect: () => ipcRenderer.invoke('discord-disconnect'),
   getDiscordUser: () => ipcRenderer.invoke('get-discord-user'),
+  // K10 Pro Drive OAuth2 (website account → pro features)
+  k10Connect: () => ipcRenderer.invoke('k10-connect'),
+  k10Disconnect: () => ipcRenderer.invoke('k10-disconnect'),
+  getK10User: () => ipcRenderer.invoke('get-k10-user'),
+  verifyK10Token: () => ipcRenderer.invoke('verify-k10-token'),
   // Remote dashboard server (iPad/tablet access)
   getRemoteServerInfo: () => ipcRenderer.invoke('get-remote-server-info'),
   startRemoteServer: (opts) => ipcRenderer.invoke('start-remote-server', opts),

--- a/web/drizzle.config.ts
+++ b/web/drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+  schema: './src/db/schema.ts',
+  out: './drizzle',
+  dialect: 'postgresql',
+  dbCredentials: {
+    url: process.env.k10_DATABASE_URL!,
+  },
+})

--- a/web/drizzle/0000_worthless_jack_murdock.sql
+++ b/web/drizzle/0000_worthless_jack_murdock.sql
@@ -1,0 +1,82 @@
+CREATE TABLE "auth_codes" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"code" varchar(64) NOT NULL,
+	"user_id" uuid NOT NULL,
+	"code_challenge" varchar(128),
+	"code_challenge_method" varchar(8),
+	"expires_at" timestamp NOT NULL,
+	"used" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "auth_codes_code_unique" UNIQUE("code")
+);
+--> statement-breakpoint
+CREATE TABLE "driver_ratings" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"category" varchar(16) NOT NULL,
+	"irating" integer DEFAULT 0 NOT NULL,
+	"safety_rating" varchar(8) DEFAULT '0.00' NOT NULL,
+	"license" varchar(4) DEFAULT 'R' NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "plugin_tokens" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"access_token" varchar(128) NOT NULL,
+	"refresh_token" varchar(128) NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"revoked" boolean DEFAULT false NOT NULL,
+	"device_name" varchar(128),
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "plugin_tokens_access_token_unique" UNIQUE("access_token"),
+	CONSTRAINT "plugin_tokens_refresh_token_unique" UNIQUE("refresh_token")
+);
+--> statement-breakpoint
+CREATE TABLE "race_sessions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"car_model" varchar(128) NOT NULL,
+	"manufacturer" varchar(64),
+	"category" varchar(16) NOT NULL,
+	"track_name" varchar(128),
+	"session_type" varchar(32),
+	"finish_position" integer,
+	"incident_count" integer,
+	"metadata" jsonb,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "rating_history" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"category" varchar(16) NOT NULL,
+	"irating" integer NOT NULL,
+	"safety_rating" varchar(8) NOT NULL,
+	"license" varchar(4) NOT NULL,
+	"prev_irating" integer,
+	"prev_safety_rating" varchar(8),
+	"prev_license" varchar(4),
+	"session_type" varchar(32),
+	"track_name" varchar(128),
+	"car_model" varchar(128),
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"discord_id" varchar(32) NOT NULL,
+	"discord_username" varchar(64) NOT NULL,
+	"discord_display_name" varchar(64),
+	"discord_avatar" text,
+	"email" varchar(255),
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "users_discord_id_unique" UNIQUE("discord_id")
+);
+--> statement-breakpoint
+ALTER TABLE "auth_codes" ADD CONSTRAINT "auth_codes_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "driver_ratings" ADD CONSTRAINT "driver_ratings_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "plugin_tokens" ADD CONSTRAINT "plugin_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "race_sessions" ADD CONSTRAINT "race_sessions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "rating_history" ADD CONSTRAINT "rating_history_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/web/drizzle/meta/0000_snapshot.json
+++ b/web/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,546 @@
+{
+  "id": "cda9ba2f-f4b8-4442-9d53-704321842a20",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_codes": {
+      "name": "auth_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_codes_user_id_users_id_fk": {
+          "name": "auth_codes_user_id_users_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_codes_code_unique": {
+          "name": "auth_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.driver_ratings": {
+      "name": "driver_ratings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "irating": {
+          "name": "irating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "safety_rating": {
+          "name": "safety_rating",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "license": {
+          "name": "license",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'R'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "driver_ratings_user_id_users_id_fk": {
+          "name": "driver_ratings_user_id_users_id_fk",
+          "tableFrom": "driver_ratings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugin_tokens": {
+      "name": "plugin_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plugin_tokens_user_id_users_id_fk": {
+          "name": "plugin_tokens_user_id_users_id_fk",
+          "tableFrom": "plugin_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plugin_tokens_access_token_unique": {
+          "name": "plugin_tokens_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "plugin_tokens_refresh_token_unique": {
+          "name": "plugin_tokens_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.race_sessions": {
+      "name": "race_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "car_model": {
+          "name": "car_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_name": {
+          "name": "track_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_type": {
+          "name": "session_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_position": {
+          "name": "finish_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_count": {
+          "name": "incident_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "race_sessions_user_id_users_id_fk": {
+          "name": "race_sessions_user_id_users_id_fk",
+          "tableFrom": "race_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rating_history": {
+      "name": "rating_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "irating": {
+          "name": "irating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "safety_rating": {
+          "name": "safety_rating",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license": {
+          "name": "license",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prev_irating": {
+          "name": "prev_irating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_safety_rating": {
+          "name": "prev_safety_rating",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_license": {
+          "name": "prev_license",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_type": {
+          "name": "session_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_name": {
+          "name": "track_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "car_model": {
+          "name": "car_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rating_history_user_id_users_id_fk": {
+          "name": "rating_history_user_id_users_id_fk",
+          "tableFrom": "rating_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_display_name": {
+          "name": "discord_display_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_avatar": {
+          "name": "discord_avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_discord_id_unique": {
+          "name": "users_discord_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1774816594594,
+      "tag": "0000_worthless_jack_murdock",
+      "breakpoints": true
+    }
+  ]
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,15 +1,17 @@
 {
-  "name": "web",
+  "name": "@k10/web",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "web",
+      "name": "@k10/web",
       "version": "0.1.0",
       "dependencies": {
         "@auth/core": "^0.41.0",
+        "@neondatabase/serverless": "^1.0.2",
         "clsx": "^2.1.1",
+        "drizzle-orm": "^0.45.2",
         "googleapis": "^171.4.0",
         "lucide-react": "^0.577.0",
         "next": "16.2.0",
@@ -22,6 +24,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "drizzle-kit": "^0.31.10",
         "eslint": "^9",
         "eslint-config-next": "16.2.0",
         "tailwindcss": "^4",
@@ -313,6 +316,13 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@drizzle-team/brocli": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz",
+      "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@emnapi/core": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
@@ -341,6 +351,884 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.3.2.tgz",
+      "integrity": "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==",
+      "deprecated": "Merged into tsx: https://tsx.is",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.18.20",
+        "source-map-support": "^0.5.21"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/@esbuild-kit/esm-loader": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.6.5.tgz",
+      "integrity": "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==",
+      "deprecated": "Merged into tsx: https://tsx.is",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@esbuild-kit/core-utils": "^3.3.2",
+        "get-tsconfig": "^4.7.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1023,6 +1911,28 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@neondatabase/serverless": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.0.2.tgz",
+      "integrity": "sha512-I5sbpSIAHiB+b6UttofhrN/UJXII+4tZPAq1qugzwCwLIL8EZLV7F/JyHUrEIiGgQpEXzpnjlJ+zwcEhheGvCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.15.30",
+        "@types/pg": "^8.8.0"
+      },
+      "engines": {
+        "node": ">=19.0.0"
+      }
+    },
+    "node_modules/@neondatabase/serverless/node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/@next/env": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.0.tgz",
@@ -1523,9 +2433,19 @@
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/react": {
@@ -2454,6 +3374,13 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -2748,6 +3675,147 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/drizzle-kit": {
+      "version": "0.31.10",
+      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.10.tgz",
+      "integrity": "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@drizzle-team/brocli": "^0.10.2",
+        "@esbuild-kit/esm-loader": "^2.5.5",
+        "esbuild": "^0.25.4",
+        "tsx": "^4.21.0"
+      },
+      "bin": {
+        "drizzle-kit": "bin.cjs"
+      }
+    },
+    "node_modules/drizzle-orm": {
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.2.tgz",
+      "integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
+        "@op-engineering/op-sqlite": ">=2",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1.13",
+        "@prisma/client": "*",
+        "@tidbcloud/serverless": "*",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/sql.js": "*",
+        "@upstash/redis": ">=1.34.7",
+        "@vercel/postgres": ">=0.8.0",
+        "@xata.io/client": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@op-engineering/op-sqlite": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@tidbcloud/serverless": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2959,6 +4027,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/escalade": {
@@ -3556,6 +4666,21 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -5362,6 +6487,37 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5414,6 +6570,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/preact": {
@@ -5910,12 +7105,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/stable-hash": {
@@ -6228,6 +7444,510 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -6371,8 +8091,7 @@
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
@@ -6567,6 +8286,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yallist": {

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,9 @@
   },
   "dependencies": {
     "@auth/core": "^0.41.0",
+    "@neondatabase/serverless": "^1.0.2",
     "clsx": "^2.1.1",
+    "drizzle-orm": "^0.45.2",
     "googleapis": "^171.4.0",
     "lucide-react": "^0.577.0",
     "next": "16.2.0",
@@ -26,15 +28,16 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "drizzle-kit": "^0.31.10",
     "eslint": "^9",
     "eslint-config-next": "16.2.0",
     "tailwindcss": "^4",
     "typescript": "^5"
   },
   "optionalDependencies": {
-    "lightningcss-darwin-arm64": "^1.30.1",
     "@ast-grep/napi-linux-x64-gnu": "^0.39.4",
     "@rollup/rollup-linux-x64-gnu": "^4.50.0",
+    "lightningcss-darwin-arm64": "^1.30.1",
     "lightningcss-linux-x64-gnu": "^1.30.1"
   }
 }

--- a/web/public/_demo/dashboard-embed.html
+++ b/web/public/_demo/dashboard-embed.html
@@ -2453,6 +2453,138 @@
     font-variant-numeric: tabular-nums;
   }
 
+  /* ── K10 Pro Drive Card (primary) ─────────────────────────── */
+  .conn-card-primary {
+    background: hsla(0, 60%, 40%, 0.08);
+    border: 1px solid hsla(0, 60%, 50%, 0.18);
+  }
+  .conn-card-icon.k10pro {
+    background: hsla(0, 60%, 40%, 0.25);
+    border-radius: 8px;
+  }
+  .conn-btn.k10-btn {
+    background: #e53935;
+    color: #fff;
+    font-weight: 700;
+  }
+  .conn-btn.k10-btn:disabled {
+    background: hsla(0, 50%, 35%, 0.5);
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+  .conn-pro-features {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin: 6px 0;
+  }
+  .conn-pro-feature-badge {
+    font-size: 9px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    padding: 2px 8px;
+    border-radius: 10px;
+    background: hsla(0, 60%, 45%, 0.2);
+    color: hsla(0, 60%, 70%, 0.9);
+    border: 1px solid hsla(0, 60%, 50%, 0.15);
+  }
+
+  /* Pro feature info panel (when not connected) */
+  .conn-pro-info {
+    background: hsla(0,0%,100%,0.02);
+    border: 1px solid hsla(0,0%,100%,0.06);
+    border-radius: 8px;
+    padding: 12px;
+    margin-bottom: 10px;
+  }
+  .conn-pro-info-title {
+    font-size: 11px;
+    font-weight: 700;
+    color: hsla(0,0%,100%,0.6);
+    margin-bottom: 4px;
+  }
+  .conn-pro-info-text {
+    font-size: 10px;
+    color: hsla(0,0%,100%,0.35);
+    line-height: 1.5;
+    margin-bottom: 8px;
+  }
+  .conn-pro-info-text strong { color: hsla(0,0%,100%,0.5); }
+  .conn-pro-feature-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 4px;
+  }
+  .conn-pro-feature-item {
+    font-size: 10px;
+    color: hsla(0,0%,100%,0.45);
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+  .conn-pro-feature-icon { font-size: 11px; }
+
+  /* Secondary cards (SimHub, Discord) — less prominent */
+  .conn-card-secondary {
+    background: hsla(0,0%,100%,0.02);
+    border: 1px solid hsla(0,0%,100%,0.05);
+    border-radius: 6px;
+    padding: 10px;
+    margin-bottom: 0;
+  }
+  .conn-card-secondary .conn-card-header {
+    margin-bottom: 0;
+  }
+
+  /* ── Pro Feature Gating — locked toggles ─────────────────── */
+  .settings-toggle.pro-locked {
+    opacity: 0.3;
+    cursor: pointer;
+    position: relative;
+  }
+  .settings-toggle.pro-locked::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+  }
+  .pro-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    margin-left: 4px;
+    cursor: pointer;
+    opacity: 0.6;
+    transition: opacity 0.2s;
+    vertical-align: middle;
+    flex-shrink: 0;
+  }
+  .pro-badge:hover { opacity: 1; }
+  .pro-badge img {
+    width: 12px;
+    height: 12px;
+    object-fit: contain;
+  }
+
+  /* Disabled sidebar item (pro-gated tab) */
+  .settings-sidebar-item.disabled {
+    opacity: 0.35;
+    cursor: pointer;
+  }
+  .settings-sidebar-item.disabled::after {
+    content: '';
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    background: url('../../images/branding/logomark.png') center/contain no-repeat;
+    margin-left: 4px;
+    opacity: 0.5;
+    vertical-align: -1px;
+  }
+
   /* ── Rally Mode ─────────────────────────────────────────────── */
 
 
@@ -6620,6 +6752,11 @@ let _settings = Object.assign({}, _defaultSettings);
 // Discord state
 let _discordUser = null;
 
+// K10 Pro Drive state (set by connections.js on startup)
+// Declared here so game-detect.js and other early scripts can reference it
+let _k10User = null;
+let _k10Features = [];
+
 // Logo cycling
 let _currentCarLogoIdx = 0;
 let _currentCarLogo = '';
@@ -6778,10 +6915,10 @@ function _fmtLapTime(secs) {
     return GAME_FEATURES[_currentGameId] || GAME_FEATURES.iracing;
   }
 
-  // Returns true if the current game is allowed (iRacing always allowed; others require Discord)
+  // Returns true if the current game is allowed (iRacing always allowed; others require K10 Pro)
   function isGameAllowed() {
     if (_currentGameId === 'iracing') return true;
-    return !!_discordUser;
+    return !!_k10User;
   }
 
   function isRallyGame() {
@@ -8796,7 +8933,7 @@ document.addEventListener('DOMContentLoaded', function () {
     _rallyModeEnabled = _settings.rallyMode || false;
     _isRally = isRallyGame() || _rallyModeEnabled;
 
-    // Sync layout rally toggle (will be updated again when Discord state loads)
+    // Sync layout rally toggle (will be updated again when K10 state loads)
     const layoutRallyToggle = document.getElementById('layoutRallyToggle');
     if (layoutRallyToggle) layoutRallyToggle.classList.toggle('on', _rallyModeEnabled);
 
@@ -8860,6 +8997,11 @@ document.addEventListener('DOMContentLoaded', function () {
 
   function switchSettingsTab(tab) {
     const tabName = tab.dataset.tab;
+    // Check if this tab requires pro and is disabled
+    if (tab.classList.contains('disabled') && tab.dataset.proTab) {
+      navigateToConnections();
+      return;
+    }
     // Update both sidebar items and legacy tab bar
     document.querySelectorAll('.settings-sidebar-item').forEach(t => t.classList.toggle('active', t.dataset.tab === tabName));
     document.querySelectorAll('.settings-tab').forEach(t => t.classList.toggle('active', t.dataset.tab === tabName));
@@ -9304,27 +9446,198 @@ document.addEventListener('DOMContentLoaded', function () {
 // Connections tab
 
   // ═══════════════════════════════════════════════════════════════
-  //  CONNECTIONS TAB — SimHub & Discord status
+  //  CONNECTIONS TAB — K10 Pro, SimHub, Discord
   // ═══════════════════════════════════════════════════════════════
 
   const DISCORD_GUILD_INVITE = 'https://discord.gg/k10mediabroadcaster';
   // _discordUser declared in config.js
   let _discordConnecting = false;
 
+  // K10 Pro Drive connection state (_k10User, _k10Features declared in config.js)
+  let _k10Connecting = false;
+
+  // Pro features — keys map to setting toggles and sidebar items
+  const PRO_FEATURE_KEYS = ['commentary','incidents','spotter','leaderboard','datastream','webgl','reflections','modules'];
+
+  function isProFeature(key) {
+    const map = {
+      'showCommentary': 'commentary',
+      'showIncidents': 'incidents',
+      'showSpotter': 'spotter',
+      'showLeaderboard': 'leaderboard',
+      'showDatastream': 'datastream',
+      'showWebGL': 'webgl',
+      'ambientMode': 'reflections',
+    };
+    return map[key] || null;
+  }
+
+  function isProEnabled(featureKey) {
+    return _k10User && _k10Features.includes(featureKey);
+  }
+
   function updateConnectionsTab() {
     updateSimhubConnectionCard();
     updateDiscordConnectionCard();
+    updateK10ConnectionCard();
+  }
+
+  // ── K10 Pro Drive connection card ──
+  function updateK10ConnectionCard() {
+    const notConn = document.getElementById('k10NotConnected');
+    const conn = document.getElementById('k10Connected');
+    const info = document.getElementById('k10ProInfo');
+    if (!notConn || !conn) return;
+
+    if (_k10User) {
+      notConn.style.display = 'none';
+      conn.style.display = '';
+      if (info) info.style.display = 'none';
+
+      const nameEl = document.getElementById('k10DisplayName');
+      const idEl = document.getElementById('k10UserId');
+      const avatarEl = document.getElementById('k10Avatar');
+      if (nameEl) nameEl.textContent = _k10User.discordDisplayName || _k10User.discordUsername || 'Connected';
+      if (idEl) idEl.textContent = _k10User.discordId || '';
+      if (avatarEl && _k10User.discordAvatar && _k10User.discordId) {
+        avatarEl.src = `https://cdn.discordapp.com/avatars/${_k10User.discordId}/${_k10User.discordAvatar}.png?size=64`;
+        avatarEl.alt = _k10User.discordDisplayName || '';
+      }
+
+      // Show feature list
+      const featureList = document.getElementById('k10FeatureList');
+      if (featureList) {
+        featureList.innerHTML = _k10Features.map(f =>
+          '<span class="conn-pro-feature-badge">' + f + '</span>'
+        ).join('');
+      }
+    } else {
+      notConn.style.display = '';
+      conn.style.display = 'none';
+      if (info) info.style.display = '';
+    }
+
+    // Update pro feature gating across all settings
+    updateProFeatureGating();
+
+    // Remote dashboard — visible when K10 connected (was Discord)
+    updateRemoteDashVisibility();
+
+    // iRacing tab — enabled when K10 connected (was Discord)
+    if (typeof updateIRacingTabState === 'function') updateIRacingTabState();
+  }
+
+  async function connectK10Pro() {
+    if (_k10Connecting) return;
+    if (!window.k10 || !window.k10.k10Connect) {
+      // Fallback: open website in browser
+      if (window.k10 && window.k10.openExternal) {
+        window.k10.openExternal('https://drive.k10motorsports.racing');
+      }
+      return;
+    }
+
+    _k10Connecting = true;
+    const btn = document.getElementById('k10ConnectBtn');
+    if (btn) { btn.disabled = true; btn.textContent = 'Connecting...'; }
+
+    try {
+      const result = await window.k10.k10Connect();
+      if (result && result.success && result.user) {
+        _k10User = result.user;
+        _k10Features = result.user.features || [];
+        _settings.k10User = result.user;
+        _settings.k10Features = result.user.features || [];
+        saveSettings();
+        updateK10ConnectionCard();
+      } else {
+        const errMsg = result?.error || 'Connection failed';
+        console.warn('[K10] Pro connect failed:', errMsg);
+        const text = document.getElementById('connK10Text');
+        if (text) text.innerHTML = '<strong style="color:hsl(0,75%,60%)">Failed</strong> — ' + errMsg;
+        setTimeout(() => {
+          if (text) text.innerHTML = 'Not connected';
+        }, 3000);
+      }
+    } catch (err) {
+      console.error('[K10] Pro connect error:', err);
+    } finally {
+      _k10Connecting = false;
+      if (btn) {
+        btn.disabled = false;
+        btn.innerHTML = '<img src="images/branding/logomark.png" alt="" style="width:12px;height:12px;vertical-align:-2px;margin-right:4px;filter:brightness(10);" /> Connect to K10 Pro Drive';
+      }
+    }
+  }
+
+  async function disconnectK10Pro() {
+    if (window.k10 && window.k10.k10Disconnect) {
+      await window.k10.k10Disconnect();
+    }
+    _k10User = null;
+    _k10Features = [];
+    delete _settings.k10User;
+    delete _settings.k10Features;
+    saveSettings();
+    updateK10ConnectionCard();
+  }
+
+  // ── Pro Feature Gating ──
+  // Add disabled state + K10 badge to toggles that require Pro
+  function updateProFeatureGating() {
+    const isPro = !!_k10User;
+
+    // Toggle elements with pro gating
+    document.querySelectorAll('[data-pro-feature]').forEach(el => {
+      const featureKey = el.dataset.proFeature;
+      const enabled = isPro && _k10Features.includes(featureKey);
+
+      if (enabled) {
+        el.classList.remove('pro-locked');
+        // Remove pro badge if present
+        const badge = el.parentElement?.querySelector('.pro-badge');
+        if (badge) badge.style.display = 'none';
+      } else {
+        el.classList.add('pro-locked');
+        // Show pro badge
+        let badge = el.parentElement?.querySelector('.pro-badge');
+        if (!badge && el.parentElement) {
+          badge = document.createElement('span');
+          badge.className = 'pro-badge';
+          badge.innerHTML = '<img src="images/branding/logomark.png" alt="Pro" />';
+          badge.title = 'K10 Pro feature — connect to enable';
+          badge.onclick = function(e) { e.stopPropagation(); navigateToConnections(); };
+          el.parentElement.appendChild(badge);
+        }
+        if (badge) badge.style.display = '';
+      }
+    });
+
+    // Sidebar items gating
+    document.querySelectorAll('[data-pro-tab]').forEach(tab => {
+      const featureKey = tab.dataset.proTab;
+      const enabled = isPro && _k10Features.includes(featureKey);
+      tab.classList.toggle('disabled', !enabled);
+      tab.title = enabled ? '' : 'K10 Pro feature — connect to enable';
+    });
+
+    // Update layout rally toggle (now based on K10 Pro, not Discord)
+    updateLayoutRallyToggle();
+    syncRallyToggles();
+  }
+
+  function navigateToConnections() {
+    const tab = document.querySelector('.settings-sidebar-item[data-tab="connections"]');
+    if (tab) switchSettingsTab(tab);
   }
 
   // ── SimHub connection card ──
   function updateSimhubConnectionCard() {
     const dot = document.getElementById('connSimhubDot');
     const text = document.getElementById('connSimhubText');
-    const urlEl = document.getElementById('connSimhubUrl');
     const urlInput = document.getElementById('settingsSimhubUrl');
     const currentUrl = window._simhubUrlOverride || SIMHUB_URL;
 
-    if (urlEl) urlEl.textContent = currentUrl;
     if (urlInput) urlInput.value = currentUrl;
 
     // Derive state from the existing connection status
@@ -9336,8 +9649,8 @@ document.addEventListener('DOMContentLoaded', function () {
       dot.className = 'conn-dot ' + (state === 'connected' ? 'green' : state === 'disconnected' ? 'red' : 'orange');
     }
     if (text) {
-      if (state === 'connected') text.innerHTML = '<strong>Connected</strong> — receiving telemetry';
-      else if (state === 'disconnected') text.innerHTML = '<strong>Disconnected</strong> — check SimHub is running';
+      if (state === 'connected') text.innerHTML = '<strong>Connected</strong>';
+      else if (state === 'disconnected') text.innerHTML = '<strong>Disconnected</strong>';
       else text.innerHTML = 'Connecting...';
     }
   }
@@ -9352,32 +9665,15 @@ document.addEventListener('DOMContentLoaded', function () {
       notConn.style.display = 'none';
       conn.style.display = '';
       const nameEl = document.getElementById('discordDisplayName');
-      const idEl = document.getElementById('discordUserId');
-      const avatarEl = document.getElementById('discordAvatar');
       if (nameEl) nameEl.textContent = _discordUser.globalName || _discordUser.username;
-      if (idEl) idEl.textContent = _discordUser.id;
-      if (avatarEl && _discordUser.avatar) {
-        avatarEl.src = `https://cdn.discordapp.com/avatars/${_discordUser.id}/${_discordUser.avatar}.png?size=64`;
-        avatarEl.alt = _discordUser.globalName || _discordUser.username;
-      }
     } else {
       notConn.style.display = '';
       conn.style.display = 'none';
     }
 
-    // Show game features card when Discord is connected
+    // Show game features card when Discord is connected (legacy)
     const gameCard = document.getElementById('gameFeatureCard');
     if (gameCard) gameCard.style.display = _discordUser ? '' : 'none';
-
-    // Update layout section rally toggle
-    updateLayoutRallyToggle();
-    syncRallyToggles();
-
-    // Remote dashboard — visible when Discord connected
-    updateRemoteDashVisibility();
-
-    // iRacing tab — enabled when Discord connected
-    if (typeof updateIRacingTabState === 'function') updateIRacingTabState();
   }
 
   async function connectDiscord() {
@@ -9402,18 +9698,12 @@ document.addEventListener('DOMContentLoaded', function () {
       } else {
         const errMsg = result?.error || 'Connection failed';
         console.warn('[K10] Discord connect failed:', errMsg);
-        const text = document.getElementById('connDiscordText');
-        if (text) text.innerHTML = '<strong style="color:hsl(0,75%,60%)">Failed</strong> — ' + errMsg;
-        // Reset after 3s
-        setTimeout(() => {
-          if (text) text.innerHTML = 'Not connected';
-        }, 3000);
       }
     } catch (err) {
       console.error('[K10] Discord connect error:', err);
     } finally {
       _discordConnecting = false;
-      if (btn) { btn.disabled = false; btn.innerHTML = '<svg viewBox="0 0 24 24" fill="currentColor" style="width:12px;height:12px;vertical-align:-1px;margin-right:4px"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.947 2.418-2.157 2.418z"/></svg> Connect Discord'; }
+      if (btn) { btn.disabled = false; btn.textContent = 'Connect'; }
     }
   }
 
@@ -9448,7 +9738,7 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function toggleLayoutRally(el) {
-    // Ignore clicks when disabled (no Discord connection)
+    // Ignore clicks when disabled (no K10 Pro connection)
     if (el.classList.contains('disabled')) return;
     const isOn = el.classList.contains('on');
     el.classList.toggle('on', !isOn);
@@ -9469,19 +9759,19 @@ document.addEventListener('DOMContentLoaded', function () {
     if (connToggle) connToggle.classList.toggle('on', _rallyModeEnabled);
   }
 
-  /** Enable/disable the layout rally toggle based on Discord state */
+  /** Enable/disable the layout rally toggle based on K10 Pro state */
   function updateLayoutRallyToggle() {
     const el = document.getElementById('layoutRallyToggle');
     const hint = document.getElementById('layoutRallyHint');
     if (!el) return;
-    if (_discordUser) {
+    if (_k10User) {
       el.classList.remove('disabled');
       if (hint) hint.style.display = 'none';
     } else {
       el.classList.add('disabled');
       el.classList.remove('on');
       if (hint) hint.style.display = '';
-      // Force rally off when Discord disconnects
+      // Force rally off when disconnected
       _rallyModeEnabled = false;
       _settings.rallyMode = false;
       _isRally = isRallyGame();
@@ -9523,7 +9813,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const section = document.getElementById('remoteDashSection');
     if (!section) return;
     if (window._k10RemoteMode) { section.style.display = 'none'; return; }
-    section.style.display = _discordUser ? '' : 'none';
+    section.style.display = _k10User ? '' : 'none';
   }
 
   async function initRemoteDashState() {
@@ -9566,7 +9856,52 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   }
 
+  // Load K10 Pro user on startup
+  async function initK10State() {
+    // Try loading from Electron's persisted file first
+    if (window.k10 && window.k10.getK10User) {
+      try {
+        const user = await window.k10.getK10User();
+        if (user && user.id) {
+          _k10User = user;
+          _k10Features = user.features || [];
+          updateK10ConnectionCard();
+
+          // Verify token in background
+          if (window.k10.verifyK10Token) {
+            window.k10.verifyK10Token().then(result => {
+              if (result && !result.valid) {
+                console.warn('[K10] Pro token invalid — clearing session');
+                _k10User = null;
+                _k10Features = [];
+                delete _settings.k10User;
+                delete _settings.k10Features;
+                saveSettings();
+                updateK10ConnectionCard();
+              } else if (result && result.features) {
+                _k10Features = result.features;
+                updateK10ConnectionCard();
+              }
+            }).catch(() => {});
+          }
+          return;
+        }
+      } catch (e) { /* ok */ }
+    }
+    // Fallback: check settings
+    if (_settings.k10User && _settings.k10User.id) {
+      _k10User = _settings.k10User;
+      _k10Features = _settings.k10Features || [];
+      updateK10ConnectionCard();
+    }
+  }
+
   function toggleSetting(el) {
+    // Check if this is a pro-locked toggle
+    if (el.classList.contains('pro-locked')) {
+      navigateToConnections();
+      return;
+    }
     const key = el.dataset.key;
     const isOn = el.classList.contains('on');
     _settings[key] = !isOn;
@@ -9584,6 +9919,11 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function toggleWebGL(el) {
+    // Check if this is a pro-locked toggle
+    if (el.classList.contains('pro-locked')) {
+      navigateToConnections();
+      return;
+    }
     const isOn = el.classList.contains('on');
     const newVal = !isOn;
     el.classList.toggle('on', newVal);
@@ -9906,6 +10246,7 @@ document.addEventListener('DOMContentLoaded', function () {
   // Load settings on startup
   loadSettings();
   initDiscordState();
+  initK10State();
   initRemoteDashState();
 
   // ═══════════════════════════════════════════════════════════════
@@ -16529,13 +16870,13 @@ document.addEventListener('DOMContentLoaded', function () {
     if (licSelect) licSelect.value = _manualLicense || 'R';
   }
 
-  // ── Enable/disable iRacing tab based on Discord connection ──
+  // ── Enable/disable iRacing tab based on K10 Pro connection ──
   function updateIRacingTabState() {
     const tab = document.getElementById('iracingTab');
     if (!tab) return;
-    const connected = !!_discordUser;
+    const connected = !!_k10User;
     tab.classList.toggle('disabled', !connected);
-    tab.title = connected ? '' : 'Connect Discord to enable';
+    tab.title = connected ? '' : 'Connect K10 Pro to enable';
   }
   window.updateIRacingTabState = updateIRacingTabState;
 

--- a/web/src/app/api/download/latest/route.ts
+++ b/web/src/app/api/download/latest/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+
+const GITHUB_REPO = 'alternatekev/media-coach-simhub-plugin'
+const GITHUB_API = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`
+
+/**
+ * GET /api/download/latest
+ *
+ * Proxy for the latest GitHub release .zip asset.
+ * Requires authentication (Discord login via NextAuth session).
+ * Resolves the latest release and redirects to the .zip download URL.
+ */
+export async function GET() {
+  const session = await auth()
+  if (!session?.user) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
+  }
+
+  try {
+    const res = await fetch(GITHUB_API, {
+      headers: {
+        Accept: 'application/vnd.github.v3+json',
+        'User-Agent': 'K10-Motorsports-Web',
+      },
+      next: { revalidate: 300 }, // Cache for 5 minutes
+    })
+
+    if (!res.ok) {
+      return NextResponse.json({ error: 'Failed to fetch release info' }, { status: 502 })
+    }
+
+    const release = await res.json()
+
+    // Find the .zip asset (installer)
+    const zipAsset = release.assets?.find((a: { name: string }) =>
+      a.name.endsWith('.zip') || a.name.includes('Setup')
+    )
+
+    if (zipAsset?.browser_download_url) {
+      return NextResponse.redirect(zipAsset.browser_download_url)
+    }
+
+    // Fallback to the zipball (source archive)
+    if (release.zipball_url) {
+      return NextResponse.redirect(release.zipball_url)
+    }
+
+    return NextResponse.json({ error: 'No download asset found' }, { status: 404 })
+  } catch (err) {
+    console.error('[download/latest] Error:', err)
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 })
+  }
+}

--- a/web/src/app/api/plugin-auth/authorize/route.ts
+++ b/web/src/app/api/plugin-auth/authorize/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { findOrCreateUser, createAuthCode } from '@/lib/plugin-auth'
+
+/**
+ * GET /api/plugin-auth/authorize
+ *
+ * Plugin OAuth2 authorization endpoint.
+ * Requires the user to be logged in via Discord (NextAuth session).
+ * Returns an auth code to the plugin's localhost callback.
+ *
+ * Query params:
+ *   - code_challenge: PKCE challenge (optional but recommended)
+ *   - code_challenge_method: 'S256' (default) or 'plain'
+ *   - state: opaque state value returned to plugin
+ *   - redirect_uri: plugin's localhost callback (e.g. http://localhost:18492/callback)
+ */
+export async function GET(request: NextRequest) {
+  const session = await auth()
+
+  if (!session?.user) {
+    // Not logged in — redirect to Discord login, then back here
+    const returnUrl = request.nextUrl.toString()
+    const loginUrl = new URL('/drive', request.nextUrl.origin)
+    loginUrl.searchParams.set('callbackUrl', returnUrl)
+    return NextResponse.redirect(loginUrl)
+  }
+
+  const { searchParams } = request.nextUrl
+  const codeChallenge = searchParams.get('code_challenge')
+  const codeChallengeMethod = searchParams.get('code_challenge_method') || 'S256'
+  const state = searchParams.get('state') || ''
+  const redirectUri = searchParams.get('redirect_uri') || 'http://localhost:18492/callback'
+
+  // Validate redirect_uri is localhost
+  try {
+    const uri = new URL(redirectUri)
+    if (uri.hostname !== 'localhost' && uri.hostname !== '127.0.0.1') {
+      return NextResponse.json({ error: 'redirect_uri must be localhost' }, { status: 400 })
+    }
+  } catch {
+    return NextResponse.json({ error: 'Invalid redirect_uri' }, { status: 400 })
+  }
+
+  // Get Discord profile from session — exposed via our JWT callback
+  const user_ext = session.user as Record<string, unknown>
+  const discordId = (user_ext.discordId as string) || session.user.email || ''
+  const username = (user_ext.discordUsername as string) || session.user.name || ''
+  const displayName = (user_ext.discordDisplayName as string) || username
+  const avatar = (user_ext.discordAvatar as string) || session.user.image || null
+
+  // Find or create user in our database
+  const user = await findOrCreateUser(
+    discordId,
+    username,
+    displayName,
+    avatar,
+    session.user.email,
+  )
+
+  // Generate auth code
+  const code = await createAuthCode(
+    user.id,
+    codeChallenge ?? undefined,
+    codeChallengeMethod,
+  )
+
+  // Redirect to plugin's localhost callback with code + state
+  const callbackUrl = new URL(redirectUri)
+  callbackUrl.searchParams.set('code', code)
+  if (state) callbackUrl.searchParams.set('state', state)
+
+  return NextResponse.redirect(callbackUrl.toString())
+}

--- a/web/src/app/api/plugin-auth/token/route.ts
+++ b/web/src/app/api/plugin-auth/token/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { exchangeCode, refreshTokenPair } from '@/lib/plugin-auth'
+
+/**
+ * POST /api/plugin-auth/token
+ *
+ * Token exchange endpoint. Accepts either:
+ * - grant_type=authorization_code + code + code_verifier (PKCE)
+ * - grant_type=refresh_token + refresh_token
+ */
+export async function POST(request: NextRequest) {
+  const body = await request.json().catch(() => ({}))
+  const grantType = body.grant_type
+
+  if (grantType === 'authorization_code') {
+    const { code, code_verifier } = body
+    if (!code) {
+      return NextResponse.json({ error: 'missing_code' }, { status: 400 })
+    }
+
+    const tokens = await exchangeCode(code, code_verifier)
+    if (!tokens) {
+      return NextResponse.json({ error: 'invalid_code' }, { status: 400 })
+    }
+
+    return NextResponse.json({
+      access_token: tokens.accessToken,
+      refresh_token: tokens.refreshToken,
+      token_type: 'Bearer',
+      expires_at: tokens.expiresAt,
+    })
+  }
+
+  if (grantType === 'refresh_token') {
+    const { refresh_token } = body
+    if (!refresh_token) {
+      return NextResponse.json({ error: 'missing_refresh_token' }, { status: 400 })
+    }
+
+    const tokens = await refreshTokenPair(refresh_token)
+    if (!tokens) {
+      return NextResponse.json({ error: 'invalid_refresh_token' }, { status: 400 })
+    }
+
+    return NextResponse.json({
+      access_token: tokens.accessToken,
+      refresh_token: tokens.refreshToken,
+      token_type: 'Bearer',
+      expires_at: tokens.expiresAt,
+    })
+  }
+
+  return NextResponse.json({ error: 'unsupported_grant_type' }, { status: 400 })
+}

--- a/web/src/app/api/plugin-auth/verify/route.ts
+++ b/web/src/app/api/plugin-auth/verify/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { validateToken } from '@/lib/plugin-auth'
+import { PRO_FEATURES } from '@/lib/plugin-auth'
+
+/**
+ * GET /api/plugin-auth/verify
+ *
+ * Token verification endpoint. The plugin calls this on startup and periodically
+ * to confirm its token is valid and get the user's profile + feature entitlements.
+ *
+ * Headers: Authorization: Bearer <access_token>
+ */
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('Authorization')
+  if (!authHeader?.startsWith('Bearer ')) {
+    return NextResponse.json({ error: 'missing_token' }, { status: 401 })
+  }
+
+  const token = authHeader.slice(7)
+  const result = await validateToken(token)
+
+  if (!result) {
+    return NextResponse.json({ error: 'invalid_token' }, { status: 401 })
+  }
+
+  // All authenticated users get all pro features (for now — could be tier-gated later)
+  const features = PRO_FEATURES.map(f => f.key)
+
+  return NextResponse.json({
+    user: result.user,
+    features,
+    expires_at: result.expiresAt,
+  })
+}

--- a/web/src/app/drive/dashboard/page.tsx
+++ b/web/src/app/drive/dashboard/page.tsx
@@ -1,0 +1,171 @@
+import { auth, signOut } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { SITE_URL, SITE_NAME, CATEGORY_LABELS, LICENSE_LABELS, LICENSE_COLORS } from '@/lib/constants'
+import { db, schema } from '@/db'
+import { eq } from 'drizzle-orm'
+import { Download, LogOut, BarChart3, Trophy, Shield, Car } from 'lucide-react'
+
+export default async function DashboardPage() {
+  const session = await auth()
+  if (!session?.user) redirect('/drive')
+
+  const user_ext = session.user as Record<string, unknown>
+  const discordId = user_ext.discordId as string
+  const displayName = (user_ext.discordDisplayName as string) || session.user.name || 'Racer'
+  const avatar = session.user.image
+
+  // Fetch race session count to determine if we should show the "keep racing" message
+  let raceCount = 0
+  let dbUser = null
+  if (discordId) {
+    const users = await db.select().from(schema.users).where(eq(schema.users.discordId, discordId)).limit(1)
+    if (users.length > 0) {
+      dbUser = users[0]
+      const sessions = await db.select().from(schema.raceSessions).where(eq(schema.raceSessions.userId, dbUser.id))
+      raceCount = sessions.length
+    }
+  }
+
+  const hasEnoughData = raceCount >= 5
+
+  return (
+    <main className="min-h-screen bg-[var(--bg)]">
+      {/* Top bar */}
+      <header className="border-b border-[var(--border)] px-6 py-4 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <img src="/branding/logomark-white.png" alt="K10" className="h-8 w-auto opacity-80" />
+          <span className="text-sm font-bold tracking-wider uppercase text-[var(--text-secondary)]">Pro Drive</span>
+        </div>
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2">
+            {avatar && <img src={avatar} alt="" className="w-7 h-7 rounded-full" />}
+            <span className="text-sm text-[var(--text-secondary)]">{displayName}</span>
+          </div>
+          <form action={async () => {
+            'use server'
+            await signOut({ redirectTo: '/drive' })
+          }}>
+            <button type="submit" className="text-xs text-[var(--text-muted)] hover:text-[var(--text-dim)] transition-colors flex items-center gap-1 cursor-pointer">
+              <LogOut size={12} /> Sign out
+            </button>
+          </form>
+        </div>
+      </header>
+
+      <div className="max-w-4xl mx-auto px-6 py-12">
+        {/* Welcome + Download */}
+        <section className="mb-12">
+          <h1 className="text-3xl font-black mb-2">Welcome, {displayName}</h1>
+          <p className="text-[var(--text-dim)] mb-6">
+            Download the K10 overlay, connect it to your Pro Drive account, and start racing. Your performance data will appear here automatically.
+          </p>
+          <a
+            href="/api/download/latest"
+            className="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-[var(--k10-red)] text-white font-bold text-sm uppercase tracking-wider hover:brightness-110 transition"
+          >
+            <Download size={16} />
+            Download K10 Overlay
+          </a>
+          <p className="mt-2 text-xs text-[var(--text-muted)]">
+            Windows installer &mdash; includes SimHub plugin and dashboard overlay
+          </p>
+        </section>
+
+        {/* Setup Instructions */}
+        <section className="mb-12 p-6 rounded-xl bg-[var(--surface)] border border-[var(--border)]">
+          <h2 className="text-lg font-bold mb-4">Get Connected</h2>
+          <ol className="space-y-3 text-sm text-[var(--text-dim)]">
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[var(--k10-red)] text-white text-xs font-bold flex items-center justify-center">1</span>
+              <span>Install the K10 overlay using the download above</span>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[var(--k10-red)] text-white text-xs font-bold flex items-center justify-center">2</span>
+              <span>Launch the overlay and open Settings (Ctrl+Shift+S)</span>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[var(--k10-red)] text-white text-xs font-bold flex items-center justify-center">3</span>
+              <span>Go to the <strong>Connections</strong> tab and click <strong>Connect to K10 Pro Drive</strong></span>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[var(--k10-red)] text-white text-xs font-bold flex items-center justify-center">4</span>
+              <span>You&apos;ll be redirected here to authorize, then the overlay unlocks all Pro features</span>
+            </li>
+          </ol>
+        </section>
+
+        {/* Performance Dashboard (placeholder or data) */}
+        <section className="mb-12">
+          <h2 className="text-lg font-bold mb-4 flex items-center gap-2">
+            <BarChart3 size={18} className="text-[var(--k10-red)]" />
+            Performance
+          </h2>
+          {hasEnoughData ? (
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+              <div className="p-4 rounded-xl bg-[var(--surface)] border border-[var(--border)]">
+                <div className="text-xs text-[var(--text-muted)] uppercase tracking-wider mb-1">Races</div>
+                <div className="text-2xl font-black">{raceCount}</div>
+              </div>
+              <div className="p-4 rounded-xl bg-[var(--surface)] border border-[var(--border)]">
+                <div className="text-xs text-[var(--text-muted)] uppercase tracking-wider mb-1">Charts</div>
+                <div className="text-sm text-[var(--text-dim)]">Coming soon</div>
+              </div>
+              <div className="p-4 rounded-xl bg-[var(--surface)] border border-[var(--border)]">
+                <div className="text-xs text-[var(--text-muted)] uppercase tracking-wider mb-1">Trends</div>
+                <div className="text-sm text-[var(--text-dim)]">Coming soon</div>
+              </div>
+            </div>
+          ) : (
+            <div className="p-8 rounded-xl bg-[var(--surface)] border border-[var(--border)] text-center">
+              <Trophy size={32} className="mx-auto mb-3 text-[var(--text-muted)]" />
+              <p className="text-sm text-[var(--text-dim)] mb-1">
+                {raceCount === 0
+                  ? 'No race data yet'
+                  : `${raceCount} of 5 races recorded`}
+              </p>
+              <p className="text-xs text-[var(--text-muted)]">
+                Charts and performance trends will appear once you&apos;ve completed at least 5 races with the overlay connected.
+                Keep racing!
+              </p>
+            </div>
+          )}
+        </section>
+
+        {/* Pro Features */}
+        <section>
+          <h2 className="text-lg font-bold mb-4 flex items-center gap-2">
+            <Shield size={18} className="text-[var(--k10-red)]" />
+            Pro Features
+          </h2>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            {[
+              { label: 'AI Commentary', icon: '🎙️' },
+              { label: 'Incidents Panel', icon: '⚠️' },
+              { label: 'Virtual Spotter', icon: '👁️' },
+              { label: 'Live Leaderboard', icon: '🏆' },
+              { label: 'Datastream', icon: '📊' },
+              { label: 'WebGL Effects', icon: '✨' },
+              { label: 'Reflections', icon: '🔮' },
+              { label: 'Module Config', icon: '⚙️' },
+            ].map(f => (
+              <div key={f.label} className="p-3 rounded-lg bg-[var(--surface)] border border-[var(--border)] text-center">
+                <div className="text-lg mb-1">{f.icon}</div>
+                <div className="text-xs font-semibold text-[var(--text-secondary)]">{f.label}</div>
+              </div>
+            ))}
+          </div>
+          <p className="mt-3 text-xs text-[var(--text-muted)]">
+            All Pro features are unlocked when your overlay is connected to your K10 Pro Drive account.
+          </p>
+        </section>
+
+        {/* Footer */}
+        <footer className="mt-16 pt-6 border-t border-[var(--border)] text-center">
+          <a href={SITE_URL} className="text-xs text-[var(--text-muted)] hover:text-[var(--text-dim)] transition-colors">
+            &larr; Back to {SITE_NAME}
+          </a>
+        </footer>
+      </div>
+    </main>
+  )
+}

--- a/web/src/app/drive/page.tsx
+++ b/web/src/app/drive/page.tsx
@@ -1,7 +1,22 @@
 import { SITE_URL, SITE_NAME } from '@/lib/constants'
-import { signIn } from '@/lib/auth'
+import { signIn, auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
 
-export default function DrivePage() {
+export default async function DrivePage({ searchParams }: { searchParams: Promise<Record<string, string>> }) {
+  const session = await auth()
+  const params = await searchParams
+  const callbackUrl = params.callbackUrl
+
+  // If user is already logged in and there's a plugin auth callback, redirect there
+  if (session?.user && callbackUrl?.includes('/api/plugin-auth/')) {
+    redirect(callbackUrl)
+  }
+
+  // If user is logged in, redirect to the members dashboard
+  if (session?.user) {
+    redirect('/drive/dashboard')
+  }
+
   return (
     <main className="flex flex-col items-center justify-center min-h-screen px-6 text-center relative overflow-hidden">
       {/* Subtle brand glow */}
@@ -20,7 +35,7 @@ export default function DrivePage() {
       <form
         action={async () => {
           'use server'
-          await signIn('discord')
+          await signIn('discord', { redirectTo: callbackUrl || '/drive/dashboard' })
         }}
       >
         <button
@@ -34,7 +49,7 @@ export default function DrivePage() {
         </button>
       </form>
       <p className="mt-6 text-xs text-[var(--text-muted)] relative z-10">
-        <a href={SITE_URL} className="hover:text-[var(--text-dim)] transition-colors">← Back to {SITE_NAME}</a>
+        <a href={SITE_URL} className="hover:text-[var(--text-dim)] transition-colors">&larr; Back to {SITE_NAME}</a>
       </p>
     </main>
   )

--- a/web/src/app/marketing/page.tsx
+++ b/web/src/app/marketing/page.tsx
@@ -54,38 +54,38 @@ export default async function HomePage() {
       {/* Features — live dashboard modules, one at a time */}
       <FeatureShowcase />
 
-      {/* Installation */}
+      {/* Get Started */}
       <section id="install" className="px-6 py-20 max-w-4xl mx-auto w-full">
-        <h2 className="text-3xl font-black mb-10">Install</h2>
+        <h2 className="text-3xl font-black mb-10">Get Started</h2>
 
         <div className="space-y-8">
           <div>
-            <h3 className="text-xl font-bold mb-3 text-[var(--k10-red)]">1. Download the Installer</h3>
+            <h3 className="text-xl font-bold mb-3 text-[var(--k10-red)]">1. Create Your Account</h3>
             <p className="text-lg text-[var(--text-dim)] mb-3">
-              The Windows installer bundles the SimHub plugin and the dashboard overlay. It auto-detects your SimHub installation and handles all file placement.
+              Sign in with Discord to access K10 Pro Drive — your personal sim racing performance dashboard and download portal.
             </p>
             <a
-              href="https://github.com/alternatekev/media-coach-simhub-plugin/releases/latest"
-              className="inline-flex items-center gap-2 px-6 py-3 rounded-lg font-bold text-sm uppercase tracking-wider bg-[var(--k10-red)] text-white hover:brightness-110 transition-all"
+              href={DRIVE_URL}
+              className="inline-flex items-center gap-2 px-6 py-3 rounded-lg font-bold text-sm uppercase tracking-wider bg-[#5865F2] text-white hover:brightness-110 hover:no-underline transition-all"
             >
-              Download K10-Motorsports-Setup.exe →
+              Sign in to Pro Drive &rarr;
             </a>
           </div>
 
           <div>
-            <h3 className="text-xl font-bold mb-3 text-[var(--k10-red)]">2. Enable in SimHub</h3>
+            <h3 className="text-xl font-bold mb-3 text-[var(--k10-red)]">2. Download & Install</h3>
             <p className="text-lg text-[var(--text-dim)] mb-3">
-              Launch SimHub, enable &ldquo;K10 Motorsports&rdquo; in the plugin list, and configure display timing, commentary categories, and strategy options in the settings panel.
+              The Windows installer is available in your Pro Drive dashboard. It bundles the SimHub plugin and the dashboard overlay, auto-detects your SimHub installation, and handles all file placement.
             </p>
           </div>
 
           <div>
-            <h3 className="text-xl font-bold mb-3 text-[var(--k10-red)]">3. Launch & Connect</h3>
+            <h3 className="text-xl font-bold mb-3 text-[var(--k10-red)]">3. Connect & Race</h3>
             <p className="text-lg text-[var(--text-dim)] mb-3">
-              The overlay runs as a transparent window on top of your sim. Stream it to any browser on your network for multi-screen setups.
+              Open the overlay settings (Ctrl+Shift+S), go to Connections, and click &ldquo;Connect to K10 Pro Drive&rdquo; to unlock all Pro features — AI commentary, incidents, spotter, leaderboard, datastream, WebGL effects, and ambient reflections.
             </p>
             <div className="bg-[var(--bg-surface)] rounded-lg p-4 font-mono text-base text-[var(--text-dim)] border border-[var(--border-subtle)]">
-              Built-in auto-updater keeps you current — check for updates from the SimHub settings panel
+              Your race data syncs automatically — performance charts appear after a few sessions
             </div>
           </div>
         </div>

--- a/web/src/components/youtube/VideoGrid.tsx
+++ b/web/src/components/youtube/VideoGrid.tsx
@@ -10,12 +10,12 @@ interface VideoGridProps {
 }
 
 const TYPE_LABELS = { video: 'Videos', short: 'Shorts', live: 'Live' } as const
-const TYPE_FILTERS = ['all', 'video', 'short', 'live'] as const
+const TYPE_FILTERS = ['video', 'short', 'live'] as const
 
 export function VideoGrid({ videos, title = 'Latest Content' }: VideoGridProps) {
-  const [filter, setFilter] = useState<string>('all')
+  const [filter, setFilter] = useState<string>('video')
 
-  const filtered = filter === 'all' ? videos : videos.filter(v => v.type === filter)
+  const filtered = videos.filter(v => v.type === filter)
   const availableTypes = new Set(videos.map(v => v.type))
 
   return (
@@ -23,7 +23,7 @@ export function VideoGrid({ videos, title = 'Latest Content' }: VideoGridProps) 
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-2xl font-black">{title}</h2>
         <div className="flex gap-2">
-          {TYPE_FILTERS.filter(t => t === 'all' || availableTypes.has(t as any)).map(t => (
+          {TYPE_FILTERS.filter(t => availableTypes.has(t as any)).map(t => (
             <button
               key={t}
               onClick={() => setFilter(t)}
@@ -33,7 +33,7 @@ export function VideoGrid({ videos, title = 'Latest Content' }: VideoGridProps) 
                   : 'bg-white/5 text-[var(--text-dim)] hover:bg-white/10'
               }`}
             >
-              {t === 'all' ? 'All' : TYPE_LABELS[t as keyof typeof TYPE_LABELS]}
+              {TYPE_LABELS[t as keyof typeof TYPE_LABELS]}
             </button>
           ))}
         </div>

--- a/web/src/db/index.ts
+++ b/web/src/db/index.ts
@@ -1,0 +1,8 @@
+import { neon } from '@neondatabase/serverless'
+import { drizzle } from 'drizzle-orm/neon-http'
+import * as schema from './schema'
+
+const sql = neon(process.env.k10_DATABASE_URL!)
+
+export const db = drizzle(sql, { schema })
+export { schema }

--- a/web/src/db/schema.ts
+++ b/web/src/db/schema.ts
@@ -1,0 +1,80 @@
+import { pgTable, text, timestamp, boolean, integer, jsonb, uuid, varchar } from 'drizzle-orm/pg-core'
+
+// ── Users (Discord-authenticated members) ──
+export const users = pgTable('users', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  discordId: varchar('discord_id', { length: 32 }).notNull().unique(),
+  discordUsername: varchar('discord_username', { length: 64 }).notNull(),
+  discordDisplayName: varchar('discord_display_name', { length: 64 }),
+  discordAvatar: text('discord_avatar'),
+  email: varchar('email', { length: 255 }),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+})
+
+// ── Plugin Tokens (OAuth2 tokens issued to the desktop plugin) ──
+export const pluginTokens = pgTable('plugin_tokens', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  accessToken: varchar('access_token', { length: 128 }).notNull().unique(),
+  refreshToken: varchar('refresh_token', { length: 128 }).notNull().unique(),
+  expiresAt: timestamp('expires_at').notNull(),
+  revoked: boolean('revoked').default(false).notNull(),
+  deviceName: varchar('device_name', { length: 128 }),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+})
+
+// ── Authorization Codes (short-lived codes for OAuth2 flow) ──
+export const authCodes = pgTable('auth_codes', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  code: varchar('code', { length: 64 }).notNull().unique(),
+  userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  codeChallenge: varchar('code_challenge', { length: 128 }),
+  codeChallengeMethod: varchar('code_challenge_method', { length: 8 }),
+  expiresAt: timestamp('expires_at').notNull(),
+  used: boolean('used').default(false).notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+})
+
+// ── Driver Ratings (iRacing performance data) ──
+export const driverRatings = pgTable('driver_ratings', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  category: varchar('category', { length: 16 }).notNull(), // road, oval, dirt_road, dirt_oval, sports_car
+  iRating: integer('irating').notNull().default(0),
+  safetyRating: varchar('safety_rating', { length: 8 }).notNull().default('0.00'),
+  license: varchar('license', { length: 4 }).notNull().default('R'),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+})
+
+// ── Rating History (historical snapshots after each race) ──
+export const ratingHistory = pgTable('rating_history', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  category: varchar('category', { length: 16 }).notNull(),
+  iRating: integer('irating').notNull(),
+  safetyRating: varchar('safety_rating', { length: 8 }).notNull(),
+  license: varchar('license', { length: 4 }).notNull(),
+  prevIRating: integer('prev_irating'),
+  prevSafetyRating: varchar('prev_safety_rating', { length: 8 }),
+  prevLicense: varchar('prev_license', { length: 4 }),
+  sessionType: varchar('session_type', { length: 32 }),
+  trackName: varchar('track_name', { length: 128 }),
+  carModel: varchar('car_model', { length: 128 }),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+})
+
+// ── Race Sessions (aggregated car/session data) ──
+export const raceSessions = pgTable('race_sessions', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  carModel: varchar('car_model', { length: 128 }).notNull(),
+  manufacturer: varchar('manufacturer', { length: 64 }),
+  category: varchar('category', { length: 16 }).notNull(),
+  trackName: varchar('track_name', { length: 128 }),
+  sessionType: varchar('session_type', { length: 32 }),
+  finishPosition: integer('finish_position'),
+  incidentCount: integer('incident_count'),
+  metadata: jsonb('metadata'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+})

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -14,6 +14,26 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     signIn: '/drive',
   },
   callbacks: {
+    // Expose Discord ID + avatar in the JWT and session
+    async jwt({ token, account, profile }) {
+      if (account && profile) {
+        token.discordId = profile.id
+        token.discordUsername = profile.username
+        token.discordDisplayName = profile.global_name ?? profile.username
+        token.discordAvatar = profile.avatar
+      }
+      return token
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        const user = session.user as unknown as Record<string, unknown>
+        user.discordId = token.discordId
+        user.discordUsername = token.discordUsername
+        user.discordDisplayName = token.discordDisplayName
+        user.discordAvatar = token.discordAvatar
+      }
+      return session
+    },
     authorized({ auth: session, request: { nextUrl } }) {
       const isOnDrive = nextUrl.pathname.startsWith('/drive')
       const isSignedIn = !!session?.user

--- a/web/src/lib/plugin-auth.ts
+++ b/web/src/lib/plugin-auth.ts
@@ -1,0 +1,188 @@
+/**
+ * Plugin OAuth2 Authorization Server
+ *
+ * Flow:
+ * 1. Plugin opens browser to /api/plugin-auth/authorize?code_challenge=...&state=...
+ * 2. User logs in with Discord (if not already logged in via NextAuth)
+ * 3. Server generates authorization code, redirects to localhost callback
+ * 4. Plugin exchanges code for access token via /api/plugin-auth/token
+ * 5. Plugin uses access token for /api/plugin-auth/verify to check status
+ */
+
+import { randomBytes, createHash } from 'crypto'
+import { db, schema } from '@/db'
+import { eq, and } from 'drizzle-orm'
+
+const ACCESS_TOKEN_EXPIRY_DAYS = 90
+const AUTH_CODE_EXPIRY_MINUTES = 5
+
+export function generateToken(): string {
+  return randomBytes(48).toString('base64url')
+}
+
+export function generateAuthCode(): string {
+  return randomBytes(24).toString('base64url')
+}
+
+/** Verify PKCE code_challenge against code_verifier */
+export function verifyPKCE(codeVerifier: string, codeChallenge: string, method: string = 'S256'): boolean {
+  if (method === 'S256') {
+    const hash = createHash('sha256').update(codeVerifier).digest('base64url')
+    return hash === codeChallenge
+  }
+  // plain method
+  return codeVerifier === codeChallenge
+}
+
+/** Find or create a user from Discord profile */
+export async function findOrCreateUser(discordId: string, username: string, displayName: string | null, avatar: string | null, email?: string | null) {
+  const existing = await db.select().from(schema.users).where(eq(schema.users.discordId, discordId)).limit(1)
+
+  if (existing.length > 0) {
+    // Update profile fields
+    await db.update(schema.users).set({
+      discordUsername: username,
+      discordDisplayName: displayName,
+      discordAvatar: avatar,
+      email: email ?? undefined,
+      updatedAt: new Date(),
+    }).where(eq(schema.users.discordId, discordId))
+    return existing[0]
+  }
+
+  const result = await db.insert(schema.users).values({
+    discordId,
+    discordUsername: username,
+    discordDisplayName: displayName,
+    discordAvatar: avatar,
+    email,
+  }).returning()
+
+  return result[0]
+}
+
+/** Create an authorization code for the plugin OAuth flow */
+export async function createAuthCode(userId: string, codeChallenge?: string, codeChallengeMethod?: string) {
+  const code = generateAuthCode()
+  const expiresAt = new Date(Date.now() + AUTH_CODE_EXPIRY_MINUTES * 60 * 1000)
+
+  await db.insert(schema.authCodes).values({
+    code,
+    userId,
+    codeChallenge: codeChallenge ?? null,
+    codeChallengeMethod: codeChallengeMethod ?? null,
+    expiresAt,
+  })
+
+  return code
+}
+
+/** Exchange an authorization code for access + refresh tokens */
+export async function exchangeCode(code: string, codeVerifier?: string) {
+  const rows = await db.select().from(schema.authCodes)
+    .where(and(eq(schema.authCodes.code, code), eq(schema.authCodes.used, false)))
+    .limit(1)
+
+  if (rows.length === 0) return null
+  const authCode = rows[0]
+
+  // Check expiry
+  if (new Date() > authCode.expiresAt) return null
+
+  // PKCE verification
+  if (authCode.codeChallenge && codeVerifier) {
+    if (!verifyPKCE(codeVerifier, authCode.codeChallenge, authCode.codeChallengeMethod ?? 'S256')) {
+      return null
+    }
+  }
+
+  // Mark code as used
+  await db.update(schema.authCodes).set({ used: true }).where(eq(schema.authCodes.id, authCode.id))
+
+  // Generate tokens
+  const accessToken = generateToken()
+  const refreshToken = generateToken()
+  const expiresAt = new Date(Date.now() + ACCESS_TOKEN_EXPIRY_DAYS * 24 * 60 * 60 * 1000)
+
+  await db.insert(schema.pluginTokens).values({
+    userId: authCode.userId,
+    accessToken,
+    refreshToken,
+    expiresAt,
+  })
+
+  return { accessToken, refreshToken, expiresAt: expiresAt.toISOString() }
+}
+
+/** Refresh an expired/active token pair */
+export async function refreshTokenPair(refreshToken: string) {
+  const rows = await db.select().from(schema.pluginTokens)
+    .where(and(eq(schema.pluginTokens.refreshToken, refreshToken), eq(schema.pluginTokens.revoked, false)))
+    .limit(1)
+
+  if (rows.length === 0) return null
+
+  // Revoke old pair
+  await db.update(schema.pluginTokens).set({ revoked: true }).where(eq(schema.pluginTokens.id, rows[0].id))
+
+  // Issue new pair
+  const newAccessToken = generateToken()
+  const newRefreshToken = generateToken()
+  const expiresAt = new Date(Date.now() + ACCESS_TOKEN_EXPIRY_DAYS * 24 * 60 * 60 * 1000)
+
+  await db.insert(schema.pluginTokens).values({
+    userId: rows[0].userId,
+    accessToken: newAccessToken,
+    refreshToken: newRefreshToken,
+    expiresAt,
+  })
+
+  return { accessToken: newAccessToken, refreshToken: newRefreshToken, expiresAt: expiresAt.toISOString() }
+}
+
+/** Validate an access token and return the user */
+export async function validateToken(accessToken: string) {
+  const rows = await db.select({
+    token: schema.pluginTokens,
+    user: schema.users,
+  })
+    .from(schema.pluginTokens)
+    .innerJoin(schema.users, eq(schema.pluginTokens.userId, schema.users.id))
+    .where(and(eq(schema.pluginTokens.accessToken, accessToken), eq(schema.pluginTokens.revoked, false)))
+    .limit(1)
+
+  if (rows.length === 0) return null
+
+  const { token, user } = rows[0]
+
+  // Check expiry
+  if (new Date() > token.expiresAt) return null
+
+  return {
+    user: {
+      id: user.id,
+      discordId: user.discordId,
+      discordUsername: user.discordUsername,
+      discordDisplayName: user.discordDisplayName,
+      discordAvatar: user.discordAvatar,
+    },
+    expiresAt: token.expiresAt.toISOString(),
+  }
+}
+
+/** Revoke all plugin tokens for a user */
+export async function revokeUserTokens(userId: string) {
+  await db.update(schema.pluginTokens).set({ revoked: true }).where(eq(schema.pluginTokens.userId, userId))
+}
+
+/** Pro features list — what gets unlocked when connected */
+export const PRO_FEATURES = [
+  { key: 'commentary', label: 'AI Commentary' },
+  { key: 'incidents', label: 'Incidents Panel' },
+  { key: 'spotter', label: 'Virtual Spotter' },
+  { key: 'leaderboard', label: 'Live Leaderboard' },
+  { key: 'datastream', label: 'Datastream Telemetry' },
+  { key: 'webgl', label: 'WebGL Effects' },
+  { key: 'reflections', label: 'Ambient Reflections' },
+  { key: 'modules', label: 'Module Customization' },
+] as const


### PR DESCRIPTION
## Summary
- **Pro Drive website**: Discord OAuth sign-in via NextAuth v5, members dashboard at `drive.k10motorsports.racing` with download link, setup instructions, performance placeholder, and pro features grid
- **Database**: Drizzle ORM + Neon Postgres — 6 tables (users, pluginTokens, authCodes, driverRatings, ratingHistory, raceSessions) with migration pushed to Neon
- **Plugin OAuth2 server**: Full PKCE authorization code flow — `/api/plugin-auth/authorize`, `/token`, `/verify` endpoints for the Electron overlay to authenticate against the website
- **Download proxy**: `/api/download/latest` proxies the latest GitHub release .zip through auth so users download from Pro Drive, not GitHub
- **Pro feature gating**: 8 overlay modules (commentary, incidents, spotter, leaderboard, datastream, webgl, reflections, module config) locked behind K10 Pro connection via `data-pro-feature` HTML attributes and CSS `.pro-locked` class with K10 logo badges
- **Connection UI overhaul**: K10 Pro Drive card is primary (red-branded, prominent); SimHub and Discord cards are compact/secondary
- **Electron IPC**: `k10-connect`, `k10-disconnect`, `get-k10-user`, `verify-k10-token` handlers with localhost:18492 callback, token persistence, and refresh flow
- **Homepage**: Videos tab now default, All filter removed
- **Marketing**: Install section updated to point to Pro Drive sign-in flow

## Test plan
- [ ] Run `npm run dev` in `/web`, sign in with Discord at `localhost:3000/drive`
- [ ] Verify redirect to `/drive/dashboard` after sign-in
- [ ] Verify download button proxies latest GitHub release
- [ ] Launch Electron overlay, open Connections tab — K10 Pro card should be primary
- [ ] Click "Connect to K10 Pro Drive" — should open browser, auth, redirect back
- [ ] Verify pro-locked toggles show K10 logo badge and redirect to Connections on click
- [ ] Disconnect K10 Pro — verify features re-lock
- [ ] Check marketing page install section points to Pro Drive
- [ ] Verify homepage defaults to Videos tab with no All filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)