### PR TITLE
Dashboard UI polish: map, logos, fonts, game logo fix

### DIFF
--- a/racecor-overlay/dashboard.html
+++ b/racecor-overlay/dashboard.html
@@ -168,15 +168,15 @@
         <div class="pedal-labels-row">
           <div class="pedal-label-group">
             <div class="pedal-channel-label throttle">THROTTLE</div>
-            <div class="pedal-pct" style="color:var(--green);">0%</div>
+            <div class="pedal-pct" style="color:hsla(0,0%,100%,0.85);">0%</div>
           </div>
           <div class="pedal-label-group">
             <div class="pedal-channel-label brake">BRAKE</div>
-            <div class="pedal-pct" style="color:var(--red);">0%</div>
+            <div class="pedal-pct" style="color:hsla(0,0%,100%,0.85);">0%</div>
           </div>
           <div class="pedal-label-group" id="clutchLabelGroup">
             <div class="pedal-channel-label clutch">CLUTCH</div>
-            <div class="pedal-pct" style="color:var(--blue);">0%</div>
+            <div class="pedal-pct" style="color:hsla(0,0%,100%,0.85);">0%</div>
           </div>
         </div>
         <div class="pedal-viz-stack">
@@ -790,6 +790,8 @@
         <div class="settings-subtitle">Configure the overlay</div>
       </div>
       <button class="settings-popout-btn" id="settingsPopoutBtn" onclick="popoutSettings()" title="Open on secondary display">⧉</button>
+      <button class="settings-titlebar-btn" onclick="toggleSettings()" title="Close settings">✕</button>
+      <button class="settings-titlebar-btn settings-quit-btn" onclick="if(window.k10 &amp;&amp; window.k10.quitApp) window.k10.quitApp(); else window.close();" title="Quit RaceCor">⏻</button>
     </div>
 
     <div class="settings-conn-warn" id="settingsConnWarn">

--- a/racecor-overlay/main.js
+++ b/racecor-overlay/main.js
@@ -679,6 +679,11 @@ ipcMain.handle('restart-app', async () => {
   app.exit(0);
 });
 
