### PR TITLE
Dashboard fixes: leaderboard modes, fuel/tires, strategy, branding, Moza

### DIFF
--- a/racecor-overlay/dashboard.html
+++ b/racecor-overlay/dashboard.html
@@ -909,6 +909,16 @@
       <div class="settings-two-col">
       <div class="settings-row"><span class="settings-label">K10 Logo</span><div class="settings-toggle on" data-section="k10LogoSquare" data-key="showK10Logo" onclick="toggleSetting(this)"></div></div>
       <div class="settings-row"><span class="settings-label">Car Manufacturer</span><div class="settings-toggle on" data-section="carLogoSquare" data-key="showCarLogo" onclick="toggleSetting(this)"></div></div>
+      <div class="settings-group-label">Customization</div>
+      <div class="settings-row" data-pro-feature="branding">
+        <span class="settings-label">Custom Logo</span>
+        <button class="settings-btn" id="customLogoBtn" onclick="selectCustomLogo()">Choose Image</button>
+      </div>
+      <div class="settings-row" data-pro-feature="branding">
+        <span class="settings-label">Logo Subtitle</span>
+        <input type="text" class="settings-input" id="logoSubtitleInput" placeholder="K10 Motorsports" maxlength="30" oninput="updateLogoSubtitle(this.value)">
+      </div>
+      <div class="settings-hint">When not connected, shows "K10 Motorsports" by default</div>
       <div class="settings-row"><span class="settings-label">Game Logo</span><div class="settings-toggle on" data-key="showGameLogo" onclick="toggleGameLogo(this)"></div></div>
       <div class="settings-row"><span class="settings-label">WebGL Effects</span><div class="settings-toggle on" data-key="showWebGL" data-pro-feature="webgl" onclick="toggleWebGL(this)"></div></div>
       <div class="settings-row"><span class="settings-label">Ambient Light</span>
@@ -1188,13 +1198,14 @@
         </div>
       </div>
 
-      <div class="settings-group-label">Moza Pithouse</div>
+      <div class="settings-group-label">Moza Pit House</div>
       <div class="settings-row">
         <span class="settings-label" id="mozaStatusLabel">Detecting...</span>
         <button class="settings-btn" id="mozaImportBtn" onclick="importMozaPedals()" disabled>Import from Moza</button>
       </div>
+      <div class="settings-row"><span class="settings-label">Moza Folder</span><button class="settings-btn" id="mozaBrowseBtn" onclick="browseMozaFolder()">Browse Folder</button></div>
       <div class="settings-info-text" id="mozaInfoText">
-        Moza Pithouse integration lets you save pedal curves per car and auto-load them when you switch cars.
+        Moza Pit House integration lets you save pedal curves per car and auto-load them when you switch cars.
       </div>
 
       <div class="settings-group-label">Debug</div>

--- a/racecor-overlay/main.js
+++ b/racecor-overlay/main.js
@@ -668,6 +668,16 @@ ipcMain.handle('get-green-screen-mode', async () => {
   return greenScreenMode;
 });
 
+// ── IPC: Folder dialog for file browser ──
+ipcMain.handle('open-folder-dialog', async (event, title) => {
+  const { dialog } = require('electron');
+  const result = await dialog.showOpenDialog(overlayWindow, {
+    title: title || 'Select Folder',
+    properties: ['openDirectory']
+  });
+  return result.canceled ? null : result.filePaths[0];
+});
+
 // ── IPC: Dashboard mode query (legacy, returns 'build') ──
 ipcMain.handle('get-dashboard-mode', async () => {
   return 'build';

--- a/racecor-overlay/modules/js/leaderboard.js
+++ b/racecor-overlay/modules/js/leaderboard.js
@@ -74,6 +74,16 @@
       maxRows = calculatedMaxRows;
     }
 
+    // Apply expand-to-fill height to container
+    const lbPanel = document.getElementById('leaderboardPanel');
+    if (lbPanel) {
+      if (expandToFill) {
+        lbPanel.style.maxHeight = 'none';
+      } else {
+        lbPanel.style.maxHeight = '';
+      }
+    }
+
     // Entry format: [pos, name, irating, bestLap, lastLap, gapToPlayer, inPit, isPlayer]
     // Find player index and session best
     let playerIdx = -1;
@@ -122,18 +132,36 @@
       }
       if (pit) classes.push('lb-pit');
 
