### PR TITLE
fix: game logo corner placement + Y-adjust slider

### DIFF
--- a/racecor-overlay/dashboard.html
+++ b/racecor-overlay/dashboard.html
@@ -963,6 +963,15 @@
         </div>
       </div>
 
+      <div class="settings-row">
+        <span class="settings-label">Y-Adjust</span>
+        <div class="settings-range-row">
+          <input class="settings-range" id="settingsBottomYOffset" type="range" min="0" max="200" step="10" value="0" oninput="previewBottomYOffset(this.value)" onchange="updateBottomYOffset(this.value)"/>
+          <span class="settings-range-val" id="bottomYOffsetVal">0px</span>
+        </div>
+      </div>
+      <div class="settings-hint">Shift bottom-anchored modules (panels, incidents, commentary) upward.</div>
+
       <div class="settings-group-label">Mode</div>
       <div class="settings-row">
         <span class="settings-label">Drive Mode</span>

--- a/racecor-overlay/modules/js/config.js
+++ b/racecor-overlay/modules/js/config.js
@@ -560,7 +560,7 @@ const _defaultSettings = {
   showFuel: true, showTyres: true, showControls: true, showPedals: true,
   showMaps: true, showPosition: true, showTacho: true, showCommentary: true,
   showK10Logo: true, showCarLogo: true, showGameLogo: true, simhubUrl: 'http://localhost:8889/k10mediabroadcaster/',
-  layoutPosition: 'top-right',
+  layoutPosition: 'top-right', bottomYOffset: 0,
   greenScreen: false, showWebGL: true, showBonkers: true, ambientMode: 'reflective',
   zoom: 165, forceFlag: '', showLeaderboard: true, showDatastream: true, showPitBox: true, showIncidents: true, showSpotter: true,
   incPenalty: 17, incDQ: 25,

--- a/racecor-overlay/modules/js/connections.js
+++ b/racecor-overlay/modules/js/connections.js
@@ -663,6 +663,14 @@
       pb.classList.add('pb-' + secVert, 'pb-' + secHoriz);
     }
 
+    // ── Bottom Y-Offset — shift bottom-anchored modules upward ──
+    const yOff = _settings.bottomYOffset || 0;
+    if (sec && secVert === 'bottom') {
+      sec.style.marginBottom = yOff ? (yOff + 'px') : '';
+    } else if (sec) {
+      sec.style.marginBottom = '';
+    }
+
     // ── 5. Incidents: same vertical edge as sec-container, always opposite
     //       horizontal edge from it (diagonal from main HUD) ──
     const incVert  = secVert;
@@ -680,9 +688,15 @@
       inc.style.left   = incHoriz === 'left'  ? '' : 'auto';
       inc.style.right  = incHoriz === 'right' ? '' : 'auto';
       inc.style.marginTop = '';
-      inc.style.marginBottom = '';
+      inc.style.marginBottom = (incVert === 'bottom' && yOff) ? (yOff + 'px') : '';
       console.log('[layout] incidents → ' + incVert + '-' + incHoriz +
         ' (sec=' + secVert + '-' + secHoriz + ', pos=' + pos + ')');
+    }
+
+    // Commentary bottom Y-offset
+    if (cmtCol) {
+      const cmtIsBottom = cmtCol.classList.contains('cmt-bl') || cmtCol.classList.contains('cmt-br');
+      cmtCol.style.marginBottom = (cmtIsBottom && yOff) ? (yOff + 'px') : '';
     }
 
     // ── 6. Spotter: co-located with race control at top center ──
@@ -743,6 +757,23 @@
       const settingsOverlay = document.getElementById('settingsOverlay');
       if (settingsOverlay) settingsOverlay.style.zoom = scale;
     }
