### PR TITLE
feat: admin area with track management and user overview

### DIFF
--- a/web/drizzle/0001_track_maps.sql
+++ b/web/drizzle/0001_track_maps.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS "track_maps" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "track_id" varchar(128) NOT NULL UNIQUE,
+  "track_name" varchar(256) NOT NULL,
+  "svg_path" text NOT NULL,
+  "point_count" integer NOT NULL,
+  "raw_csv" text NOT NULL,
+  "contributor_id" uuid REFERENCES "users"("id") ON DELETE SET NULL,
+  "game_name" varchar(64) DEFAULT 'iracing',
+  "track_length_km" double precision,
+  "svg_preview" text,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "track_maps_track_id_idx" ON "track_maps" ("track_id");
+CREATE INDEX IF NOT EXISTS "track_maps_game_name_idx" ON "track_maps" ("game_name");

--- a/web/src/app/api/admin/tracks/route.ts
+++ b/web/src/app/api/admin/tracks/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { db, schema } from '@/db'
+import { eq, desc } from 'drizzle-orm'
+import { requireAdmin } from '@/lib/admin'
+import { csvToSvg, generateSvgPreview } from '@/lib/track-svg'
+
+/** GET /api/admin/tracks — List all track maps */
+export async function GET() {
+  const session = await requireAdmin()
+  if (!session) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  const tracks = await db
+    .select({
+      id: schema.trackMaps.id,
+      trackId: schema.trackMaps.trackId,
+      trackName: schema.trackMaps.trackName,
+      svgPath: schema.trackMaps.svgPath,
+      pointCount: schema.trackMaps.pointCount,
+      gameName: schema.trackMaps.gameName,
+      trackLengthKm: schema.trackMaps.trackLengthKm,
+      createdAt: schema.trackMaps.createdAt,
+      updatedAt: schema.trackMaps.updatedAt,
+    })
+    .from(schema.trackMaps)
+    .orderBy(desc(schema.trackMaps.updatedAt))
+
+  return NextResponse.json({ tracks })
+}
+
+/** POST /api/admin/tracks — Upload CSV to create/replace a track map */
+export async function POST(request: NextRequest) {
+  const session = await requireAdmin()
+  if (!session) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  try {
+    const body = await request.json()
+    const { trackId, trackName, rawCsv, gameName, trackLengthKm } = body
+
+    if (!trackId || !trackName || !rawCsv) {
+      return NextResponse.json(
+        { error: 'Missing required fields: trackId, trackName, rawCsv' },
+        { status: 400 }
+      )
+    }
+
+    const normalizedTrackId = trackId.toLowerCase().trim()
+
+    // Generate SVG from CSV
+    const { svgPath, pointCount, svgPreview } = csvToSvg(rawCsv, trackName.trim())
+
+    // Check if track exists — if so, replace it
+    const existing = await db
+      .select({ id: schema.trackMaps.id })
+      .from(schema.trackMaps)
+      .where(eq(schema.trackMaps.trackId, normalizedTrackId))
+      .limit(1)
+
+    if (existing.length > 0) {
+      await db
+        .update(schema.trackMaps)
+        .set({
+          trackName: trackName.trim(),
+          svgPath,
+          pointCount,
+          rawCsv: rawCsv.trim(),
+          gameName: (gameName || 'iracing').toLowerCase().trim(),
+          trackLengthKm: trackLengthKm ? Number(trackLengthKm) : null,
+          svgPreview,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.trackMaps.trackId, normalizedTrackId))
+
+      return NextResponse.json({
+        success: true,
+        status: 'replaced',
+        trackId: normalizedTrackId,
+        pointCount,
+      })
+    }
+
+    // Insert new
+    const result = await db
+      .insert(schema.trackMaps)
+      .values({
+        trackId: normalizedTrackId,
+        trackName: trackName.trim(),
+        svgPath,
+        pointCount,
+        rawCsv: rawCsv.trim(),
+        gameName: (gameName || 'iracing').toLowerCase().trim(),
+        trackLengthKm: trackLengthKm ? Number(trackLengthKm) : null,
+        svgPreview,
+      })
+      .returning({ id: schema.trackMaps.id })
+
+    return NextResponse.json({
+      success: true,
+      status: 'created',
+      trackId: normalizedTrackId,
+      mapId: result[0].id,
+      pointCount,
+    }, { status: 201 })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Invalid request'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}
+
+/** DELETE /api/admin/tracks?trackId=xxx — Remove a track map */
+export async function DELETE(request: NextRequest) {
+  const session = await requireAdmin()
+  if (!session) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  const trackId = request.nextUrl.searchParams.get('trackId')
+  if (!trackId) {
+    return NextResponse.json({ error: 'trackId required' }, { status: 400 })
+  }
+
+  const normalizedId = trackId.toLowerCase().trim()
+  const deleted = await db
+    .delete(schema.trackMaps)
+    .where(eq(schema.trackMaps.trackId, normalizedId))
+    .returning({ id: schema.trackMaps.id })
+
+  if (deleted.length === 0) {
+    return NextResponse.json({ error: 'Track map not found' }, { status: 404 })
+  }
+
+  return NextResponse.json({ success: true, trackId: normalizedId })
+}

--- a/web/src/app/api/admin/users/route.ts
+++ b/web/src/app/api/admin/users/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server'
+import { db, schema } from '@/db'
+import { desc, count, eq } from 'drizzle-orm'
+import { requireAdmin } from '@/lib/admin'
+
+/** GET /api/admin/users — List all registered users (read-only) */
+export async function GET() {
+  const session = await requireAdmin()
+  if (!session) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  const users = await db
+    .select({
+      id: schema.users.id,
+      discordId: schema.users.discordId,
+      discordUsername: schema.users.discordUsername,
+      discordDisplayName: schema.users.discordDisplayName,
+      discordAvatar: schema.users.discordAvatar,
+      email: schema.users.email,
+      createdAt: schema.users.createdAt,
+      updatedAt: schema.users.updatedAt,
+    })
+    .from(schema.users)
+    .orderBy(desc(schema.users.createdAt))
+
+  // Get active token count per user
+  const tokenCounts = await db
+    .select({
+      userId: schema.pluginTokens.userId,
+      tokenCount: count(schema.pluginTokens.id),
+    })
+    .from(schema.pluginTokens)
+    .where(eq(schema.pluginTokens.revoked, false))
+    .groupBy(schema.pluginTokens.userId)
+
+  const tokenMap = new Map(tokenCounts.map(t => [t.userId, Number(t.tokenCount)]))
+
+  const enriched = users.map(u => ({
+    ...u,
+    activeTokens: tokenMap.get(u.id) || 0,
+  }))
+
+  return NextResponse.json({ users: enriched })
+}

--- a/web/src/app/drive/admin/AdminPanel.tsx
+++ b/web/src/app/drive/admin/AdminPanel.tsx
@@ -1,0 +1,371 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+
+// ── Types ──
+
+interface Track {
+  id: string
+  trackId: string
+  trackName: string
+  svgPath: string
+  pointCount: number
+  gameName: string | null
+  trackLengthKm: number | null
+  createdAt: string
+  updatedAt: string
+}
+
+interface User {
+  id: string
+  discordId: string
+  discordUsername: string
+  discordDisplayName: string | null
+  discordAvatar: string | null
+  email: string | null
+  createdAt: string
+  updatedAt: string
+  activeTokens: number
+}
+
+// ── Main Component ──
+
+export default function AdminPanel() {
+  const [tab, setTab] = useState<'tracks' | 'users'>('tracks')
+
+  return (
+    <div className="max-w-6xl mx-auto px-6 py-8">
+      <div className="flex gap-1 mb-8 border-b border-[var(--border)]">
+        <TabButton active={tab === 'tracks'} onClick={() => setTab('tracks')}>Track Maps</TabButton>
+        <TabButton active={tab === 'users'} onClick={() => setTab('users')}>Users</TabButton>
+      </div>
+      {tab === 'tracks' ? <TracksSection /> : <UsersSection />}
+    </div>
+  )
+}
+
+function TabButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-4 py-2 text-sm font-medium tracking-wide uppercase transition-colors cursor-pointer border-b-2 -mb-[1px] ${
+        active
+          ? 'text-[var(--k10-red)] border-[var(--k10-red)]'
+          : 'text-[var(--text-muted)] border-transparent hover:text-[var(--text-dim)]'
+      }`}
+    >
+      {children}
+    </button>
+  )
+}
+
+// ── Tracks Section ──
+
+function TracksSection() {
+  const [tracks, setTracks] = useState<Track[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [deleting, setDeleting] = useState<string | null>(null)
+
+  const fetchTracks = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/admin/tracks')
+      if (!res.ok) throw new Error('Failed to fetch tracks')
+      const data = await res.json()
+      setTracks(data.tracks)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { fetchTracks() }, [fetchTracks])
+
+  const deleteTrack = async (trackId: string) => {
+    if (!confirm(`Delete "${trackId}"? This cannot be undone.`)) return
+    setDeleting(trackId)
+    try {
+      const res = await fetch(`/api/admin/tracks?trackId=${encodeURIComponent(trackId)}`, { method: 'DELETE' })
+      if (!res.ok) throw new Error('Delete failed')
+      setTracks(prev => prev.filter(t => t.trackId !== trackId))
+    } catch (e) {
+      alert(e instanceof Error ? e.message : 'Delete failed')
+    } finally {
+      setDeleting(null)
+    }
+  }
+
+  return (
+    <div>
+      <UploadForm onUploaded={fetchTracks} />
+
+      <h2 className="text-lg font-bold tracking-wide uppercase text-[var(--text-secondary)] mb-4 mt-8">
+        Track Maps ({tracks.length})
+      </h2>
+
+      {loading && <p className="text-[var(--text-muted)] text-sm">Loading...</p>}
+      {error && <p className="text-red-400 text-sm">{error}</p>}
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {tracks.map(track => (
+          <div
+            key={track.id}
+            className="border border-[var(--border)] rounded-lg p-4 bg-[var(--bg-surface)] hover:border-[var(--border-accent)] transition-colors"
+          >
+            <div className="flex justify-between items-start mb-3">
+              <div className="min-w-0">
+                <h3 className="text-sm font-bold text-[var(--text)] truncate">{track.trackName}</h3>
+                <p className="text-xs text-[var(--text-muted)] truncate">{track.trackId}</p>
+              </div>
+              <button
+                onClick={() => deleteTrack(track.trackId)}
+                disabled={deleting === track.trackId}
+                className="text-xs text-red-400 hover:text-red-300 transition-colors cursor-pointer shrink-0 ml-2 disabled:opacity-50"
+              >
+                {deleting === track.trackId ? '...' : 'Delete'}
+              </button>
+            </div>
+
+            {/* SVG Preview */}
+            <div className="bg-[var(--bg-panel)] rounded border border-[var(--border-subtle)] p-2 mb-3 flex items-center justify-center aspect-square">
+              <svg viewBox="0 0 100 100" className="w-full h-full">
+                <path
+                  d={track.svgPath}
+                  fill="none"
+                  stroke="var(--k10-red)"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+
+            <div className="flex justify-between text-xs text-[var(--text-muted)]">
+              <span>{track.pointCount} pts</span>
+              <span>{track.gameName}</span>
+              <span>{new Date(track.createdAt).toLocaleDateString()}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {!loading && tracks.length === 0 && (
+        <p className="text-[var(--text-muted)] text-sm text-center py-8">No track maps in the database.</p>
+      )}
+    </div>
+  )
+}
+
+// ── Upload Form ──
+
+function UploadForm({ onUploaded }: { onUploaded: () => void }) {
+  const [trackId, setTrackId] = useState('')
+  const [trackName, setTrackName] = useState('')
+  const [gameName, setGameName] = useState('iracing')
+  const [csvText, setCsvText] = useState('')
+  const [fileName, setFileName] = useState('')
+  const [uploading, setUploading] = useState(false)
+  const [result, setResult] = useState<{ ok: boolean; message: string } | null>(null)
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setFileName(file.name)
+    // Auto-fill track name from filename if empty
+    if (!trackName) {
+      const name = file.name.replace(/\.csv$/i, '').replace(/[-_]/g, ' ')
+      setTrackName(name)
+      if (!trackId) setTrackId(name.toLowerCase().trim())
+    }
+    const reader = new FileReader()
+    reader.onload = (ev) => setCsvText(ev.target?.result as string || '')
+    reader.readAsText(file)
+  }
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    const file = e.dataTransfer.files[0]
+    if (!file) return
+    setFileName(file.name)
+    if (!trackName) {
+      const name = file.name.replace(/\.csv$/i, '').replace(/[-_]/g, ' ')
+      setTrackName(name)
+      if (!trackId) setTrackId(name.toLowerCase().trim())
+    }
+    const reader = new FileReader()
+    reader.onload = (ev) => setCsvText(ev.target?.result as string || '')
+    reader.readAsText(file)
+  }
+
+  const submit = async () => {
+    if (!trackId || !trackName || !csvText) return
+    setUploading(true)
+    setResult(null)
+    try {
+      const res = await fetch('/api/admin/tracks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ trackId, trackName, rawCsv: csvText, gameName }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Upload failed')
+      setResult({ ok: true, message: `${data.status}: ${data.trackId} (${data.pointCount} points)` })
+      setTrackId('')
+      setTrackName('')
+      setCsvText('')
+      setFileName('')
+      onUploaded()
+    } catch (e) {
+      setResult({ ok: false, message: e instanceof Error ? e.message : 'Upload failed' })
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  return (
+    <div className="border border-[var(--border)] rounded-lg p-5 bg-[var(--bg-surface)]">
+      <h2 className="text-sm font-bold tracking-wide uppercase text-[var(--text-secondary)] mb-4">Upload Track CSV</h2>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-4">
+        <input
+          type="text"
+          placeholder="track id (e.g. sebring international)"
+          value={trackId}
+          onChange={e => setTrackId(e.target.value)}
+          className="bg-[var(--bg-panel)] border border-[var(--border-subtle)] rounded px-3 py-2 text-sm text-[var(--text)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--k10-red)]"
+        />
+        <input
+          type="text"
+          placeholder="Track Name"
+          value={trackName}
+          onChange={e => setTrackName(e.target.value)}
+          className="bg-[var(--bg-panel)] border border-[var(--border-subtle)] rounded px-3 py-2 text-sm text-[var(--text)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--k10-red)]"
+        />
+        <select
+          value={gameName}
+          onChange={e => setGameName(e.target.value)}
+          className="bg-[var(--bg-panel)] border border-[var(--border-subtle)] rounded px-3 py-2 text-sm text-[var(--text)] focus:outline-none focus:border-[var(--k10-red)]"
+        >
+          <option value="iracing">iRacing</option>
+          <option value="lmu">Le Mans Ultimate</option>
+          <option value="acc">ACC</option>
+        </select>
+      </div>
+
+      {/* Drop zone */}
+      <div
+        onDragOver={e => e.preventDefault()}
+        onDrop={handleDrop}
+        className="border-2 border-dashed border-[var(--border)] rounded-lg p-6 text-center mb-4 hover:border-[var(--k10-red)] transition-colors cursor-pointer"
+        onClick={() => document.getElementById('csv-file-input')?.click()}
+      >
+        <input id="csv-file-input" type="file" accept=".csv" onChange={handleFile} className="hidden" />
+        {fileName ? (
+          <p className="text-sm text-[var(--text)]">{fileName} <span className="text-[var(--text-muted)]">({csvText.split('\n').length} lines)</span></p>
+        ) : (
+          <p className="text-sm text-[var(--text-muted)]">Drop a CSV file here or click to browse</p>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3">
+        <button
+          onClick={submit}
+          disabled={uploading || !trackId || !trackName || !csvText}
+          className="px-4 py-2 bg-[var(--k10-red)] text-white text-sm font-medium rounded hover:brightness-110 transition-all disabled:opacity-40 cursor-pointer disabled:cursor-not-allowed"
+        >
+          {uploading ? 'Uploading...' : 'Upload & Generate SVG'}
+        </button>
+        {result && (
+          <span className={`text-xs ${result.ok ? 'text-[var(--green)]' : 'text-red-400'}`}>
+            {result.message}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── Users Section ──
+
+function UsersSection() {
+  const [users, setUsers] = useState<User[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch('/api/admin/users')
+      .then(r => r.json())
+      .then(data => setUsers(data.users))
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [])
+
+  return (
+    <div>
+      <h2 className="text-lg font-bold tracking-wide uppercase text-[var(--text-secondary)] mb-4">
+        Registered Users ({users.length})
+      </h2>
+      <p className="text-xs text-[var(--text-muted)] mb-4">
+        Read-only view. To remove users, manage access through Discord moderation.
+      </p>
+
+      {loading && <p className="text-[var(--text-muted)] text-sm">Loading...</p>}
+
+      <div className="border border-[var(--border)] rounded-lg overflow-hidden">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="bg-[var(--bg-surface)] text-[var(--text-muted)] text-xs uppercase tracking-wider">
+              <th className="text-left px-4 py-3">User</th>
+              <th className="text-left px-4 py-3">Discord ID</th>
+              <th className="text-left px-4 py-3">Email</th>
+              <th className="text-center px-4 py-3">Tokens</th>
+              <th className="text-right px-4 py-3">Joined</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map(user => (
+              <tr key={user.id} className="border-t border-[var(--border-subtle)] hover:bg-[var(--bg-elevated)] transition-colors">
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-2">
+                    {user.discordAvatar && user.discordId ? (
+                      <img
+                        src={`https://cdn.discordapp.com/avatars/${user.discordId}/${user.discordAvatar}.png?size=32`}
+                        alt=""
+                        className="w-6 h-6 rounded-full"
+                      />
+                    ) : (
+                      <div className="w-6 h-6 rounded-full bg-[var(--bg-panel)]" />
+                    )}
+                    <div>
+                      <div className="text-[var(--text)] font-medium">{user.discordDisplayName || user.discordUsername}</div>
+                      <div className="text-xs text-[var(--text-muted)]">@{user.discordUsername}</div>
+                    </div>
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-[var(--text-dim)] font-mono text-xs">{user.discordId}</td>
+                <td className="px-4 py-3 text-[var(--text-dim)]">{user.email || '—'}</td>
+                <td className="px-4 py-3 text-center">
+                  <span className={`text-xs px-2 py-0.5 rounded-full ${
+                    user.activeTokens > 0
+                      ? 'bg-[var(--green)]/20 text-[var(--green)]'
+                      : 'bg-[var(--bg-panel)] text-[var(--text-muted)]'
+                  }`}>
+                    {user.activeTokens}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-right text-[var(--text-muted)]">
+                  {new Date(user.createdAt).toLocaleDateString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {!loading && users.length === 0 && (
+        <p className="text-[var(--text-muted)] text-sm text-center py-8">No registered users.</p>
+      )}
+    </div>
+  )
+}