-      // Gap display
+      // Gap display — mode-dependent
       let gapStr = '', gapClass = 'gap-player';
-      if (isPlayer) {
-        gapStr = '';
-      } else if (gap < 0) {
-        gapStr = '-' + Math.abs(gap).toFixed(1) + 's';
-        gapClass = 'gap-ahead';
-      } else if (gap > 0) {
-        gapStr = '+' + gap.toFixed(1) + 's';
-        gapClass = 'gap-behind';
+      if (focusMode === 'lead') {
+        // Gap to leader mode
+        if (pos === 1) {
+          gapStr = '';  // leader shows no gap
+        } else {
+          const leaderEntry = raw.find(e => e[0] === 1);
+          const leaderGap = leaderEntry ? leaderEntry[5] : 0;
+          const gapToLeader = gap - leaderGap;
+          if (gapToLeader > 0) {
+            gapStr = '+' + gapToLeader.toFixed(1) + 's';
+            gapClass = 'gap-behind';
+          } else {
+            gapStr = '';
+          }
+        }
       } else {
-        gapStr = '';
+        // Relative to player mode (existing logic)
+        if (isPlayer) {
+          gapStr = '';
+        } else if (gap < 0) {
+          gapStr = '-' + Math.abs(gap).toFixed(1) + 's';
+          gapClass = 'gap-ahead';
+        } else if (gap > 0) {
+          gapStr = '+' + gap.toFixed(1) + 's';
+          gapClass = 'gap-behind';
+        } else {
+          gapStr = '';
+        }
       }
 
       // iRating shorthand

--- a/racecor-overlay/modules/js/pedal-curves.js
+++ b/racecor-overlay/modules/js/pedal-curves.js
@@ -466,6 +466,38 @@ function importMozaPedals() {
   }).catch(function () {});
 }
 
+function browseMozaFolder() {
+  // Use Electron file dialog if available, otherwise prompt for path
+  if (window.k10 && window.k10.openFolderDialog) {
+    window.k10.openFolderDialog('Select Moza Pit House folder').then(function(folderPath) {
+      if (!folderPath) return;
+      importMozaFromPath(folderPath);
+    });
+  } else {
+    // Fallback: prompt for path
+    var path = prompt('Enter the path to your MOZA Pit House folder:');
+    if (path) importMozaFromPath(path);
+  }
+}
+
+function importMozaFromPath(folderPath) {
+  var url = (window._simhubUrlOverride || SIMHUB_URL) + '?action=importMozaPedals&path=' + encodeURIComponent(folderPath);
+  fetch(url).then(function(r) { return r.json(); })
+    .then(function(result) {
+      if (result.ok) {
+        loadPedalProfiles();
+        var btn = document.getElementById('mozaBrowseBtn');
+        if (btn) { btn.textContent = 'Imported!'; setTimeout(function() { btn.textContent = 'Browse Folder'; }, 3000); }
+      } else {
+        var btn = document.getElementById('mozaBrowseBtn');
+        if (btn) { btn.textContent = 'Not found'; setTimeout(function() { btn.textContent = 'Browse Folder'; }, 3000); }
+      }
+    }).catch(function() {
+      var btn = document.getElementById('mozaBrowseBtn');
+      if (btn) { btn.textContent = 'Error'; setTimeout(function() { btn.textContent = 'Browse Folder'; }, 3000); }
+    });
+}
+
 // Detect Moza status and update UI when the Pedals tab loads
 function updatePedalSettingsUI() {
   var profile = window.getCurrentPedalProfile ? window.getCurrentPedalProfile() : null;

--- a/racecor-overlay/modules/js/poll-engine.js
+++ b/racecor-overlay/modules/js/poll-engine.js
@@ -238,7 +238,7 @@
     });
 
     // ─── Fuel — bar shows current fuel vs full tank capacity ───