+// ── IPC: Quit app ──
+ipcMain.handle('quit-app', () => {
+  app.quit();
+});
+
 // ── IPC: Open external URL in user's default browser ──
 ipcMain.handle('open-external', async (event, urlStr) => {
   try {

--- a/racecor-overlay/modules/js/config.js
+++ b/racecor-overlay/modules/js/config.js
@@ -415,27 +415,27 @@ const _demoModels = {
 const _defaultLogoBg = 'hsla(0, 0%, 12%, 1.0)';
 
 const _mfrBrandColors = {
-  bmw:         'hsla(204, 100%, 45%, 0.65)',
-  mclaren:     'hsla(24, 100%, 52%, 0.65)',
-  mazda:       'hsla(0, 90%, 44%, 0.65)',
-  nissan:      'hsla(0, 85%, 50%, 0.65)',
-  dallara:     'hsla(210, 85%, 48%, 0.65)',
-  ferrari:     'hsla(0, 90%, 48%, 0.65)',
-  porsche:     'hsla(0, 0%, 50%, 0.60)',
-  audi:        'hsla(0, 0%, 50%, 0.60)',
-  mercedes:    'hsla(175, 65%, 42%, 0.62)',
-  lamborghini: 'hsla(48, 90%, 48%, 0.62)',
-  chevrolet:   'hsla(40, 62%, 38%, 0.65)',
-  ford:        'hsla(237, 100%, 28%, 0.65)',
-  toyota:      'hsla(0, 85%, 48%, 0.65)',
-  hyundai:     'hsla(216, 85%, 45%, 0.65)',
-  cadillac:    'hsla(0, 0%, 50%, 0.60)',
-  astonmartin: 'hsla(155, 70%, 38%, 0.65)',
-  lotus:       'hsla(57, 100%, 50%, 0.65)',
-  ligier:      'hsla(204, 78%, 40%, 0.65)',
-  fia:         'hsla(228, 73%, 21%, 0.65)',
-  radical:     'hsla(43, 82%, 57%, 0.65)',
-  honda:       'hsla(0, 90%, 42%, 0.65)'
+  bmw:         'hsla(204, 100%, 45%, 0.55)',
+  mclaren:     'hsla(24, 100%, 52%, 0.55)',
+  mazda:       'hsla(0, 90%, 44%, 0.55)',
+  nissan:      'hsla(0, 85%, 50%, 0.55)',
+  dallara:     'hsla(210, 85%, 48%, 0.55)',
+  ferrari:     'hsla(0, 90%, 48%, 0.55)',
+  porsche:     'hsla(0, 0%, 50%, 0.50)',
+  audi:        'hsla(0, 0%, 50%, 0.50)',
+  mercedes:    'hsla(175, 65%, 42%, 0.52)',
+  lamborghini: 'hsla(48, 90%, 48%, 0.52)',
+  chevrolet:   'hsla(40, 62%, 38%, 0.55)',
+  ford:        'hsla(237, 100%, 28%, 0.55)',
+  toyota:      'hsla(0, 85%, 48%, 0.55)',
+  hyundai:     'hsla(216, 85%, 45%, 0.55)',
+  cadillac:    'hsla(0, 0%, 50%, 0.50)',
+  astonmartin: 'hsla(155, 70%, 38%, 0.55)',
+  lotus:       'hsla(57, 100%, 50%, 0.55)',
+  ligier:      'hsla(204, 78%, 40%, 0.55)',
+  fia:         'hsla(228, 73%, 21%, 0.55)',
+  radical:     'hsla(43, 82%, 57%, 0.55)',
+  honda:       'hsla(0, 90%, 42%, 0.55)'
 };
 
 // Manufacturer → ISO 3166-1 alpha-2 country code (used for flag display)

--- a/racecor-overlay/modules/js/game-logo.js
+++ b/racecor-overlay/modules/js/game-logo.js
@@ -19,13 +19,13 @@
   };
 
   // Logo-corner mapping: dashboard position → logo position
-  // Logo goes on the same vertical edge as the dashboard but on the
-  // opposite horizontal side — keeps it aligned with main modules.
+  // Logo goes on the opposite vertical edge AND opposite horizontal side
+  // to avoid overlap with the dashboard.
   var OPPOSITE_CORNER = {
-    'top-right':       'top-left',
-    'top-left':        'top-right',
-    'bottom-right':    'bottom-left',
-    'bottom-left':     'bottom-right',
+    'top-right':       'bottom-left',
+    'top-left':        'bottom-right',
+    'bottom-right':    'top-left',
+    'bottom-left':     'top-right',
     'absolute-center': 'bottom-left'
   };
 
@@ -42,7 +42,7 @@
     _logoEl = document.createElement('div');
     _logoEl.id = 'gameLogoOverlay';
     _logoEl.style.cssText =
-      'position:fixed;z-index:50;width:250px;pointer-events:none;' +
+      'position:fixed;z-index:50;width:180px;pointer-events:none;' +
       'opacity:0;transition:opacity 0.4s ease;' +
       'display:flex;align-items:center;justify-content:center;';
     document.body.appendChild(_logoEl);

--- a/racecor-overlay/modules/styles/base.css
+++ b/racecor-overlay/modules/styles/base.css
@@ -31,10 +31,10 @@
     --ff-display: 'Cinzel Decorative', 'Georgia', serif;
     --ff-mono: 'JetBrains Mono', 'Consolas', 'SF Mono', monospace;
     --fs-xl: 20px;
-    --fs-lg: 14px;
-    --fs-md: 14px;
-    --fs-sm: 14px;
-    --fs-xs: 14px;
+    --fs-lg: 13px;
+    --fs-md: 11px;
+    --fs-sm: 11px;
+    --fs-xs: 10px;
     --fw-black: 800;
     --fw-bold: 700;
     --fw-semi: 600;

--- a/racecor-overlay/modules/styles/connections.css
+++ b/racecor-overlay/modules/styles/connections.css
@@ -27,7 +27,7 @@
   .conn-card-icon.discord { background: hsla(235, 86%, 65%, 0.2); }
   .conn-card-icon svg { width: 18px; height: 18px; }
   .conn-card-title {
-    font-family: var(--ff-display);
+    font-family: var(--ff);
     font-size: 14px;
     font-weight: 700;
     color: hsla(0,0%,100%,0.9);

--- a/racecor-overlay/modules/styles/dashboard.css
+++ b/racecor-overlay/modules/styles/dashboard.css
@@ -87,7 +87,7 @@
     border-bottom-right-radius: var(--corner-r);
   }
   .panel-label {
-    font-family: var(--ff-display);
+    font-family: var(--ff);
     font-size: var(--fs-xs);
     font-weight: 700;
     text-transform: uppercase;
@@ -171,7 +171,7 @@
   }
 
   .commentary-title {
-    font-family: var(--ff-display);
+    font-family: var(--ff);
     font-size: 20px;
     font-weight: 700;
     line-height: 1.0;
@@ -412,7 +412,7 @@
     border-bottom-right-radius: var(--corner-r);
   }
   .logo-square img {
-    width: 56px;
+    width: 70%;
     height: auto;
     opacity: 1;
   }
@@ -429,8 +429,8 @@
     flex-shrink: 0;
   }
   .car-logo-icon svg {
-    width: 44px;
-    height: 44px;
+    width: 64px;
+    height: 64px;
     opacity: 0.96;
   }
   .car-model-label {
@@ -1230,6 +1230,7 @@
     gap: var(--gap);
     flex-shrink: 0;
     width: 96px;
+    justify-content: flex-start;
   }
   .map-panel {
     flex: 1;
@@ -1238,6 +1239,12 @@
     align-items: center;
     justify-content: center;
     position: relative;
+  }
+  .map-panel:first-child {
+    flex: 2;
+  }
+  .map-panel:last-child {
+    flex: 1;
   }
   .map-svg { width: 92%; height: 92%; }
   /* Track outline — three-layer rendering: thick outer edges, dark gap, thin center line */

--- a/racecor-overlay/modules/styles/datastream.css
+++ b/racecor-overlay/modules/styles/datastream.css
@@ -35,7 +35,7 @@
     position: relative;
   }
   .ds-header {
-    font-family: var(--ff-display);
+    font-family: var(--ff);
     font-size: 14px;
     font-weight: 700;
     text-transform: uppercase;

--- a/racecor-overlay/modules/styles/effects.css
+++ b/racecor-overlay/modules/styles/effects.css
@@ -82,7 +82,7 @@
     z-index: 1;
   }
   .rc-title {
-    font-family: var(--ff-display);
+    font-family: var(--ff);
     font-size: 28px;
     font-weight: 700;
     text-transform: uppercase;
@@ -588,7 +588,7 @@
   .re-tint-neutral .re-position { color: var(--text-primary); opacity: 0.8; }
 
   .re-title {
-    font-family: var(--ff-display);
+    font-family: var(--ff);
     font-size: 32px;
     font-weight: 700;
     text-transform: uppercase;
@@ -758,7 +758,7 @@
   .sp-inner.sp-danger .sp-icon { color: hsl(0, 70%, 65%); }
   .sp-inner.sp-clear .sp-icon { color: hsl(145, 60%, 60%); }
   .sp-header {
-    font-family: var(--ff-display);
+    font-family: var(--ff);
     font-size: 14px;
     font-weight: 700;
     text-transform: uppercase;
@@ -850,7 +850,7 @@
     position: absolute;
   }
   .grid-title {
-    font-family: var(--ff-display);
+    font-family: var(--ff);
     font-size: 14px;
     font-weight: 700;
     text-transform: uppercase;

--- a/racecor-overlay/modules/styles/leaderboard.css
+++ b/racecor-overlay/modules/styles/leaderboard.css
@@ -168,9 +168,9 @@
     text-transform: uppercase;
     letter-spacing: 0.06em;
   }
-  .pedal-channel-label.throttle { color: var(--green); }
-  .pedal-channel-label.brake { color: var(--red); }
-  .pedal-channel-label.clutch { color: var(--blue); }
+  .pedal-channel-label.throttle { color: hsla(0, 0%, 100%, 0.9); }
+  .pedal-channel-label.brake { color: hsla(0, 0%, 100%, 0.9); }
+  .pedal-channel-label.clutch { color: hsla(0, 0%, 100%, 0.9); }
   .pedal-pct {
     font-size: var(--fs-xs);
     font-weight: var(--fw-bold);
@@ -370,7 +370,7 @@
     overflow: hidden;
   }
   .lb-header {
-    font-family: var(--ff-display);
+    font-family: var(--ff);
     font-size: 14px;
     font-weight: 700;
     text-transform: uppercase;

--- a/racecor-overlay/modules/styles/settings.css
+++ b/racecor-overlay/modules/styles/settings.css
@@ -194,7 +194,7 @@
     color: #e8e8f0;
   }
   .dp-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
-  .dp-title { font-family: var(--ff-display); font-size: 24px; font-weight: 700; }
+  .dp-title { font-family: var(--ff); font-size: 24px; font-weight: 700; }
   .dp-close {
     width: 36px; height: 36px; border: none; border-radius: 8px;
     background: hsla(0,0%,100%,0.06); color: hsla(0,0%,100%,0.5);
@@ -228,7 +228,7 @@
 
   .dp-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
   .dp-section-title {
-    font-family: var(--ff-display); font-size: 14px; font-weight: 700; text-transform: uppercase;
+    font-family: var(--ff); font-size: 14px; font-weight: 700; text-transform: uppercase;
     letter-spacing: 0.1em; color: hsla(0,0%,100%,0.4); margin-bottom: 8px;
   }
   .dp-chart { width: 100%; border-radius: 8px; background: hsla(0,0%,100%,0.02); }
@@ -418,6 +418,29 @@
   }
   /* Hide popout button when already in popout window */
   body.settings-popout .settings-popout-btn { display: none; }
+  .settings-titlebar-btn {
+    background: hsla(0,0%,100%,0.06);
+    border: 1px solid hsla(0,0%,100%,0.1);
+    border-radius: 6px;
+    color: hsla(0,0%,100%,0.5);
+    font-size: 14px;
+    width: 30px;
+    height: 30px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    transition: background 0.15s, color 0.15s;
+  }
+  .settings-titlebar-btn:hover {
+    background: hsla(0,0%,100%,0.12);
+    color: hsla(0,0%,100%,0.8);
+  }
+  .settings-quit-btn:hover {
+    background: hsla(0, 70%, 45%, 0.3);
+    color: hsla(0, 80%, 70%, 1);
+  }
   .settings-titlebar-logo {
     display: flex;
     align-items: center;

--- a/racecor-overlay/preload.js
+++ b/racecor-overlay/preload.js
@@ -74,4 +74,6 @@ contextBridge.exposeInMainWorld('k10', {
   },
   // Ambient light — screen capture moved to C# plugin (ScreenColorSampler).
   // Color data now arrives via poll JSON (DS.AmbientR/G/B), no IPC needed.
+  // Quit application
+  quitApp: () => ipcRenderer.invoke('quit-app'),
 });


### PR DESCRIPTION
## Summary
- Reposition global map higher (flex 2:1 ratio) with zoom map below
- Enlarge manufacturer logos (44→64px) with 10% softer brand color backgrounds
- White text on pedal histogram labels and percentages
- Remove Cinzel Decorative from all HUD elements (kept only in settings header)
- Restore small font sizes (13/11/11/10px); settings panel unaffected
- Add Close (✕) and Quit (⏻) buttons to settings titlebar with full IPC wiring
- Fix game logo overlap by placing in diagonally opposite corner; reduce width 250→180px

## Test plan
- [ ] Verify map panel takes 2/3 of maps column, zoom map 1/3
- [ ] Confirm manufacturer logos are larger and brand backgrounds are subtler
- [ ] Check pedal histogram labels are white
- [ ] Verify Cinzel Decorative only appears in settings title
- [ ] Confirm font sizes are smaller across HUD panels
- [ ] Test Close button dismisses settings overlay
- [ ] Test Quit button exits the Electron app
- [ ] Verify game logo appears in diagonal opposite corner for all layout positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)