+  }
+
+  function previewBottomYOffset(val) {
+    val = Math.max(0, Math.min(200, +val));
+    document.getElementById('bottomYOffsetVal').textContent = val + 'px';
+    _settings.bottomYOffset = val;
+    applyLayout();
+    // Also nudge the game logo
+    if (window.updateGameLogo) window.updateGameLogo(window._currentGameId || '', _settings.showGameLogo !== false);
+  }
+  function updateBottomYOffset(val) {
+    val = Math.max(0, Math.min(200, +val));
+    _settings.bottomYOffset = val;
+    document.getElementById('bottomYOffsetVal').textContent = val + 'px';
+    applyLayout();
+    if (window.updateGameLogo) window.updateGameLogo(window._currentGameId || '', _settings.showGameLogo !== false);
+    saveSettings();
   }
 
   function updateForceFlag(val) {

--- a/racecor-overlay/modules/js/game-logo.js
+++ b/racecor-overlay/modules/js/game-logo.js
@@ -19,11 +19,11 @@
   };
 
   // Logo-corner mapping: dashboard position → logo position
-  // Logo goes on the opposite vertical edge AND opposite horizontal side
-  // to avoid overlap with the dashboard.
+  // Top layouts: same row, opposite column (keeps logo visible near HUD).
+  // Bottom layouts: diagonal opposite (top row, opposite column).
   var OPPOSITE_CORNER = {
-    'top-right':       'bottom-left',
-    'top-left':        'bottom-right',
+    'top-right':       'top-left',
+    'top-left':        'top-right',
     'bottom-right':    'top-left',
     'bottom-left':     'top-right',
     'absolute-center': 'bottom-left'
@@ -64,6 +64,11 @@
       var kv = p.split(':');
       if (kv.length === 2) _logoEl.style[kv[0].trim()] = kv[1].trim();
     });