-    const fuel = +d('DataCorePlugin.GameData.Fuel', 'Demo.Fuel') || 0;
+    const fuel = +d('DataCorePlugin.GameData.Fuel', 'Demo.Fuel') || +v('DataCorePlugin.GameRawData.Telemetry.FuelLevel') || 0;
     const maxFuel = +d('DataCorePlugin.GameData.MaxFuel', 'Demo.MaxFuel') || 0;
     // Bar percentage: current fuel / full tank capacity (not starting fuel)
     const fuelPct = maxFuel > 0 ? (fuel / maxFuel) * 100 : 0;
@@ -284,10 +284,26 @@
       updateTyreCell(2, +v('K10Motorsports.Plugin.Demo.TyreTempRL'), (1 - (+v('K10Motorsports.Plugin.Demo.TyreWearRL') || 0)) * 100);
       updateTyreCell(3, +v('K10Motorsports.Plugin.Demo.TyreTempRR'), (1 - (+v('K10Motorsports.Plugin.Demo.TyreWearRR') || 0)) * 100);
     } else {
-      updateTyreCell(0, +v('DataCorePlugin.GameData.TyreTempFrontLeft'), (p['DataCorePlugin.GameData.TyreWearFrontLeft'] != null ? (1 - +p['DataCorePlugin.GameData.TyreWearFrontLeft']) * 100 : -1));
-      updateTyreCell(1, +v('DataCorePlugin.GameData.TyreTempFrontRight'), (p['DataCorePlugin.GameData.TyreWearFrontRight'] != null ? (1 - +p['DataCorePlugin.GameData.TyreWearFrontRight']) * 100 : -1));
-      updateTyreCell(2, +v('DataCorePlugin.GameData.TyreTempRearLeft'), (p['DataCorePlugin.GameData.TyreWearRearLeft'] != null ? (1 - +p['DataCorePlugin.GameData.TyreWearRearLeft']) * 100 : -1));
-      updateTyreCell(3, +v('DataCorePlugin.GameData.TyreTempRearRight'), (p['DataCorePlugin.GameData.TyreWearRearRight'] != null ? (1 - +p['DataCorePlugin.GameData.TyreWearRearRight']) * 100 : -1));
+      // Temps — try game data first, fall back to raw telemetry
+      const tFL = +v('DataCorePlugin.GameData.TyreTempFrontLeft') || +v('DataCorePlugin.GameRawData.Telemetry.LFtempCL') || 0;
+      const tFR = +v('DataCorePlugin.GameData.TyreTempFrontRight') || +v('DataCorePlugin.GameRawData.Telemetry.RFtempCL') || 0;
+      const tRL = +v('DataCorePlugin.GameData.TyreTempRearLeft') || +v('DataCorePlugin.GameRawData.Telemetry.LRtempCL') || 0;
+      const tRR = +v('DataCorePlugin.GameData.TyreTempRearRight') || +v('DataCorePlugin.GameRawData.Telemetry.RRtempCL') || 0;
+
+      // Wear — try game data first, fall back to iRacing raw telemetry
+      const wFL = p['DataCorePlugin.GameData.TyreWearFrontLeft'] != null ? +p['DataCorePlugin.GameData.TyreWearFrontLeft']
+                : (p['DataCorePlugin.GameRawData.Telemetry.LFwearL'] != null ? (+p['DataCorePlugin.GameRawData.Telemetry.LFwearL'] + +p['DataCorePlugin.GameRawData.Telemetry.LFwearM'] + +p['DataCorePlugin.GameRawData.Telemetry.LFwearR']) / 3 : null);
+      const wFR = p['DataCorePlugin.GameData.TyreWearFrontRight'] != null ? +p['DataCorePlugin.GameData.TyreWearFrontRight']
+                : (p['DataCorePlugin.GameRawData.Telemetry.RFwearL'] != null ? (+p['DataCorePlugin.GameRawData.Telemetry.RFwearL'] + +p['DataCorePlugin.GameRawData.Telemetry.RFwearM'] + +p['DataCorePlugin.GameRawData.Telemetry.RFwearR']) / 3 : null);
+      const wRL = p['DataCorePlugin.GameData.TyreWearRearLeft'] != null ? +p['DataCorePlugin.GameData.TyreWearRearLeft']
+                : (p['DataCorePlugin.GameRawData.Telemetry.LRwearL'] != null ? (+p['DataCorePlugin.GameRawData.Telemetry.LRwearL'] + +p['DataCorePlugin.GameRawData.Telemetry.LRwearM'] + +p['DataCorePlugin.GameRawData.Telemetry.LRwearR']) / 3 : null);
+      const wRR = p['DataCorePlugin.GameData.TyreWearRearRight'] != null ? +p['DataCorePlugin.GameData.TyreWearRearRight']
+                : (p['DataCorePlugin.GameRawData.Telemetry.RRwearL'] != null ? (+p['DataCorePlugin.GameRawData.Telemetry.RRwearL'] + +p['DataCorePlugin.GameRawData.Telemetry.RRwearM'] + +p['DataCorePlugin.GameRawData.Telemetry.RRwearR']) / 3 : null);
+
+      updateTyreCell(0, tFL, wFL != null ? (1 - wFL) * 100 : -1);
+      updateTyreCell(1, tFR, wFR != null ? (1 - wFR) * 100 : -1);
+      updateTyreCell(2, tRL, wRL != null ? (1 - wRL) * 100 : -1);
+      updateTyreCell(3, tRR, wRR != null ? (1 - wRR) * 100 : -1);
     }
 
     // ─── Controls (BB / TC / ABS) ───

