### PR TITLE
Tune race start lights — rolling skips reds, standing faster

### DIFF
--- a/racecor-overlay/modules/js/formation.js
+++ b/racecor-overlay/modules/js/formation.js
@@ -34,13 +34,14 @@
     if (!mod || !info || !lights) return;
 
     // Detect transition from ParadeLaps (3) to Racing (4): this is when lights should show.
-    // If plugin doesn't send LightsPhase, we generate a synthetic green sequence
-    // and hold it for 3 seconds so it's actually visible.
+    // If plugin doesn't send LightsPhase, we generate a synthetic green sequence.
+    // Rolling starts: instant green flash with 5s hold (no reds).
+    // Standing starts: synthetic green with 5s hold (reds come from plugin).
     const transitioningToRace = _gridPrevSessionState >= 1 && _gridPrevSessionState <= 3 && sessionState === 4;
     if (transitioningToRace && lightsPhase === 0 && _simLightsPhase === 0) {
       _simLightsPhase = 7;
       clearTimeout(_simLightsTimer);
-      _simLightsTimer = setTimeout(() => { _simLightsPhase = 0; }, 3000);
+      _simLightsTimer = setTimeout(() => { _simLightsPhase = 0; }, 5000);
     }
     // Use synthetic phase when plugin isn't sending one
     if (lightsPhase === 0 && _simLightsPhase > 0) lightsPhase = _simLightsPhase;
@@ -60,8 +61,8 @@
       _gridActive = false;
       if (window.setGridFlagGL) window.setGridFlagGL(false);
       clearTimeout(_gridFadeTimer);