--- a/web/src/app/drive/admin/page.tsx
+++ b/web/src/app/drive/admin/page.tsx
@@ -1,0 +1,31 @@
+import { redirect } from 'next/navigation'
+import { requireAdmin } from '@/lib/admin'
+import AdminPanel from './AdminPanel'
+
+export const metadata = {
+  title: 'Admin — K10 Pro Drive',
+}
+
+export default async function AdminPage() {
+  const session = await requireAdmin()
+  if (!session) redirect('/drive/dashboard')
+
+  const user = session.user as unknown as Record<string, unknown>
+
+  return (
+    <main className="min-h-screen bg-[var(--bg)]">
+      <header className="border-b border-[var(--border)] px-6 py-4 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <a href="/drive/dashboard" className="text-[var(--text-muted)] hover:text-[var(--text)] transition-colors text-sm">&larr; Dashboard</a>
+          <span className="text-[var(--border)]">/</span>
+          <span className="text-sm font-bold tracking-wider uppercase text-[var(--k10-red)]">Admin</span>
+        </div>
+        <div className="flex items-center gap-2">
+          {session.user?.image && <img src={session.user.image} alt="" className="w-6 h-6 rounded-full" />}
+          <span className="text-xs text-[var(--text-muted)]">{user.discordDisplayName as string}</span>
+        </div>
+      </header>
+      <AdminPanel />
+    </main>
+  )
+}