+    // Apply bottom Y-offset when logo is on a bottom edge
+    if (logoPos.indexOf('bottom') === 0) {
+      var yOff = (window._settings && window._settings.bottomYOffset) || 0;
+      if (yOff) _logoEl.style.bottom = (10 + yOff) + 'px';
+    }
   }
 
   function loadSvg(gameId) {

--- a/racecor-overlay/modules/js/settings.js
+++ b/racecor-overlay/modules/js/settings.js
@@ -70,6 +70,13 @@
     if (zoomLabel) zoomLabel.textContent = zoomVal + '%';
     applyZoom(zoomVal);
 
+    // Bottom Y-offset
+    const yOffVal = _settings.bottomYOffset || 0;
+    const yOffSlider = document.getElementById('settingsBottomYOffset');
+    const yOffLabel = document.getElementById('bottomYOffsetVal');
+    if (yOffSlider) yOffSlider.value = yOffVal;
+    if (yOffLabel) yOffLabel.textContent = yOffVal + 'px';
+
     // Force flag
     _forceFlagState = _settings.forceFlag || '';
     const flagSelect = document.getElementById('settingsForceFlag');

--- a/racecor-overlay/tests/unit/issue-7-logo-corner.spec.mjs
+++ b/racecor-overlay/tests/unit/issue-7-logo-corner.spec.mjs
@@ -1,55 +1,62 @@
 /**
  * Issue #7 — Game logo opposite corner logic
  *
- * The OPPOSITE_CORNER map flips the vertical axis so the logo sits on the
- * opposite vertical edge from the dashboard, same horizontal side.
- * Dashboard top-right → logo bottom-right, etc.
+ * Top layouts: logo on the same row, opposite column (top-right → top-left).
+ * Bottom layouts: logo on the diagonal opposite (bottom-right → top-left).
  */
 
 import { test, expect } from '@playwright/test';
 
 // Re-implementation of the OPPOSITE_CORNER map from game-logo.js
 const OPPOSITE_CORNER = {
-  'top-right':       'bottom-right',
-  'top-left':        'bottom-left',
-  'bottom-right':    'top-right',
-  'bottom-left':     'top-left',
+  'top-right':       'top-left',
+  'top-left':        'top-right',
+  'bottom-right':    'top-left',
+  'bottom-left':     'top-right',
   'absolute-center': 'bottom-left',
 };
 
 test.describe('Issue #7 — Game logo opposite corner', () => {
 
-  test('top-right maps to bottom-right (opposite row, same column)', () => {
-    expect(OPPOSITE_CORNER['top-right']).toBe('bottom-right');
+  test('top-right maps to top-left (same row, opposite column)', () => {
+    expect(OPPOSITE_CORNER['top-right']).toBe('top-left');
   });
 
-  test('top-left maps to bottom-left (opposite row, same column)', () => {
-    expect(OPPOSITE_CORNER['top-left']).toBe('bottom-left');
+  test('top-left maps to top-right (same row, opposite column)', () => {
+    expect(OPPOSITE_CORNER['top-left']).toBe('top-right');
   });
 
-  test('bottom-right maps to top-right (opposite row, same column)', () => {
-    expect(OPPOSITE_CORNER['bottom-right']).toBe('top-right');
+  test('bottom-right maps to top-left (diagonal opposite)', () => {
+    expect(OPPOSITE_CORNER['bottom-right']).toBe('top-left');
   });
 
-  test('bottom-left maps to top-left (opposite row, same column)', () => {
-    expect(OPPOSITE_CORNER['bottom-left']).toBe('top-left');
+  test('bottom-left maps to top-right (diagonal opposite)', () => {
+    expect(OPPOSITE_CORNER['bottom-left']).toBe('top-right');
   });
 
-  test('opposite corner flips vertical edge (top becomes bottom, bottom becomes top)', () => {
+  test('top layouts keep same vertical edge, flip horizontal', () => {
     for (const [from, to] of Object.entries(OPPOSITE_CORNER)) {
       if (from === 'absolute-center') continue;
-      const fromEdge = from.split('-')[0];   // 'top' or 'bottom'
+      if (!from.startsWith('top')) continue;
+      const fromEdge = from.split('-')[0];
       const toEdge   = to.split('-')[0];
-      expect(toEdge).not.toBe(fromEdge);
+      expect(toEdge).toBe(fromEdge); // same row
+      const fromSide = from.split('-')[1];
+      const toSide   = to.split('-')[1];
+      expect(toSide).not.toBe(fromSide); // opposite column
     }
   });
 
-  test('opposite corner preserves horizontal side', () => {
+  test('bottom layouts flip vertical edge and horizontal side (diagonal)', () => {
     for (const [from, to] of Object.entries(OPPOSITE_CORNER)) {
       if (from === 'absolute-center') continue;
-      const fromSide = from.split('-')[1];   // 'left' or 'right'
+      if (!from.startsWith('bottom')) continue;
+      const fromEdge = from.split('-')[0];
+      const toEdge   = to.split('-')[0];
+      expect(toEdge).not.toBe(fromEdge); // opposite row
+      const fromSide = from.split('-')[1];
       const toSide   = to.split('-')[1];
-      expect(toSide).toBe(fromSide);
+      expect(toSide).not.toBe(fromSide); // opposite column
     }
   });
 
@@ -57,10 +64,9 @@ test.describe('Issue #7 — Game logo opposite corner', () => {
     expect(OPPOSITE_CORNER['absolute-center']).toBe('bottom-left');
   });
 
-  test('applying opposite twice returns to original corner', () => {
-    const corners = ['top-right', 'top-left', 'bottom-right', 'bottom-left'];
-    for (const c of corners) {
-      expect(OPPOSITE_CORNER[OPPOSITE_CORNER[c]]).toBe(c);
+  test('logo never overlaps dashboard position', () => {
+    for (const [from, to] of Object.entries(OPPOSITE_CORNER)) {
+      expect(to).not.toBe(from);
     }
   });
 });


### PR DESCRIPTION
## Summary
- **Game logo corner fix**: Top layouts now place the logo on the same row, opposite column (top-right → top-left, top-left → top-right) instead of the previous diagonal mapping. Bottom layouts remain diagonal opposite.
- **Y-Adjustment slider**: New 0–200px slider (10px steps) in Layout settings shifts all bottom-anchored modules upward.
- **Updated unit tests**: Rewrote issue-7 corner spec to match the new mapping rules.

## Test plan
- [ ] Set layout to top-left → verify game logo appears at top-right
- [ ] Set layout to top-right → verify game logo appears at top-left
- [ ] Set layout to bottom-right → verify game logo appears at top-left
- [ ] Set layout to bottom-left → verify game logo appears at top-right
- [ ] Drag Y-Adjust slider → verify bottom panels shift upward
- [ ] Confirm Y-Adjust persists across settings reload