-      // Extend fade timer from 4s to 6s to allow lights to fully display during race start transition
-      const fadeDelay = transitioningToRace ? 6000 : 4000;
+      // Extend fade timer to allow lights (especially green flash) to fully display during race start
+      const fadeDelay = transitioningToRace ? 8000 : 4000;
       _gridFadeTimer = setTimeout(() => {
         mod.classList.remove('grid-fadeout');
         // Reset lights
@@ -73,6 +74,16 @@
     }
 
     if (!shouldShow) return;
+
+    // Cancel any pending fadeout if lights just became active (e.g. green flash arrived late)
+    if (isLightsActive && mod.classList.contains('grid-fadeout')) {
+      clearTimeout(_gridFadeTimer);
+      mod.classList.remove('grid-fadeout');
+      mod.classList.add('grid-visible');
+      _gridActive = true;
+      document.body.classList.add('grid-active');
+      if (window.setGridFlagGL) window.setGridFlagGL(true);
+    }
 
     // Show the module
     if (!_gridActive) {

--- a/racecor-plugin/simhub-plugin/plugin/K10Motorsports.Plugin/Plugin.cs
+++ b/racecor-plugin/simhub-plugin/plugin/K10Motorsports.Plugin/Plugin.cs
@@ -535,19 +535,31 @@ namespace K10Motorsports.Plugin
 
         /// <summary>
         /// Synthesize F1-style start lights from iRacing PaceMode / SessionState.
-        /// Rolling start: PaceMode 2 (Approaching) → build reds, PaceMode 3 (CrossSF) → all red hold,
-        /// SessionState 3→4 transition → green. Called every eval cycle (~100ms).
+        /// Standing start: build reds 1-5, all-red hold, then green on SessionState 3→4.
+        /// Rolling start:  skip reds entirely — just flash green GO! on SessionState 3→4.
+        /// Called every eval cycle (~100ms).
         /// </summary>
         private void UpdateLightsPhase()
         {
             int ss = _current.SessionState;
             int pm = _current.PaceMode;
+            bool isStanding = _current.IsStandingStart;
 
-            // Green flag: session just went to Racing (4) from formation (3)
-            if (ss == 4 && _lightsPrevSessionState == 3 && _lightsPhase >= 1 && _lightsPhase <= 6)
+            // ── Green flag: session just went to Racing (4) from formation (3) ──
+            if (ss == 4 && _lightsPrevSessionState == 3)
             {
-                _lightsPhase = 7; // GREEN!
-                _lightsHoldFrames = 15; // hold green ~1.5s
+                // If reds were building or holding (standing start), fire green
+                if (_lightsPhase >= 1 && _lightsPhase <= 6)
+                {
+                    _lightsPhase = 7; // GREEN!
+                    _lightsHoldFrames = isStanding ? 30 : 50; // standing ~3s, rolling ~5s
+                }
+                // Rolling start with no prior lights — instant green flash
+                else if (_lightsPhase == 0 && !isStanding)
+                {
+                    _lightsPhase = 7;
+                    _lightsHoldFrames = 50; // hold green ~5s so driver sees it
+                }
             }
             // Green hold → done
             else if (_lightsPhase == 7)
@@ -561,56 +573,57 @@ namespace K10Motorsports.Plugin
                 _lightsHoldFrames--;
                 if (_lightsHoldFrames <= -10) _lightsPhase = 0;
             }
-            // All red hold — waiting for green
+            // All red hold — waiting for green (standing starts only)
             else if (_lightsPhase == 6)
             {
                 // Just hold until green flag (handled above)
             }
-            // Building reds 1-5
+            // Building reds 1-5 (standing starts only)
             else if (_lightsPhase >= 1 && _lightsPhase < 6)
             {
                 _lightsStepFrame--;
                 if (_lightsStepFrame <= 0)
                 {
                     _lightsPhase++;
-                    _lightsStepFrame = 8; // ~0.8s per light column
+                    _lightsStepFrame = 4; // ~0.4s per light column (faster build)
                 }
             }
             // Not active — detect start condition
             else if (_lightsPhase == 0)
             {
-                // PaceMode transitions to 2+ during formation (SS 3)
-                bool pmTransition = ss == 3 && pm >= 2 && _lightsPrevPaceMode < 2;
-                // SessionState transitions to 3 while PaceMode already >= 2
-                // (rolling starts: PM can already be 2 when SS goes to 3)
-                bool ssTransition = ss == 3 && _lightsPrevSessionState != 3 && pm >= 2;
-
-                if (pmTransition || ssTransition)
+                if (isStanding)
                 {
-                    if (pm == 3)
-                        _lightsPhase = 6; // jump to all red
-                    else
+                    // ── Standing start: build red lights ──
+                    bool pmTransition = ss == 3 && pm >= 2 && _lightsPrevPaceMode < 2;
+                    bool ssTransition = ss == 3 && _lightsPrevSessionState != 3 && pm >= 2;
+
+                    if (pmTransition || ssTransition)
                     {
-                        _lightsPhase = 1;
-                        _lightsStepFrame = 8;
+                        if (pm == 3)
+                            _lightsPhase = 6; // jump to all red
+                        else
+                        {
+                            _lightsPhase = 1;
+                            _lightsStepFrame = 4; // ~0.4s per column
+                        }
+                    }
+                    else if (ss == 3 && pm == 3 && _lightsPrevPaceMode < 3)
+                    {
+                        _lightsPhase = 6; // jump to all red
+                    }
+                    else if (ss == 3 && pm >= 3 && _lightsPrevPaceMode >= 3)
+                    {
+                        _lightsPhase = 6;
                     }
                 }
-                // If we somehow get PaceMode 3 directly
-                else if (ss == 3 && pm == 3 && _lightsPrevPaceMode < 3)
-                {
-                    _lightsPhase = 6; // jump to all red
-                }
-                // Final fallback: in formation with pace mode >= 3 but somehow never started
-                else if (ss == 3 && pm >= 3 && _lightsPrevPaceMode >= 3)
-                {
-                    _lightsPhase = 6;
-                }
+                // ── Rolling start: no red build — green fires on SS 3→4 (handled above) ──
+
                 // Catch-all: if session just went to Racing and we never fired lights,
                 // show a quick green flash so the driver sees something
-                else if (ss == 4 && _lightsPrevSessionState <= 3 && _lightsPrevSessionState >= 1 && _lightsPhase == 0)
+                if (ss == 4 && _lightsPrevSessionState <= 3 && _lightsPrevSessionState >= 1 && _lightsPhase == 0)
                 {
                     _lightsPhase = 7; // GREEN!
-                    _lightsHoldFrames = 15;
+                    _lightsHoldFrames = 50; // hold green ~5s
                 }
             }
 


### PR DESCRIPTION
## Summary
- **Rolling starts**: Skip red light buildup entirely — flash green GO! immediately on green flag (SessionState 3→4), held for ~5s so the driver sees it
- **Standing starts**: Keep the full F1-style red build sequence but faster (~0.4s per column vs 0.8s) with extended green hold (~3s)
- **Overlay fallback**: Synthetic green extended from 3s to 5s, fadeout cancel if lights arrive during fade, race transition fade delay extended to 8s

## Why
The red buildup takes ~4s (0.8s × 5 columns) but rolling starts only have a ~2-3s window between PaceMode transitions and green flag. The reds can't finish building before green fires, so the driver sees nothing. Since rolling starts don't have physical red lights on the track (it's a green flag wave), skipping reds and just flashing green matches the real experience.

## Test plan
- [ ] Rolling start: verify green GO! flashes immediately on green flag with no red lights preceding it
- [ ] Standing start: verify red lights build 1→5 then green fires on lights out
- [ ] Verify green holds long enough to be visible (~5s rolling, ~3s standing)
- [ ] Demo mode: verify both start types work (40% chance standing per DemoTelemetryProvider)
- [ ] Edge case: verify catch-all still fires green if session jumps straight to Racing

🤖 Generated with [Claude Code](https://claude.com/claude-code)