--- a/web/src/app/drive/dashboard/page.tsx
+++ b/web/src/app/drive/dashboard/page.tsx
@@ -1,9 +1,10 @@
 import { auth, signOut } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { SITE_URL, SITE_NAME, CATEGORY_LABELS, LICENSE_LABELS, LICENSE_COLORS } from '@/lib/constants'
+import { isAdmin } from '@/lib/admin'
 import { db, schema } from '@/db'
 import { eq } from 'drizzle-orm'
-import { Download, LogOut, BarChart3, Trophy, Shield, Car } from 'lucide-react'
+import { Download, LogOut, BarChart3, Trophy, Shield, Car, Settings } from 'lucide-react'
 
 export default async function DashboardPage() {
   const session = await auth()
@@ -41,6 +42,14 @@ export default async function DashboardPage() {
             {avatar && <img src={avatar} alt="" className="w-7 h-7 rounded-full" />}
             <span className="text-sm text-[var(--text-secondary)]">{displayName}</span>
           </div>
+          {isAdmin(discordId) && (
+            <a
+              href="/drive/admin"
+              className="text-xs text-[var(--k10-red)] hover:brightness-110 transition-colors flex items-center gap-1"
+            >
+              <Settings size={12} /> Admin
+            </a>
+          )}
           <form action={async () => {
             'use server'
             await signOut({ redirectTo: '/drive' })

--- a/web/src/db/schema.ts
+++ b/web/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp, boolean, integer, jsonb, uuid, varchar } from 'drizzle-orm/pg-core'
+import { pgTable, text, timestamp, boolean, integer, doublePrecision, jsonb, uuid, varchar } from 'drizzle-orm/pg-core'
 
 // ── Users (Discord-authenticated members) ──
 export const users = pgTable('users', {
@@ -34,6 +34,22 @@ export const authCodes = pgTable('auth_codes', {
   expiresAt: timestamp('expires_at').notNull(),
   used: boolean('used').default(false).notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),
+})
+
+// ── Track Maps (community-contributed SVG track outlines) ──
+export const trackMaps = pgTable('track_maps', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  trackId: varchar('track_id', { length: 128 }).notNull().unique(),
+  trackName: varchar('track_name', { length: 256 }).notNull(),
+  svgPath: text('svg_path').notNull(),
+  pointCount: integer('point_count').notNull(),
+  rawCsv: text('raw_csv').notNull(),
+  contributorId: uuid('contributor_id').references(() => users.id, { onDelete: 'set null' }),
+  gameName: varchar('game_name', { length: 64 }).default('iracing'),
+  trackLengthKm: doublePrecision('track_length_km'),
+  svgPreview: text('svg_preview'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
 })
 
 // ── Driver Ratings (iRacing performance data) ──

--- a/web/src/lib/admin.ts
+++ b/web/src/lib/admin.ts
@@ -1,0 +1,27 @@
+import { auth } from '@/lib/auth'
+
+const ADMIN_DISCORD_ID = process.env.K10_ADMIN_DISCORD_ID || ''
+
+/**
+ * Check if the current session belongs to the admin user.
+ * Returns the session if admin, null otherwise.
+ */
+export async function requireAdmin() {
+  const session = await auth()
+  if (!session?.user) return null
+
+  const user = session.user as unknown as Record<string, unknown>
+  const discordId = user.discordId as string | undefined
+
+  if (!ADMIN_DISCORD_ID || !discordId || discordId !== ADMIN_DISCORD_ID) {
+    return null
+  }
+
+  return session
+}
+
+/** Check if a discordId is the admin */
+export function isAdmin(discordId: string | undefined | null): boolean {
+  if (!ADMIN_DISCORD_ID || !discordId) return false
+  return discordId === ADMIN_DISCORD_ID
+}

--- a/web/src/lib/track-svg.ts
+++ b/web/src/lib/track-svg.ts
@@ -1,0 +1,111 @@
+/**
+ * Track map CSV → SVG normalization pipeline.
+ * Mirrors the C# TrackMapProvider algorithm:
+ *   1. Parse worldX, worldZ, lapDistPct from CSV
+ *   2. Normalize to 0–100 viewBox with 5% padding (uniform scale)
+ *   3. Convert via Catmull-Rom → cubic Bézier spline
+ */
+
+interface TrackPoint {
+  x: number
+  y: number
+  lapDistPct: number
+}
+
+/** Parse CSV (worldX,worldZ,lapDistPct per line, optional header) */
+export function parseCsv(csv: string): TrackPoint[] {
+  const lines = csv.trim().split('\n').filter(l => l.trim().length > 0)
+  const points: TrackPoint[] = []
+
+  for (const line of lines) {
+    const parts = line.split(',').map(s => s.trim())
+    if (parts.length < 3) continue
+    const x = parseFloat(parts[0])
+    const z = parseFloat(parts[1])
+    const pct = parseFloat(parts[2])
+    if (isNaN(x) || isNaN(z)) continue
+    points.push({ x, y: z, lapDistPct: isNaN(pct) ? 0 : pct })
+  }
+
+  return points
+}
+
+/** Normalize points to 0–100 viewBox with 5% padding, uniform scale */
+function normalize(points: TrackPoint[]): TrackPoint[] {
+  let minX = Infinity, maxX = -Infinity
+  let minY = Infinity, maxY = -Infinity
+
+  for (const p of points) {
+    if (p.x < minX) minX = p.x
+    if (p.x > maxX) maxX = p.x
+    if (p.y < minY) minY = p.y
+    if (p.y > maxY) maxY = p.y
+  }
+
+  let rangeX = maxX - minX
+  let rangeY = maxY - minY
+  if (rangeX < 0.01) rangeX = 1
+  if (rangeY < 0.01) rangeY = 1
+
+  // Uniform scale to fit in 90×90 (5% padding each side)
+  const scale = 90.0 / Math.max(rangeX, rangeY)
+  const offsetX = (100.0 - rangeX * scale) / 2.0
+  const offsetY = (100.0 - rangeY * scale) / 2.0
+
+  return points.map(p => ({
+    x: (p.x - minX) * scale + offsetX,
+    y: (p.y - minY) * scale + offsetY,
+    lapDistPct: p.lapDistPct,
+  }))
+}
+
+/** Build SVG path using Catmull-Rom → cubic Bézier conversion */
+function buildSvgPath(pts: TrackPoint[]): string {
+  if (pts.length < 2) return ''
+
+  const f = (n: number) => n.toFixed(2)
+  let path = `M ${f(pts[0].x)},${f(pts[0].y)}`
+
+  for (let i = 0; i < pts.length; i++) {
+    const i0 = (i - 1 + pts.length) % pts.length
+    const i1 = i
+    const i2 = (i + 1) % pts.length
+    const i3 = (i + 2) % pts.length
+
+    // Catmull-Rom control points → Bézier control points
+    const x1 = pts[i1].x + (pts[i2].x - pts[i0].x) / 6.0
+    const y1 = pts[i1].y + (pts[i2].y - pts[i0].y) / 6.0
+    const x2 = pts[i2].x - (pts[i3].x - pts[i1].x) / 6.0
+    const y2 = pts[i2].y - (pts[i3].y - pts[i1].y) / 6.0
+
+    path += ` C ${f(x1)},${f(y1)} ${f(x2)},${f(y2)} ${f(pts[i2].x)},${f(pts[i2].y)}`
+  }
+
+  return path + ' Z'
+}
+
+/** Generate inline SVG preview element */
+export function generateSvgPreview(svgPath: string, trackName: string): string {
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="200" height="200">
+  <title>${trackName}</title>
+  <path d="${svgPath}" fill="none" stroke="#e53935" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>`
+}
+
+/** Full pipeline: CSV string → { svgPath, pointCount, svgPreview } */
+export function csvToSvg(csv: string, trackName: string) {
+  const raw = parseCsv(csv)
+  if (raw.length < 10) {
+    throw new Error(`Too few points (${raw.length}). Need at least 10.`)
+  }
+
+  const normalized = normalize(raw)
+  const svgPath = buildSvgPath(normalized)
+  const svgPreview = generateSvgPreview(svgPath, trackName)
+
+  return {
+    svgPath,
+    pointCount: raw.length,
+    svgPreview,
+  }
+}


### PR DESCRIPTION
## Summary
- Admin panel at `/drive/admin` gated by `K10_ADMIN_DISCORD_ID` env var
- Track maps management: view SVG previews, upload CSV (Catmull-Rom to Bezier normalization), delete tracks
- Read-only users table with Discord avatars, usernames, email, active token counts
- `trackMaps` database table with Drizzle migration
- Admin link in dashboard header (visible only to admin user)

## Test plan
- [ ] Set `K10_ADMIN_DISCORD_ID` to your Discord ID and verify admin link appears on dashboard
- [ ] Navigate to `/drive/admin` and verify tracks + users tabs render
- [ ] Upload a track CSV and verify SVG preview generates correctly
- [ ] Delete a track and verify it is removed
- [ ] Verify non-admin users are redirected to dashboard
- [ ] Run the Drizzle migration (`0001_track_maps.sql`) against the database

Generated with [Claude Code](https://claude.com/claude-code)