### PR TITLE
Fix overlay UX: taskbar reflow, remove bottom vswap, adj styling

### DIFF
--- a/racecor-overlay/main.js
+++ b/racecor-overlay/main.js
@@ -231,6 +231,26 @@ async function createOverlay() {
 
   overlayWindow.on('closed', () => { overlayWindow = null; });
 
+  // ── Windows: reflow overlay when taskbar appears / disappears ──
+  // The taskbar auto-hide changes workArea but not bounds.  Listen for
+  // display-metrics-changed so we always fill the entire screen.
+  if (process.platform === 'win32' && !greenScreenMode) {
+    screen.on('display-metrics-changed', (_event, display, changedMetrics) => {
+      if (!overlayWindow || overlayWindow.isDestroyed()) return;
+      if (!changedMetrics.includes('workArea') && !changedMetrics.includes('bounds')) return;
+
+      const primary = screen.getPrimaryDisplay();
+      if (display.id !== primary.id) return;
+
+      const { x, y, width, height } = primary.bounds;
+      const cur = overlayWindow.getBounds();
+      if (cur.x === x && cur.y === y && cur.width === width && cur.height === height) return;
+
+      logToFile(`[K10] Display metrics changed (${changedMetrics.join(', ')}), reflowing overlay to ${width}x${height}`);
+      overlayWindow.setBounds({ x, y, width, height });
+    });
+  }
+
   // ── Windows: periodically re-assert always-on-top ──────────
   // DirectX fullscreen exclusive mode can steal z-order even from
   // screen-saver level windows. Re-assert every 5 seconds.

--- a/racecor-overlay/modules/styles/dashboard.css
+++ b/racecor-overlay/modules/styles/dashboard.css
@@ -53,47 +53,9 @@
     border-top-left-radius: var(--corner-r); border-bottom-left-radius: var(--corner-r);
   }
 
-  /* ── Vertical swap for bottom corners ──
-     Reverses internal column order so panels read correctly
-     when the HUD is anchored to the bottom edge. */
-  .dashboard.layout-br .fuel-tyres-col,
-  .dashboard.layout-bl .fuel-tyres-col,
-  .dashboard.layout-br .controls-pedals-block,
-  .dashboard.layout-bl .controls-pedals-block,
-  .dashboard.layout-br .maps-col,
-  .dashboard.layout-bl .maps-col,
-  .dashboard.layout-br .pos-gaps-col,
-  .dashboard.layout-bl .pos-gaps-col,
-  .dashboard.layout-br .logo-col,
-  .dashboard.layout-bl .logo-col {
-    flex-direction: column-reverse;
-  }
-
-  /* Vswap corner rounding — bottom-right (RTL): fuel→bottom-left, tyres→top-left */
-  .dashboard.layout-br .fuel-block  { border-top-left-radius: 0; border-bottom-left-radius: var(--corner-r); }
-  .dashboard.layout-br .tyres-block { border-bottom-left-radius: 0; border-top-left-radius: var(--corner-r); }
-
-  /* Vswap corner rounding — bottom-left (LTR): fuel→bottom-right, tyres→top-right */
-  .dashboard.layout-bl .fuel-block  {
-    border-top-right-radius: 0; border-bottom-right-radius: var(--corner-r);
-    border-top-left-radius: 0; border-bottom-left-radius: 0;
-  }
-  .dashboard.layout-bl .tyres-block {
-    border-bottom-right-radius: 0; border-top-right-radius: var(--corner-r);
-    border-bottom-left-radius: 0; border-top-left-radius: 0;
-  }
-
-  /* Vswap logo column — bottom corners flip logo squares */
-  .dashboard.layout-br .logo-col .logo-square:first-child,
-  .dashboard.layout-bl .logo-col .logo-square:first-child {
-    border-top-left-radius: 0; border-top-right-radius: 0;
-    border-bottom-left-radius: var(--corner-r); border-bottom-right-radius: var(--corner-r);
-  }
-  .dashboard.layout-br .logo-col .logo-square:last-child,
-  .dashboard.layout-bl .logo-col .logo-square:last-child {
-    border-bottom-left-radius: 0; border-bottom-right-radius: 0;
-    border-top-left-radius: var(--corner-r); border-top-right-radius: var(--corner-r);
-  }
+  /* ── Vertical swap DISABLED ──
+     Previously reversed internal column order for bottom layouts.
+     Modules now keep the same orientation regardless of HUD position. */
   .dashboard::before {
     content: '';
     position: absolute;

--- a/racecor-overlay/modules/styles/leaderboard.css
+++ b/racecor-overlay/modules/styles/leaderboard.css
@@ -143,16 +143,24 @@
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    gap: 0;
     position: relative;
   }
   .pedal-labels-row {
     display: flex;
     gap: 6px;
     justify-content: space-around;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 6;
+    pointer-events: none;
+    padding: 3px 0;
   }
   .pedal-label-group {
     text-align: center;
+    text-shadow: 0 1px 4px rgba(0, 0, 0, 0.8);
   }
   .pedal-channel-label {
     font-size: var(--fs-xs);

--- a/racecor-overlay/modules/styles/pitbox.css
+++ b/racecor-overlay/modules/styles/pitbox.css
@@ -238,15 +238,15 @@
   .pb-adj-label {
     font-size: 14px;
     font-weight: 500;
-    color: hsla(0, 0%, 100%, 0.45);
+    color: hsla(0, 0%, 100%, 0.85);
   }
   .pb-adj-val {
     font-family: 'JetBrains Mono', monospace;
     font-size: 14px;
     font-weight: 600;
-    color: hsla(0, 0%, 100%, 0.8);
+    color: hsla(0, 0%, 100%, 1);
   }
-  .pb-adj-val.zero { color: hsla(0, 0%, 100%, 0.2); }
+  .pb-adj-val.zero { color: hsla(0, 0%, 100%, 0.3); }
 
   /* ── Info text ── */
   .pb-info {


### PR DESCRIPTION
## Summary

This PR addresses three key UX improvements to the overlay:

- **Windows taskbar reflow** — The overlay now listens for `display-metrics-changed` events to resize when the taskbar auto-hides or reappears, preventing layout shift
- **Remove vswap** — Modules maintain consistent orientation regardless of whether the HUD is positioned at the top or bottom of the screen
- **Adjustment styling** — Adjustment fonts are now white, and pedal histogram bars extend behind labels creating a layered visual effect