--- a/racecor-overlay/modules/js/settings.js
+++ b/racecor-overlay/modules/js/settings.js
@@ -99,6 +99,12 @@
     // Datastream field toggles
     applyDsFieldToggles();
 
+    // Custom logo + subtitle
+    if (typeof applyCustomLogo === 'function') applyCustomLogo();
+    if (typeof applyLogoSubtitle === 'function') applyLogoSubtitle();
+    const subtitleInput = document.getElementById('logoSubtitleInput');
+    if (subtitleInput) subtitleInput.value = _settings.logoSubtitle || '';
+
     // Logo-only startup: apply body class so CSS hides everything except logos
     if (_settings.logoOnlyStart !== false) {
       document.body.classList.add('logo-only');
@@ -185,6 +191,69 @@
     _settings.lbExpandToFill = !isOn;
     _lbLastJson = '';
     saveSettings();
+  }
+
+  // ── Custom Logo + Subtitle ──
+  function selectCustomLogo() {
+    // Use file input to pick an image
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'image/*';
+    input.onchange = function(e) {
+      const file = e.target.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = function(ev) {
+        _settings.customLogo = ev.target.result;
+        applyCustomLogo();
+        saveSettings();
+        const btn = document.getElementById('customLogoBtn');
+        if (btn) { btn.textContent = 'Updated!'; setTimeout(function() { btn.textContent = 'Choose Image'; }, 2000); }
+      };
+      reader.readAsDataURL(file);
+    };
+    input.click();
+  }
+
+  function applyCustomLogo() {
+    const sq = document.getElementById('k10LogoSquare');
+    if (!sq) return;
+    const img = sq.querySelector('img');
+    if (_settings.customLogo && img) {
+      img.src = _settings.customLogo;
+    } else if (img) {
+      img.src = 'images/branding/logomark.png';
+    }
+  }
+
+  function updateLogoSubtitle(value) {
+    _settings.logoSubtitle = value;
+    applyLogoSubtitle();
+    saveSettings();
+  }
+
+  function applyLogoSubtitle() {
+    let label = document.getElementById('k10SubtitleLabel');
+    if (!label) {
+      // Create subtitle label element under the K10 logo square
+      const sq = document.getElementById('k10LogoSquare');
+      if (!sq) return;
+      label = document.createElement('span');
+      label.id = 'k10SubtitleLabel';
+      label.className = 'car-model-label';
+      label.style.position = 'relative';
+      label.style.zIndex = '2';
+      sq.appendChild(label);
+    }
+    const connected = window._k10ProUser || window._discordUser;
+    if (connected) {
+      label.textContent = _settings.logoSubtitle || '';
+    } else {
+      label.textContent = '';
+      // Show disabled input placeholder
+      const input = document.getElementById('logoSubtitleInput');
+      if (input) { input.disabled = true; input.placeholder = 'K10 Motorsports'; }
+    }
   }
 
   // ── Datastream field toggles ──

