### PR TITLE
fix: pitbox dismiss never worked during race

### DIFF
--- a/racecor-overlay/modules/js/pitbox.js
+++ b/racecor-overlay/modules/js/pitbox.js
@@ -318,10 +318,12 @@
       _lastIncrement = pbInc; _lastDecrement = pbDec;
       _lastToggle = pbTog;
     } else {
-      // Tab cycling
+      // Tab cycling — respond to TabCycle, TabCycleBack, Next, and Prev
       var tabDir = 0;
       if (tabCycle !== _lastTabCycle)         { _lastTabCycle = tabCycle; tabDir = 1; }
       if (tabCycleBack !== _lastTabCycleBack) { _lastTabCycleBack = tabCycleBack; tabDir = -1; }
+      if (pbNext !== _lastNext)               { _lastNext = pbNext; tabDir = 1; }
+      if (pbPrev !== _lastPrev)               { _lastPrev = pbPrev; tabDir = -1; }
       if (tabDir !== 0) {
         var panel = document.getElementById('pitBoxPanel');
         if (_pbHidden) {
@@ -341,6 +343,11 @@
           if (atEnd || atStart) {
             _pbHidden = true;
             if (panel) panel.classList.add('pb-dismissed');
+            // Deselect all tabs and pages so state is clean on re-show
+            var allTabs = document.querySelectorAll('.pb-tab');
+            var allPages = document.querySelectorAll('.pb-page');
+            for (var t = 0; t < allTabs.length; t++) allTabs[t].classList.remove('active');
+            for (var p = 0; p < allPages.length; p++) allPages[p].classList.remove('active');
           } else {
             var nextIdx = idx + tabDir;
             var nextTab = document.querySelector('.pb-tab[data-pb-tab="' + _tabOrder[nextIdx] + '"]');
@@ -348,10 +355,6 @@
           }
         }
       }
-
-      // Element navigation / value adjustment — actions stubbed for future mapping
-      if (pbNext !== _lastNext)  { _lastNext = pbNext;  /* TODO: move focus to next element */ }
-      if (pbPrev !== _lastPrev)  { _lastPrev = pbPrev;  /* TODO: move focus to prev element */ }
       if (pbInc !== _lastIncrement)  { _lastIncrement = pbInc;  /* TODO: increment focused value */ }
       if (pbDec !== _lastDecrement)  { _lastDecrement = pbDec;  /* TODO: decrement focused value */ }
       if (pbTog !== _lastToggle) { _lastToggle = pbTog; /* TODO: toggle focused element on/off */ }

--- a/racecor-overlay/modules/styles/pitbox.css
+++ b/racecor-overlay/modules/styles/pitbox.css
@@ -8,7 +8,7 @@
     flex-shrink: 0;
   }
   .pitbox-panel.section-hidden { display: none; }
-  .pitbox-panel.pb-dismissed { opacity: 0; pointer-events: none; }
+  .pitbox-panel.pb-dismissed { opacity: 0 !important; pointer-events: none; }
 
   .pb-inner {
     background: hsla(0, 0%, 5%, 0.90);


### PR DESCRIPTION
## Summary
- **Root cause**: `.pitbox-panel.pb-dismissed { opacity: 0 }` was overridden by higher-specificity rules in effects.css like `body.rc-active .pitbox-panel { opacity: 0.5 }`, so the dismiss was silently ignored during any active race state
- Added `!important` to the pb-dismissed opacity rule so it always wins regardless of body state classes
- Wired `PitboxNext`/`PitboxPrev` wheel button actions into the tab cycling logic (previously stubbed as TODOs)
- Tabs are now fully deselected on dismiss so state is clean when re-showing

## Test plan
- [ ] Cycle forward past the last pitbox tab (Camera) — panel should fade out
- [ ] Press next again from dismissed state — panel should re-show on Tyres tab
- [ ] Cycle backward past the first tab (Tyres) — panel should fade out
- [ ] Press prev from dismissed — panel should re-show on Camera tab
- [ ] Verify this works during an active race session (body.rc-active)

Generated with [Claude Code](https://claude.com/claude-code)