--- a/racecor-overlay/preload.js
+++ b/racecor-overlay/preload.js
@@ -74,6 +74,8 @@ contextBridge.exposeInMainWorld('k10', {
   },
   // Ambient light — screen capture moved to C# plugin (ScreenColorSampler).
   // Color data now arrives via poll JSON (DS.AmbientR/G/B), no IPC needed.
+  // Folder dialog for file browser
+  openFolderDialog: (title) => ipcRenderer.invoke('open-folder-dialog', title),
   // Quit application
   quitApp: () => ipcRenderer.invoke('quit-app'),
 });

--- a/racecor-plugin/simhub-plugin/plugin/K10Motorsports.Plugin/Engine/Strategy/TireTracker.cs
+++ b/racecor-plugin/simhub-plugin/plugin/K10Motorsports.Plugin/Engine/Strategy/TireTracker.cs
@@ -208,8 +208,13 @@ namespace K10Motorsports.Plugin.Engine.Strategy
         {
             var now = DateTime.UtcNow;
 
+            // ── Minimum stint age — suppress early-stint noise ────────────
+            // Wear data stabilizes after a few laps; don't fire calls before then
+            int stintLaps = stint?.WearPerLap?.Count ?? 0;
+            bool earlyStint = stintLaps < 4;
+
             // ── Critical wear ───────────────────────────────────────────
-            if (TireHealthState == 2 && (now - _lastWearCall).TotalSeconds >= WearCooldownSec)
+            if (TireHealthState == 2 && !earlyStint && (now - _lastWearCall).TotalSeconds >= WearCooldownSec)
             {
                 _lastWearCall = now;
                 string worst = WorstTireLabel();
@@ -228,7 +233,7 @@ namespace K10Motorsports.Plugin.Engine.Strategy
             }
 
             // ── Warning wear ────────────────────────────────────────────
-            if (TireHealthState == 1 && EstimatedLapsRemaining < 10
+            if (TireHealthState == 1 && !earlyStint && EstimatedLapsRemaining < 10
                 && (now - _lastWearCall).TotalSeconds >= WearCooldownSec)
             {
                 _lastWearCall = now;


### PR DESCRIPTION
## Summary
- **Leaderboard**: auto-switch gap display — relative gaps on "Focus on Me", gap-to-leader on "Focus on Lead". Fix expand-to-fill height constraint.
- **Fuel/Tire graphics**: iRacing raw telemetry fallbacks for fuel level, tire temps (center temp), and tire wear (averaged L/M/R). Fixes blank displays when SimHub normalized fields unavailable.
- **Strategy**: suppress critical/warning tire calls during first 4 laps of a stint to prevent false "critical after 1-2 laps" alerts.
- **Pro branding**: custom logo upload (file picker → base64) and subtitle text field, gated behind pro features. Default "K10 Motorsports" when disconnected.
- **Moza import**: "Browse Folder" button with Electron folder dialog IPC for manual MOZA Pit House path selection.

## Test plan
- [ ] Leaderboard "Focus on Me" → gaps relative to player
- [ ] Leaderboard "Focus on Lead" → gaps relative to P1
- [ ] "Expand to Fill" toggle and "Opponents" count work
- [ ] iRacing fuel bar fills, tire temps/wear show
- [ ] No false "critical tire" call in first 1-3 laps
- [ ] Custom logo upload in Branding settings works
- [ ] Subtitle text appears under K10 logo
- [ ] "Browse Folder" opens Electron folder dialog for Moza

🤖 Generated with [Claude Code](https://claude.com/claude-code)