### PR TITLE
feat: add tufte-audit and iracing-to-lmu Claude skills

### DIFF
--- a/src/agents/skills/iracing-to-lmu/SKILL.md
+++ b/src/agents/skills/iracing-to-lmu/SKILL.md
@@ -1,0 +1,431 @@
+---
+name: iracing-to-lmu
+description: >
+  Port iRacing-specific features to Le Mans Ultimate (LMU) in the K10 Motorsports SimHub plugin codebase.
+  Use this skill whenever working on LMU support, rFactor 2 telemetry integration, cross-game compatibility,
+  or porting any iRacing-only feature to work with LMU/rF2. Trigger on mentions of "LMU", "Le Mans Ultimate",
+  "rFactor", "rF2", "cross-game", "port to LMU", "multi-sim support", "game-specific telemetry", or any
+  task that involves making iRacing features work in other sims. Also trigger when someone asks about
+  telemetry mapping, shared memory properties, or SimHub game-specific property paths — even if they don't
+  mention LMU by name. If someone says "make this work for other games" or "why doesn't X work in LMU",
+  this is your skill.
+---
+
+# iRacing → Le Mans Ultimate Porting Skill
+
+You are porting iRacing-specific features in the K10 Motorsports plugin to work with Le Mans Ultimate
+(LMU). LMU runs on the rFactor 2 engine (Studio 397 / Motorsport Games), so its telemetry comes from
+the rF2 shared memory system. The goal is to make LMU a first-class citizen alongside iRacing — not a
+degraded fallback experience.
+
+## Architecture Context
+
+The K10 Motorsports codebase has four major components:
+
+1. **SimHub Plugin** (C# .NET 4.8) — Telemetry capture, trigger evaluation, commentary engine, strategy
+2. **Electron Overlay** (Vanilla JS) — Dashboard HUD rendering
+3. **Homebridge Plugin** (TypeScript) — HomeKit smart light integration
+4. **Next.js Web Platform** — Marketing site
+
+Porting work lives almost entirely in the **SimHub Plugin**, specifically in these files:
+
+| File | Role | Porting Relevance |
+|------|------|-------------------|
+| `TelemetrySnapshot.Capture.cs` | Game-specific telemetry reads | **PRIMARY** — all property mapping lives here |
+| `TelemetrySnapshot.cs` | Data model (fields + types) | Add new fields if LMU exposes data iRacing doesn't |
+| `IRacingSdkBridge.cs` | Direct iRacing SDK access | **REFERENCE ONLY** — shows what iRacing provides natively |
+| `TrackMapProvider.cs` | SVG track map from dead reckoning | Verify velocity/heading works for LMU |
+| `CommentaryEngine.cs` | Trigger evaluation + prompt selection | Mostly game-agnostic, but check trigger thresholds |
+| `Strategy/*.cs` | Fuel + tire strategy | Game-agnostic, but verify telemetry feeds are populated |
+| `Plugin.cs` | Entry point, HTTP API, property registration | Demo mode forces GameId to "iRacing" |
+
+## How Game Detection Works
+
+```csharp
+private enum GameId { Unknown, IRacing, ACC, AC, ACEvo, ACRally, LMU, RaceRoom, EAWRC, Forza }
+
+private static GameId DetectGame(string gameName)
+{
+    // Matches "lemans", "lmu", or "rfactor" → GameId.LMU
+    // iRacing matches "iracing" → GameId.IRacing
+}
+```
+
+LMU and rFactor 2 are treated identically (both map to `GameId.LMU`). SimHub reports the game name
+and the plugin normalizes it.
+
+## How Telemetry Properties Are Read
+
+Two access patterns exist side by side:
+
+```csharp
+// 1. SimHub normalized properties (cross-game, via GameData)
+float speed = GetNorm<float>(d, "SpeedKmh");
+
+// 2. Game-specific raw properties (via PluginManager)
+float steer = GetRaw<float>(pm, "Telemetry.mUnfilteredSteering", "DataCorePlugin.GameRawData.");
+```
+
+**Rule of thumb:** Use SimHub normalized properties as the primary source. Fall back to raw rF2 shared
+memory properties only when SimHub doesn't expose what you need (or exposes it incorrectly).
+
+### Raw Property Path Convention for LMU / rF2
+
+rFactor 2 shared memory data is accessed through SimHub at paths like:
+```
+DataCorePlugin.GameRawData.Telemetry.<fieldName>
+DataCorePlugin.GameRawData.Scoring.mScoringInfo.<fieldName>
+DataCorePlugin.GameRawData.Scoring.mVehicles[0].<fieldName>
+```
+
+The `GetRaw<T>(pm, path, prefix)` helper prepends the prefix automatically.
+
+---
+
+## The Porting Checklist
+
+When porting an iRacing feature to LMU, work through this checklist for each telemetry field:
+
+### Step 1: Identify the iRacing Source
+
+Find the iRacing property being read. It's usually one of:
+- **Direct SDK variable** via `GetRaw<T>(pm, "VariableName")` — e.g., `SteeringWheelAngle`, `dcBrakeBias`
+- **IRacingSdkBridge field** — e.g., `_sdkBridge.PlayerIRating` (parsed from session YAML)
+- **iRacing-specific SimHub property** — e.g., `IRacingExtraProperties.iRating`
+
+### Step 2: Find the rF2 / LMU Equivalent
+
+Consult the telemetry mapping reference (`references/telemetry-mapping.md`). The rF2 shared memory
+exposes data through these buffer types:
+
+| Buffer | Update Rate | Content |
+|--------|-------------|---------|
+| Telemetry | ~50 FPS | Vehicle dynamics, driver inputs, tire/suspension |
+| Scoring | ~5 FPS | Lap times, positions, pit status, flag state |
+| Rules | ~3 FPS | Session rule state |
+| Extended | ~5 FPS | Additional vehicle/session data |
+| ForceFeedback | ~400 FPS | FFB calculations |
+
+Common LMU raw property paths:
+
+```
+Telemetry.mUnfilteredThrottle      — throttle (0-1)
+Telemetry.mUnfilteredBrake         — brake (0-1)
+Telemetry.mUnfilteredSteering      — steering (-1 to +1, normalized)
+Telemetry.mUnfilteredClutch        — clutch (0-1, 1=disengaged in rF2)
+Telemetry.mGear                    — gear (-1=R, 0=N, 1-8=forward)
+Telemetry.mEngineRPM               — RPM
+Telemetry.mSpeed                   — speed (m/s, NOT km/h!)
+Telemetry.mFuel                    — fuel level (liters)
+Telemetry.mBatteryChargeFraction   — ERS/hybrid battery (0-1)
+Telemetry.mRearFlapLegalStatus     — DRS legality (0=none, 1=available, 2=active)
+Telemetry.mSpeedLimiter            — pit limiter active (bool)
+Telemetry.mTractionControl         — TC setting (float)
+Telemetry.mAntiLockBraking         — ABS setting (float)
+Telemetry.mRearBrakeBias           — rear brake bias (0-1)
+Telemetry.mSteeringArmForce        — FFB force
+Telemetry.mHighestFlagColor        — flag color enum
+Telemetry.mLocalAccel              — local acceleration vector (m/s²)
+
+Scoring.mScoringInfo.mGamePhase    — session state (enum)
+Scoring.mScoringInfo.mNumVehicles  — number of cars in session
+Scoring.mVehicles[N].mLapDist      — car N's distance around track
+Scoring.mVehicles[N].mInPits       — car N in pit lane (bool)
+Scoring.mVehicles[N].mTotalLaps    — car N's completed laps
+Scoring.mVehicles[N].mIsPlayer     — is this the player? (bool)
+```
+
+### Step 3: Handle Unit Conversions
+
+This is where most bugs hide. Key conversions:
+
+| Field | iRacing | LMU/rF2 | Conversion |
+|-------|---------|---------|------------|
+| Speed | m/s | m/s | None (but verify SimHub isn't pre-converting) |
+| Steering angle | radians | -1 to +1 ratio | Multiply by car's max steer angle (if available) or by π |
+| Brake bias | front % (0-100) | rear ratio (0-1) | `frontPct = (1 - rearBias) * 100` |
+| Acceleration | m/s² | m/s² | `G = value / 9.80665` |
+| Clutch | 0=out, 1=in | 0=engaged, 1=disengaged | May need inversion depending on SimHub normalization |
+| Fuel | liters | liters | None (but iRacing sometimes uses gallons in UI) |
+| Tire wear | 1=new, 0=worn (iRacing raw) | varies | Plugin convention: 0=new, 1=worn. Check direction. |
+| Tire temps | °C | °C | None, but verify inner/middle/outer mapping |
+
+### Step 4: Add the LMU Case to the Game Switch
+
+The existing pattern in `TelemetrySnapshot.Capture.cs` uses either:
+
+```csharp
+// Pattern A: if/else chain
+if (detectedGame == GameId.IRacing)
+    value = GetRaw<float>(pm, "iRacingProperty");
+else if (detectedGame == GameId.LMU)
+    value = GetRaw<float>(pm, "Telemetry.mLmuProperty", "DataCorePlugin.GameRawData.");
+else
+    value = GetNorm<float>(d, "SimHubNormalizedProperty");
+
+// Pattern B: switch in a helper method
+private float GetBrakeBias(GameId game, PluginManager pm, GameData d)
+{
+    switch (game)
+    {
+        case GameId.IRacing: return GetRaw<float>(pm, "dcBrakeBias");
+        case GameId.ACC:     return GetRaw<float>(pm, "Physics.BrakeBias", prefix) * 100f;
+        case GameId.LMU:     return (1f - GetRaw<float>(pm, "Telemetry.mRearBrakeBias", prefix)) * 100f;
+        default:             return (float)d.NewData.BrakeBias;
+    }
+}
+```
+
+**Prefer Pattern B** for new code — it's cleaner and easier to extend. When modifying existing Pattern A
+code, match the existing style for consistency.
+
+### Step 5: Test with Null/Zero Guards
+
+rF2 shared memory fields can be 0 or null before a session loads, or during transitions. Always guard:
+
+```csharp
+float raw = GetRaw<float>(pm, "Telemetry.mSomeField", prefix);
+if (raw != 0 || sessionRunning)
+    s.SomeField = ConvertUnits(raw);
+// else: leave at default (0 or previous value)
+```
+
+### Step 6: Verify the Downstream Consumer
+
+Trace how the field is used after capture:
+- **CommentaryEngine** — Check trigger thresholds. A trigger set for iRacing's scale may not fire
+  correctly for LMU values. Example: if yaw rate thresholds assume radians but LMU provides a
+  different scale.
+- **StrategyCoordinator** — Verify fuel/tire data flows correctly. The strategy engine is game-agnostic
+  but depends on `TelemetrySnapshot` being populated.
+- **Dashboard overlay** — The JSON API serves raw snapshot values. If LMU units differ from iRacing,
+  the overlay may display garbage.
+- **Homebridge** — Color mapping uses flags and severity. Verify LMU flags trigger the same codes.
+
+---
+
+## Known LMU Gaps (Current State of the Codebase)
+
+These are the features that are currently broken or missing for LMU. Consult the reference doc
+(`references/telemetry-mapping.md`) for the full mapping table.
+
+### Critical Gaps (Features Return 0 or Empty for LMU)
+
+1. **ABS Setting** — No `case GameId.LMU` in the ABS helper. Falls through to iRacing's `dcABS`
+   which doesn't exist in LMU. Fix: map to `Telemetry.mAntiLockBraking`.
+
+2. **Pit Speed Limit** — No LMU handling. iRacing uses `PitSpeedLimit` (m/s). LMU needs its own
+   source or a hardcoded fallback (most LMU series use 60 km/h pit limit).
+
+3. **Pit Menu Selections** — Fuel amount, tire pressures, compound choice. iRacing has `PitSv*`
+   variables; LMU has no equivalent mapped. The pitbox panel shows empty for LMU.
+
+4. **Multi-Car Arrays** — `CarIdxLapDistPct`, `CarIdxOnPitRoad`, `CarIdxLapCompleted` are iRacing-only
+   per-car arrays. LMU returns empty arrays. This breaks:
+   - Gap-to-car-ahead/behind calculations
+   - Track map opponent dots
+   - Proximity/spotter warnings
+   - **Fix:** Build arrays from `Scoring.mVehicles[N]` data (iterate mNumVehicles).
+
+5. **Sector Boundaries** — iRacing provides precise boundaries from session YAML. LMU falls back to
+   equal thirds (33%/67%). rF2 scoring may have sector data in `mVehicles[N].mSector` — investigate
+   whether `mCurSector1/2` provides boundaries.
+
+### Partial Gaps (Features Work But Incorrectly)
+
+6. **Steering Angle** — LMU reads `mUnfilteredSteering` (-1 to +1) but stores it without converting
+   to radians. Dashboard and commentary engine expect radians. Fix: multiply by estimated max steer
+   (or by π as approximation).
+
+7. **Session Flags** — Green, yellow, blue, black, white are mapped. Missing: red flag, debris flag,
+   checkered flag. The `mGamePhase` enum may have additional states for these.
+
+8. **Steering Torque** — Uses `mSteeringArmForce` which is force (Newtons), not torque (Nm). The
+   distinction matters for FFB analysis in commentary.
+
+### iRacing-Only Features (No LMU Equivalent)
+
+These genuinely don't exist in LMU and should degrade gracefully:
+
+- **iRating / Safety Rating / License** — iRacing's competitive rating system. Commentary engine
+  already falls back to generic "the driver" phrasing.
+- **Incident Limits** — iRacing tracks incidents toward penalty/DQ thresholds. LMU has penalties
+  but not the same escalation system.
+- **In-Car Adjustments** — iRacing's `dc*` variables (ARB, engine power, fuel mixture, weight jacker,
+  wing angles). LMU may expose some via rF2 telemetry but the property names differ completely.
+
+---
+
+## Coding Conventions in This Codebase
+
+Follow these when writing LMU porting code:
+
+### Property Access Helpers
+```csharp
+// Normalized (cross-game via SimHub)
+T GetNorm<T>(GameData d, string propName)
+
+// Raw game-specific (with optional prefix)
+T GetRaw<T>(PluginManager pm, string propName, string prefix = "DataCorePlugin.GameRawData.")
+
+// Raw array (iRacing per-car data)
+T[] GetRawArray<T>(PluginManager pm, string propName)
+```
+
+### Constants
+```csharp
+private const float MsToG = 1f / 9.80665f;  // m/s² → G conversion
+private const string Rf2Prefix = "DataCorePlugin.GameRawData.";  // rF2 raw property prefix
+```
+
+### Naming
+- LMU fields use `mCamelCase` prefix from rF2 (e.g., `mUnfilteredSteering`, `mRearBrakeBias`)
+- iRacing fields use PascalCase or dcCamelCase (e.g., `SteeringWheelAngle`, `dcBrakeBias`)
+- SimHub normalized fields use PascalCase (e.g., `SpeedKmh`, `BrakeBias`)
+
+### Testing
+- Unit tests live in `racecor-plugin/simhub-plugin/tests/K10Motorsports.Tests/`
+- Use NUnit framework
+- Mock `PluginManager` and `GameData` for telemetry tests
+- Dataset validation in `tests/validate_datasets.py`
+
+### Documentation
+- Add `// LMU: <explanation>` comments on every game-specific branch
+- Reference rF2 shared memory field names in comments
+- Note unit conversions with before/after units: `// rF2 rear bias (0-1) → front % (0-100)`
+
+---
+
+## Multi-Car Data Porting Strategy
+
+This is the most complex porting task because iRacing exposes flat per-car arrays while rF2 uses
+a structured vehicle list. Here's the recommended approach:
+
+### iRacing Model (Current)
+```csharp
+s.PlayerCarIdx = GetRaw<int>(pm, "PlayerCarIdx");
+s.CarIdxLapDistPct = GetRawArray<float>(pm, "CarIdxLapDistPct");  // [64] array
+s.CarIdxOnPitRoad = GetRawArray<bool>(pm, "CarIdxOnPitRoad");
+s.CarIdxLapCompleted = GetRawArray<int>(pm, "CarIdxLapCompleted");
+```
+
+### LMU Equivalent (To Build)
+```csharp
+case GameId.LMU:
+    int numVehicles = GetRaw<int>(pm, "Scoring.mScoringInfo.mNumVehicles", Rf2Prefix);
+    var lapDist = new float[numVehicles];
+    var onPit = new bool[numVehicles];
+    var lapsCompleted = new int[numVehicles];
+    int playerIdx = 0;
+
+    for (int i = 0; i < numVehicles; i++)
+    {
+        string veh = $"Scoring.mVehicles[{i}].";
+        lapDist[i] = GetRaw<float>(pm, veh + "mLapDist", Rf2Prefix);
+        onPit[i] = GetRaw<bool>(pm, veh + "mInPits", Rf2Prefix);
+        lapsCompleted[i] = GetRaw<int>(pm, veh + "mTotalLaps", Rf2Prefix);
+        if (GetRaw<bool>(pm, veh + "mIsPlayer", Rf2Prefix))
+            playerIdx = i;
+    }
+
+    // Normalize lapDist to 0-1 range (rF2 uses meters, need track length)
+    float trackLength = GetRaw<float>(pm, "Scoring.mScoringInfo.mLapDist", Rf2Prefix);
+    if (trackLength > 0)
+        for (int i = 0; i < numVehicles; i++)
+            lapDist[i] /= trackLength;
+
+    s.PlayerCarIdx = playerIdx;
+    s.CarIdxLapDistPct = lapDist;
+    s.CarIdxOnPitRoad = onPit;
+    s.CarIdxLapCompleted = lapsCompleted;
+    break;
+```
+
+**Important:** rF2's `mLapDist` is in meters (distance from start), not percentage. Divide by
+`mScoringInfo.mLapDist` (total track length in meters) to get 0-1 percentage matching iRacing's
+`CarIdxLapDistPct` convention.
+
+**Performance note:** This loop runs every ~100ms (6th frame). With 60 cars max, 60 iterations
+of `GetRaw` calls is acceptable but should be profiled. If slow, consider caching the scoring buffer
+read.
+
+---
+
+## rF2 Shared Memory Enums
+
+### mGamePhase (Session State)
+```
+0 = Before session has begun
+1 = Reconaissance laps
+2 = Grid walk-through
+3 = Formation lap
+4 = Starting light countdown
+5 = Green flag (race running)
+6 = Full course yellow / safety car
+7 = Session stopped
+8 = Session over
+9 = Pause (if enabled)
+```
+
+### mHighestFlagColor (Per-Driver Flag)
+```
+0 = None
+1 = Green
+2 = Blue
+3 = Yellow
+4 = Red (not currently mapped!)
+5 = Black
+6 = White
+7 = Checkered
+```
+
+### mFinishStatus
+```
+0 = None (still racing)
+1 = Finished
+2 = DNF
+3 = DQ
+```
+
+---
+
+## Verification Strategy
+
+After porting a feature, verify it works by checking these layers:
+
+1. **Telemetry Snapshot** — Is the field populated with sensible values during an LMU session?
+2. **HTTP API output** — Does `GET /k10mediabroadcaster/` include the correct value?
+3. **Dashboard overlay** — Does the relevant panel display correctly?
+4. **Commentary triggers** — Do triggers fire at appropriate thresholds for LMU data scale?
+5. **Strategy calculations** — Do fuel/tire estimates still make sense?
+6. **Homebridge colors** — Do flags map to the correct light colors?
+
+If you can't run a live LMU session, write unit tests with mock rF2 telemetry data that exercises
+the new code paths. The existing test suite in `K10Motorsports.Tests` has patterns for this.
+
+---
+
+## Output Format
+
+When completing a porting task, structure your output as:
+
+### Porting Report: [Feature Name]
+
+**Status:** [Complete / Partial / Blocked]
+**Files Changed:**
+- `path/to/file.cs` — [what changed]
+
+**Telemetry Mapping:**
+| Field | iRacing Source | LMU Source | Conversion |
+|-------|---------------|------------|------------|
+
+**Testing:**
+- [ ] Unit test added/updated
+- [ ] Null/zero guard in place
+- [ ] Downstream consumers verified
+
+**Known Limitations:**
+- [anything that can't be fully ported]
+
+**Code Changes:**
+[The actual diffs or new code]

--- a/src/agents/skills/iracing-to-lmu/references/telemetry-mapping.md
+++ b/src/agents/skills/iracing-to-lmu/references/telemetry-mapping.md
@@ -1,0 +1,183 @@
+# Complete Telemetry Mapping: iRacing ↔ LMU/rF2 ↔ SimHub Normalized
+
+## Table of Contents
+1. Core Vehicle Dynamics
+2. Driver Inputs
+3. Tire Data
+4. Driver Aids
+5. Session & Scoring
+6. Flags
+7. Pit Lane
+8. Energy Recovery / Hybrid
+9. In-Car Adjustments
+10. Multi-Car / Opponent Data
+11. Career / Rating
+12. Environment
+
+---
+
+## 1. Core Vehicle Dynamics
+
+| Field | iRacing Raw | LMU/rF2 Raw | SimHub Normalized | Units | Conversion Notes |
+|-------|------------|-------------|-------------------|-------|-----------------|
+| Speed | `Speed` | `Telemetry.mSpeed` | `SpeedKmh` | m/s (raw), km/h (SimHub) | SimHub pre-converts to km/h |
+| Lateral Accel | `LatAccel` | `Telemetry.mLocalAccel.x` | `AccelerationSway` | m/s² → G | Divide by 9.80665 |
+| Long Accel | `LongAccel` | `Telemetry.mLocalAccel.z` | `AccelerationSurge` | m/s² → G | Divide by 9.80665 |
+| Vert Accel | `VertAccel` | `Telemetry.mLocalAccel.y` | `AccelerationHeave` | m/s² → G | Divide by 9.80665 |
+| Yaw Rate | `YawRate` | `Telemetry.mLocalRot.y` | `Yaw` | rad/s | Direct read |
+| Velocity X | `VelocityX` | `Telemetry.mLocalVel.x` | `VelocityX` | m/s | Car-local lateral |
+| Velocity Z | `VelocityZ` | `Telemetry.mLocalVel.z` | `VelocityZ` | m/s | Car-local forward |
+| Heading/Yaw | `Yaw` | computed from `mOri` | `Yaw` | radians | rF2 may need extraction from orientation matrix |
+| RPM | `RPM` | `Telemetry.mEngineRPM` | `Rpms` | RPM | Direct |
+| Gear | `Gear` | `Telemetry.mGear` | `Gear` | int | -1=R, 0=N, 1+=forward |
+
+## 2. Driver Inputs
+
+| Field | iRacing Raw | LMU/rF2 Raw | SimHub Normalized | Units | Conversion Notes |
+|-------|------------|-------------|-------------------|-------|-----------------|
+| Throttle | `Throttle` | `Telemetry.mUnfilteredThrottle` | `ThrottlePedal` | 0-1 | Direct |
+| Brake | `Brake` | `Telemetry.mUnfilteredBrake` | `BrakePedal` | 0-1 | Direct |
+| Clutch | `Clutch` | `Telemetry.mUnfilteredClutch` | `ClutchPedal` | 0-1 | rF2: 1=disengaged; may need `1-value` |
+| Steering Angle | `SteeringWheelAngle` | `Telemetry.mUnfilteredSteering` | N/A | radians (iR) / -1 to +1 (rF2) | ⚠️ MUST convert: multiply rF2 by π or by max steer angle |
+| Steering Torque | `SteeringWheelTorque` | `Telemetry.mSteeringArmForce` | N/A | Nm (iR) / N (rF2) | ⚠️ Different physical quantity |
+
+## 3. Tire Data
+
+| Field | iRacing Raw | LMU/rF2 Raw | SimHub Normalized | Conversion Notes |
+|-------|------------|-------------|-------------------|-----------------|
+| Wear FL | `LFwearL/M/R` avg | `Telemetry.mWheels[0].mWear` | `TyreWearFrontLeft` | rF2: 1=new, 0=worn → invert to match plugin convention |
+| Wear FR | `RFwearL/M/R` avg | `Telemetry.mWheels[1].mWear` | `TyreWearFrontRight` | Same inversion |
+| Wear RL | `LRwearL/M/R` avg | `Telemetry.mWheels[2].mWear` | `TyreWearRearLeft` | Same inversion |
+| Wear RR | `RRwearL/M/R` avg | `Telemetry.mWheels[3].mWear` | `TyreWearRearRight` | Same inversion |
+| Temp FL | `LFtempCL/CM/CR` avg | `Telemetry.mWheels[0].mTemperature[0/1/2]` | `TyreTempFrontLeft` | °C, inner/middle/outer |
+| Temp FR | `RFtempCL/CM/CR` avg | `Telemetry.mWheels[1].mTemperature[0/1/2]` | `TyreTempFrontRight` | °C |
+| Temp RL | `LRtempCL/CM/CR` avg | `Telemetry.mWheels[2].mTemperature[0/1/2]` | `TyreTempRearLeft` | °C |
+| Temp RR | `RRtempCL/CM/CR` avg | `Telemetry.mWheels[3].mTemperature[0/1/2]` | `TyreTempRearRight` | °C |
+| Pressure FL | `LFpressure` | `Telemetry.mWheels[0].mPressure` | `TyrePressureFrontLeft` | kPa |
+| Pressure FR | `RFpressure` | `Telemetry.mWheels[1].mPressure` | `TyrePressureFrontRight` | kPa |
+
+**rF2 Wheel Order:** [0]=FL, [1]=FR, [2]=RL, [3]=RR (same as iRacing convention)
+
+## 4. Driver Aids
+
+| Field | iRacing Raw | LMU/rF2 Raw | SimHub Normalized | Conversion Notes |
+|-------|------------|-------------|-------------------|-----------------|
+| Brake Bias | `dcBrakeBias` | `Telemetry.mRearBrakeBias` | `BrakeBias` | iRacing: front % (0-100). rF2: rear ratio (0-1). Convert: `(1-rear)*100` |
+| TC Setting | `dcTractionControl` | `Telemetry.mTractionControl` | N/A | Both are float; check range |
+| ABS Setting | `dcABS` | `Telemetry.mAntiLockBraking` | N/A | ⚠️ Currently NOT mapped for LMU |
+| ABS Active | via flag | via threshold | `ElectronicsAbsActive` | Boolean event detection |
+| TC Active | via flag | via threshold | `ElectronicsTcActive` | Boolean event detection |
+
+## 5. Session & Scoring
+
+| Field | iRacing Raw | LMU/rF2 Raw | SimHub Normalized | Notes |
+|-------|------------|-------------|-------------------|-------|
+| Position | `PlayerCarPosition` | `Scoring.mVehicles[player].mPlace` | `Position` | 1-based |
+| Lap Count | `Lap` | `Scoring.mVehicles[player].mTotalLaps` | `CurrentLap` | |
+| Lap Time | `LapCurrentTime` | computed | `CurrentLapTime` | |
+| Best Lap | `LapBestLapTime` | `Scoring.mVehicles[player].mBestLapTime` | `BestLapTime` | |
+| Last Lap | `LapLastLapTime` | `Scoring.mVehicles[player].mLastLapTime` | `LastLapTime` | |
+| Delta to Best | `LapDeltaToBestLap` | computed | `DeltaToBestLap` | |
+| Track Distance | `LapDistPct` | `Scoring.mVehicles[player].mLapDist / mLapDist` | `TrackPositionPercent` | rF2 in meters → divide by track length |
+| Laps Remaining | `SessionLapsRemain` | computed from session info | `RemainingLaps` | |
+| Fuel Level | `FuelLevel` | `Telemetry.mFuel` | `Fuel` | Liters |
+| Incident Count | `PlayerCarMyIncidentCount` | `Scoring.mNumPenalties` | N/A | rF2 = penalties, not incidents |
+
+## 6. Flags
+
+| Flag | iRacing (SessionFlags bitmask) | LMU mGamePhase | LMU mHighestFlagColor | Notes |
+|------|-------------------------------|----------------|----------------------|-------|
+| Green | 0x0004 | 5 | 1 | Race running |
+| Yellow (Full Course) | 0x0008 | 6 | 3 | Safety car / FCY |
+| Yellow (Local) | 0x0008 | — | 3 | Per-driver flag |
+| Blue | 0x0080 | — | 2 | Being lapped |
+| Black | 0x0100 | — | 5 | Penalty / DQ |
+| White | 0x0200 | — | 6 | Slow car ahead |
+| Red | 0x0040 | 7 (stopped) | 4 | ⚠️ NOT currently mapped! |
+| Checkered | 0x0002 | 8 (over) | 7 | ⚠️ NOT currently mapped! |
+| Debris | 0x2000 | — | — | No direct rF2 equivalent |
+
+## 7. Pit Lane
+
+| Field | iRacing Raw | LMU/rF2 Raw | SimHub Normalized | Notes |
+|-------|------------|-------------|-------------------|-------|
+| In Pit Lane | `OnPitRoad` | `Scoring.mVehicles[player].mInPits` | `IsInPitLane` | Boolean |
+| Pit Limiter On | `dcPitSpeedLimiterToggle` | `Telemetry.mSpeedLimiter` | `PitLimiterOn` | Boolean |
+| Pit Speed Limit | `PitSpeedLimit` (m/s) | ❌ Not directly exposed | N/A | ⚠️ Need hardcoded fallback or series config |
+| Pit Fuel Request | `PitSvFuel` (liters) | ❌ Not mapped | N/A | rF2 may not expose pit menu state |
+| Pit Tire Pressures | `PitSvLFP/RFP/LRP/RRP` | ❌ Not mapped | N/A | |
+| Pit Compound | `PitSvTireCompound` | ❌ Not mapped | N/A | |
+
+## 8. Energy Recovery / Hybrid
+
+| Field | iRacing Raw | LMU/rF2 Raw | SimHub Normalized | Notes |
+|-------|------------|-------------|-------------------|-------|
+| Battery Level | `EnergyERSBatteryPct` | `Telemetry.mBatteryChargeFraction` | N/A | 0-1 range |
+| DRS Status | `DrsStatus` | `Telemetry.mRearFlapLegalStatus` | N/A | 0=none, 1=available, 2=active |
+| MGU-K Power | `dcMGUKDeployMode` | varies by car | N/A | Not all LMU cars have hybrid |
+
+## 9. In-Car Adjustments (iRacing dc* Variables)
+
+These are iRacing-specific driver controls. LMU equivalents are partial:
+
+| iRacing Variable | LMU Equivalent | Status |
+|-----------------|----------------|--------|
+| `dcBrakeBias` | `Telemetry.mRearBrakeBias` (converted) | ✓ Mapped |
+| `dcTractionControl` | `Telemetry.mTractionControl` | ✓ Mapped |
+| `dcABS` | `Telemetry.mAntiLockBraking` | ❌ NOT mapped |
+| `dcAntiRollFront` | Unknown | ❌ Not available |
+| `dcAntiRollRear` | Unknown | ❌ Not available |
+| `dcEnginePower` | Unknown | ❌ Not available |
+| `dcFuelMixture` | Unknown | ❌ Not available |
+| `dcWeightJackerLeft` | Unknown | ❌ Not available |
+| `dcWeightJackerRight` | Unknown | ❌ Not available |
+| `dcWingFront` | Unknown | ❌ Not available |
+| `dcWingRear` | Unknown | ❌ Not available |
+
+## 10. Multi-Car / Opponent Data
+
+| Field | iRacing | LMU/rF2 | Notes |
+|-------|---------|---------|-------|
+| Player Car Index | `PlayerCarIdx` | Find `mIsPlayer==true` in `mVehicles` | |
+| Car N Position % | `CarIdxLapDistPct[N]` | `Scoring.mVehicles[N].mLapDist / trackLength` | rF2 in meters |
+| Car N In Pits | `CarIdxOnPitRoad[N]` | `Scoring.mVehicles[N].mInPits` | Boolean |
+| Car N Laps Done | `CarIdxLapCompleted[N]` | `Scoring.mVehicles[N].mTotalLaps` | |
+| Car N Driver Name | Session YAML | `Scoring.mVehicles[N].mDriverName` | |
+| Car N Vehicle Name | Session YAML | `Scoring.mVehicles[N].mVehicleName` | |
+| Car N Class | Session YAML | `Scoring.mVehicles[N].mVehicleClass` | Multi-class support |
+| Number of Cars | Session YAML count | `Scoring.mScoringInfo.mNumVehicles` | |
+
+## 11. Career / Rating (iRacing Only)
+
+| Field | Source | LMU Equivalent |
+|-------|--------|---------------|
+| iRating | IRacingSdkBridge / YAML | ❌ None — use graceful fallback |
+| Safety Rating | IRacingSdkBridge / YAML | ❌ None |
+| License Class | IRacingSdkBridge / YAML | ❌ None |
+| Incident Limit (Penalty) | IRacingSdkBridge / YAML | ❌ None |
+| Incident Limit (DQ) | IRacingSdkBridge / YAML | ❌ None |
+
+## 12. Environment
+
+| Field | iRacing Raw | LMU/rF2 Raw | SimHub Normalized | Notes |
+|-------|------------|-------------|-------------------|-------|
+| Air Temp | `AirTemp` | `Scoring.mScoringInfo.mAmbientTemp` | `AirTemperature` | °C |
+| Track Temp | `TrackTempCrew` | `Scoring.mScoringInfo.mTrackTemp` | `RoadTemperature` | °C |
+| Rain | `Precipitation` | `Scoring.mScoringInfo.mRaining` | `RainIntensity` | rF2: 0-1 float |
+| Wind Speed | `WindVel` | `Scoring.mScoringInfo.mWind` | N/A | m/s |
+
+---
+
+## SimHub Property Path Quick Reference
+
+When reading raw rF2 properties through SimHub, prepend: `DataCorePlugin.GameRawData.`
+
+Examples:
+```
+DataCorePlugin.GameRawData.Telemetry.mEngineRPM
+DataCorePlugin.GameRawData.Telemetry.mFuel
+DataCorePlugin.GameRawData.Scoring.mScoringInfo.mGamePhase
+DataCorePlugin.GameRawData.Scoring.mVehicles[0].mLapDist
+```
+
+The `GetRaw<T>(pm, path, "DataCorePlugin.GameRawData.")` helper handles the prefix automatically.

--- a/src/agents/skills/tufte-audit/SKILL.md
+++ b/src/agents/skills/tufte-audit/SKILL.md
@@ -1,0 +1,396 @@
+---
+name: tufte-audit
+description: >
+  Audit any data visualization, chart, dashboard, or graphical display through the lens of Edward Tufte's
+  principles. Use this skill whenever you're reviewing, critiquing, or improving charts, graphs, dashboards,
+  sparklines, heatmaps, maps, calendars, or any visual display of quantitative information. Also trigger
+  when someone asks you to "review my chart", "improve this visualization", "check my dashboard",
+  "apply Tufte principles", "reduce chartjunk", "audit this graph", or anything involving data visualization
+  quality — even if they don't mention Tufte by name. If someone shows you a chart or dashboard and asks
+  "how can I make this better?", this is your skill.
+---
+
+# Tufte Audit Skill
+
+You are conducting a visualization audit through the eyes of Edward Tufte — statistician, professor emeritus
+at Yale, and the person who literally wrote the book(s) on data visualization. Tufte's core belief is that
+excellence in data graphics comes from substance, statistics, and design working together, and that every
+visual choice should serve the data, not the designer's ego.
+
+Your job is to examine a visualization (or code that produces one) and deliver a structured, actionable
+audit. You're not trying to be harsh — you're trying to help the visualization reach its potential. Tufte
+himself says "the task of the designer is to give visual access to the subtle and the difficult — that is,
+the revelation of the complex." Keep that spirit.
+
+## How to Conduct an Audit
+
+When given a visualization to audit (an image, code, description, or dashboard), work through the
+following checklist systematically. Not every section will apply to every visualization — skip what's
+irrelevant and focus your energy where the biggest improvements live.
+
+After the checklist, deliver:
+
+1. **A severity-ranked list of findings** — each tagged as 🔴 Critical, 🟡 Moderate, or 🟢 Minor
+2. **Specific, concrete fixes** — not vague advice like "simplify it", but "remove the grey background fill
+   and the outer border; let the data points float on white space"
+3. **A Tufte Score** — a 0–100 rating across the dimensions below, with a composite score
+
+If you're auditing *code* that generates a visualization, also produce corrected code with inline comments
+explaining each Tufte-motivated change.
+
+---
+
+## The Audit Checklist
+
+### 1. Data-Ink Ratio
+
+The data-ink ratio is the proportion of a graphic's total ink (or pixels) that represents actual data. Tufte's
+five laws:
+
+- **Above all else, show the data.**
+- **Maximize the data-ink ratio.** Every mark on the page should encode information. If you can erase
+  something without losing data, it shouldn't be there.
+- **Erase non-data-ink.** Backgrounds, decorative borders, heavy gridlines, 3D effects, gradient fills,
+  drop shadows — these are ink spent on nothing.
+- **Erase redundant data-ink.** If the same information is encoded twice (e.g., a bar's height AND a number
+  label AND a color AND a legend entry all saying the same thing), strip the redundancy.
+- **Revise and edit.** Good graphics are rewritten graphics.
+
+**What to look for:**
+- Background fills or shading that serve no data purpose
+- Heavy or dark gridlines (light ones are sometimes acceptable if they genuinely aid reading)
+- Borders and boxes around the chart area
+- 3D effects on bars, pies, or any chart element
+- Gradient fills, shadows, or glow effects
+- Redundant legends (if values are directly labeled, the legend is redundant)
+- Excessive tick marks or axis furniture
+- "Ducks" — decorative images or icons placed on the chart
+
+**Scoring (0–100):**
+- 90–100: Nearly every pixel serves data. Axis furniture is minimal. No decorative elements.
+- 70–89: Some unnecessary elements remain but data dominates.
+- 50–69: Noticeable decoration, heavy gridlines, or redundant encoding.
+- Below 50: The chart is mostly furniture. Data is a guest in its own house.
+
+---
+
+### 2. Chartjunk
+
+Chartjunk is Tufte's term for visual elements that don't help the viewer decode data. There are three
+species:
+
+- **Moiré vibration**: Patterns (hatching, cross-hatching, dense stripes) that create optical buzzing and
+  interfere with reading. Common in older bar charts that used pattern fills instead of solid colors.
+- **The Grid**: Heavy, prominent gridlines that dominate the data. Grids should be muted or absent — if
+  you need them, make them the lightest possible grey.
+- **The Duck**: Decoration masquerading as information. A chart shaped like a dollar bill, clip art icons
+  sprinkled around, or a pie chart rendered as a 3D exploded donut with a photograph texture. The name
+  comes from the architecture concept of a "decorated shed" vs. a "duck" (a building shaped like what it
+  sells).
+
+**What to look for:**
+- Pattern fills where solid (or no) fills would work
+- Gridlines that are darker than the data
+- Icons, illustrations, or clip art on or around the chart
+- 3D perspective effects (they always distort proportions)
+- Pie charts (Tufte is famously skeptical — they're rarely the best choice)
+- Unnecessary color variation (using 12 colors when 3 would do)
+- Animated transitions that don't encode data change
+- "Infographic" styling that prioritizes aesthetics over accuracy
+
+---
+
+### 3. Graphical Integrity & Proper Axes
+
+Tufte insists that visual representations must tell the truth. His Lie Factor formula:
+
+```
+Lie Factor = (size of effect shown in graphic) / (size of effect in data)
+```
+
+A Lie Factor of 1.0 is honest. Anything between 0.95 and 1.05 is acceptable. Outside that range, the
+graphic is distorting reality.
+
+**Six Principles of Graphical Integrity:**
+
+1. **Proportional representation.** The physical size of graphic elements must be directly proportional to
+   the quantities they represent. A bar twice as tall should represent a value twice as large.
+
+2. **Clear, detailed labeling.** Use thorough labels to defeat distortion and ambiguity. Write explanations
+   directly on the graphic. Label important events in the data. Axes must have:
+   - Units clearly stated
+   - Appropriate tick intervals (not too many, not too few)
+   - A zero baseline for bar charts (truncated axes exaggerate differences)
+   - Consistent scaling across panels being compared
+
+3. **Show data variation, not design variation.** The viewer's eye should be drawn to differences in the
+   data, not differences in the design.
+
+4. **Deflated, standardized units for money over time.** If showing monetary values across years, adjust
+   for inflation. Nominal dollars over time is almost always misleading.
+
+5. **Dimensional consistency.** Don't represent 1D data (a single number) with 2D areas or 3D volumes.
+   This is how a 53% increase gets visually exaggerated into a 783% increase (the infamous Lie Factor of
+   14.8 from Tufte's fuel economy example).
+
+6. **Context over decoration.** Content determines credibility. Cite your sources, state the time period,
+   explain methodology.
+
+**Axes-specific checklist:**
+- Does the y-axis start at zero for bar charts? (Line charts may have a non-zero baseline if the data
+  range warrants it, but it should be clearly marked.)
+- Are axis labels present and legible?
+- Are units specified?
+- Is the aspect ratio appropriate? (An artificially wide or tall chart can exaggerate or flatten trends.)
+- For dual-axis charts: are they actually necessary, or do they create false implied correlations?
+- Are comparison panels using the same scale?
+- Is there a Lie Factor issue? Check the visual proportions against the data.
+
+---
+
+### 4. Small Multiples
+
+Tufte defines small multiples as "illustrations of postage-stamp size are indexed by category or a label,
+sequenced over time like the frames of a movie, or ordered by a quantitative variable not used in the
+single image itself."
+
+The power of small multiples is that they enforce visual comparison by keeping the graphic form constant
+and letting the data change. The viewer's eye doesn't need to relearn how to read the chart — the design
+is the same, only the data varies.
+
+**When to recommend small multiples:**
+- The visualization crams too many series into one chart (spaghetti lines, overlapping bars)
+- A dashboard shows variations across categories, time periods, or geographies
+- An animation or interactive toggle is used where side-by-side comparison would be more effective
+- A pie chart shows composition across groups (replace with small multiples of bar charts)
+
+**What makes good small multiples:**
+- Consistent axes across all panels (this is critical — different scales defeat the purpose)
+- Clear, compact labeling (each panel is titled by its category/time/group)
+- Enough panels to show the pattern, but not so many that individual panels become unreadable
+- Removed redundancy: shared axes labeled once, not repeated on every panel
+- Tight spacing — the panels should feel like one integrated graphic, not a scattered grid
+
+**What to flag:**
+- Inconsistent scales across panels
+- Too much annotation repeated per panel
+- Panels too large (wasting space) or too small (unreadable)
+- Missing panel labels or unclear ordering
+
+---
+
+### 5. Sparklines
+
+Tufte invented the sparkline — "data-intense, design-simple, word-sized graphics." A sparkline has a
+data-pixel ratio of essentially 1.0. It consists entirely of data: no frames, no tick marks, no axes, no
+legends.
+
+**When to recommend sparklines:**
+- A table or dashboard shows numbers that have a temporal or sequential dimension
+- The viewer needs to see the trend/shape, not exact values
+- Space is at a premium (dashboards, reports, KPI summaries)
+- Inline context matters — the sparkline sits next to the text or number it illuminates
+
+**What makes a good sparkline:**
+- Word-sized: it fits naturally in a line of text or a table cell
+- Shows shape and trend, not precise values
+- Key values annotated minimally (perhaps the first value, last value, min, and max — as tiny dots or
+  numbers, not heavy labels)
+- Consistent scaling when multiple sparklines are compared side-by-side
+- No axes, no gridlines, no frames — pure data
+
+**What to flag:**
+- Sparklines with axes or grids (defeats the purpose)
+- Sparklines too large to be word-sized (they're becoming regular charts)
+- Inconsistent scaling across a set of sparklines being compared
+- Missing context numbers (the sparkline should be accompanied by at least the current/final value)
+
+---
+
+### 6. Heatmaps
+
+Heatmaps encode values as color intensity across a matrix. When done well, they reveal patterns in
+dense data that no other form can match. When done poorly, they become a confusing quilt.
+
+**Tufte-aligned heatmap principles:**
+- **Color choice matters profoundly.** Use a single-hue sequential scale (light-to-dark) for magnitude, or
+  a carefully chosen diverging scale (with a meaningful neutral midpoint) for deviation data. Rainbow/
+  jet colormaps are chartjunk — they impose artificial boundaries, are not perceptually uniform, and fail
+  for colorblind viewers.
+- **Label the data.** If the matrix isn't too large, show the actual values in cells. The color gives the
+  pattern; the numbers give the precision.
+- **Order matters.** Rows and columns should be ordered meaningfully — by value, by hierarchy, by time.
+  Alphabetical order rarely reveals structure.
+- **Provide a clear legend.** The color scale must be labeled with units and range.
+- **Reduce non-data-ink.** Thick cell borders, heavy gridlines between cells, and ornamental frames all
+  reduce the data-ink ratio.
+
+**What to flag:**
+- Rainbow/jet colormap usage
+- Missing color scale legend
+- Alphabetical instead of meaningful ordering
+- Heavy cell borders that fragment the visual pattern
+- No annotation of extreme or notable values
+- Inconsistent cell sizing
+
+---
+
+### 7. Calendars
+
+Calendar visualizations (like GitHub contribution graphs) are a special form of heatmap where time
+structure provides the grid. Tufte's principles apply directly:
+
+**Good calendar visualizations:**
+- Use the natural grid of weeks/months/days — the calendar structure is itself meaningful, not decorative
+- Apply color or size encoding consistently and with a clear scale
+- Don't overload with too many encodings per cell
+- Label months and days of the week clearly but minimally
+- Allow the pattern to emerge — the grid should recede, the data should pop
+
+**What to flag:**
+- Excessive decoration around the calendar grid
+- Color scales that don't start from a clear zero/baseline
+- Missing legends or unclear what the intensity represents
+- Cells too small to read or too large, wasting space
+- Inconsistent time coverage (gaps that aren't explained)
+
+---
+
+### 8. Maps & Geographical Visualization
+
+Tufte has specific, strong opinions on data maps. His core criticism of choropleth maps: they "mix up
+acres with people" by equating visual importance with geographic area rather than the quantity being
+measured. A vast, sparsely populated county dominates the eye while a dense, important city is a tiny
+speck.
+
+**Tufte-aligned map principles:**
+- **Be wary of choropleth maps.** Geographic area ≠ data importance. Consider alternatives:
+  cartograms, dot-density maps, hex-bin maps, or mesh maps (uniform grids).
+- **The ecological correlation problem.** Aggregate geographic data (county averages, state totals) can
+  reverse direction at the individual level. Maps showing aggregates should carry this caveat.
+- **Use lighter colors** so underlying geography remains visible.
+- **Label directly.** Annotate notable regions on the map rather than relying on a separate legend that
+  forces the eye to shuttle back and forth.
+- **Accompany with data tables.** Maps show patterns; tables provide precision. They complement each
+  other.
+- **Projections matter.** Mercator distorts area. Choose a projection appropriate to the data's geography
+  and state which projection you're using.
+
+**What to flag:**
+- Choropleth maps without consideration of area-vs-population distortion
+- Rainbow colormaps on maps
+- Missing scale/legend
+- No data table companion
+- Unlabeled or unclear boundaries
+- Misleading projection choice
+- Interactive maps where a static small-multiples view would be more effective for comparison
+
+---
+
+### 9. Layering, Separation & Interactivity
+
+From *Envisioning Information*: "Confusion and clutter are failures of design, not attributes of
+information." Layering and separation are how you tame complexity without throwing away dimensions.
+
+**Layering principles:**
+- **Visual hierarchy.** The most important data layer should be the most visually prominent. Secondary
+  reference layers (grids, baselines, annotations) should recede.
+- **Color as layer.** Use bright, saturated colors sparingly — for the data that matters most. Background
+  and reference elements should be muted greys or near-white.
+- **The 1+1=3 problem.** Two dark lines close together create a perceived third element (the white space
+  between them). This phantom contour is non-data-ink. Lighten, thin, or separate elements to prevent
+  it.
+- **Tables without grids.** Start without any gridlines. Add the minimum rules needed for clarity. Thin
+  lines beat thick lines. Vertical rules are rarely needed.
+- **White space is active.** Negative space separates layers and gives the eye room to parse.
+
+**Interactivity principles (extending Tufte for digital media):**
+Tufte's work is rooted in print, but his principles extend naturally to interactive visualizations:
+
+- **Detail-on-demand, not detail-by-default.** Show the overview first, let the user drill down. This is
+  Tufte's macro/micro principle applied to interaction: the macro view reveals pattern, the micro view
+  reveals detail.
+- **Tooltips over labels when density is high.** If labeling every point would create clutter, tooltips on
+  hover are a reasonable compromise — they're a form of layering.
+- **Filtering and highlighting over animation.** Let users select and compare subsets rather than watching
+  things move. Animation is temporal chartjunk unless it encodes a temporal variable.
+- **Linked views.** Multiple coordinated panels (brushing and linking) embody the small-multiples
+  principle in an interactive context.
+- **Don't make the user work for context.** If the user has to click three times to understand what a chart
+  shows, the chart has failed. The overview should be self-explanatory.
+- **Respect the data-ink ratio in UI chrome.** Toolbars, control panels, and filter widgets are non-data
+  elements. Keep them visually subordinate to the data display.
+
+---
+
+## Scoring Rubric
+
+After working through the checklist, produce a scorecard:
+
+| Dimension                  | Score (0–100) | Key Findings |
+|----------------------------|---------------|--------------|
+| Data-Ink Ratio             |               |              |
+| Chartjunk                  |               |              |
+| Graphical Integrity & Axes |               |              |
+| Small Multiples (if applicable) |          |              |
+| Sparklines (if applicable) |               |              |
+| Heatmaps (if applicable)   |               |              |
+| Calendars (if applicable)  |               |              |
+| Maps (if applicable)       |               |              |
+| Layering & Separation      |               |              |
+| Interactivity (if applicable) |            |              |
+| **Composite Tufte Score**  |               |              |
+
+The composite score is a weighted average. Data-Ink Ratio, Chartjunk, and Graphical Integrity are always
+weighted most heavily because they apply universally. Other dimensions are weighted only if they're
+relevant to the visualization being audited.
+
+---
+
+## Output Format
+
+Structure your audit report as:
+
+### Tufte Audit Report
+
+**Visualization:** [what's being audited]
+**Overall Tufte Score:** [X/100]
+**Summary:** [2–3 sentence executive summary of the visualization's strengths and biggest opportunities]
+
+#### Critical Findings (🔴)
+[Numbered list of issues that actively mislead or seriously undermine the visualization]
+
+#### Moderate Findings (🟡)
+[Numbered list of issues that reduce clarity or waste the viewer's attention]
+
+#### Minor Findings (🟢)
+[Numbered list of polish items and nice-to-haves]
+
+#### Scorecard
+[The scoring table above]
+
+#### Recommended Changes
+[Prioritized, specific, actionable fixes — not vague advice. If code was provided, include corrected code
+with comments explaining each change.]
+
+#### What's Working Well
+[Genuine praise for what the visualization does right. Even a bad chart usually has something worth
+keeping.]
+
+---
+
+## Philosophy Notes
+
+Keep these Tufte quotes in mind as you audit — they capture the spirit:
+
+- "Above all else, show the data."
+- "Graphical excellence is that which gives to the viewer the greatest number of ideas in the shortest
+  time with the least ink in the smallest space."
+- "Clutter and confusion are not attributes of data — they are shortcomings of design."
+- "The task of the designer is to give visual access to the subtle and the difficult."
+- "Graphical excellence is nearly always multivariate."
+- "If the statistics are boring, then you've got the wrong numbers."
+
+When in doubt, ask: "Does this visual element help the viewer understand the data?" If yes, keep it. If no,
+it's a candidate for removal or muting. And always remember — Tufte's goal isn't minimalism for its own
+sake. It's clarity. A dense, information-rich graphic is excellent if every element earns its place.

--- a/src/agents/skills/tufte-audit/references/tufte-deep-reference.md
+++ b/src/agents/skills/tufte-audit/references/tufte-deep-reference.md
@@ -1,0 +1,231 @@
+# Edward Tufte Deep Reference
+
+## Table of Contents
+1. The Books and Their Focus
+2. Data-Ink Ratio — Extended Examples
+3. Chartjunk — The Three Species in Detail
+4. Lie Factor — Worked Examples
+5. Small Multiples — When and How
+6. Sparklines — Design Specifications
+7. Micro/Macro Design
+8. Layering and Separation — Color and Grid Strategy
+9. Maps — The Choropleth Problem
+10. Minard's Napoleon Chart — The Gold Standard
+
+---
+
+## 1. The Books and Their Focus
+
+Tufte's five self-published books each tackle a different facet of information design:
+
+- **The Visual Display of Quantitative Information (1983, 2001)**: The foundational text. Introduces
+  data-ink ratio, chartjunk, graphical integrity, the Lie Factor, and small multiples. Focuses on
+  statistical graphics.
+- **Envisioning Information (1990)**: Deals with design strategies — escaping flatland (showing
+  multivariate data on 2D surfaces), micro/macro readings, layering and separation, color theory,
+  small multiples, and narrative in visual design.
+- **Visual Explanations (1997)**: Focuses on depicting causality, mechanism, dynamics, and process.
+  Includes the Challenger disaster analysis showing how better visualization might have prevented
+  the launch decision.
+- **Beautiful Evidence (2006)**: Introduces sparklines formally. Discusses the fundamental principles
+  of analytical design, corruption in evidence presentations (PowerPoint critique), and mapped
+  pictures (integrating data with images).
+- **Seeing with Fresh Eyes (2020)**: Expands on meaning, space, data, and truth in visual design.
+
+---
+
+## 2. Data-Ink Ratio — Extended Examples
+
+**Formula:** Data-Ink Ratio = Data-Ink / Total Ink Used in the Graphic
+
+**Equivalently:** 1.0 − (proportion of graphic that can be erased without loss of data-information)
+
+**High data-ink examples:**
+- A simple scatterplot with data points only, axis labels, and nothing else
+- A Tufte-style boxplot (replaces the box with a dot for median, thin line for IQR, gap for CI)
+- A sparkline (data-ink ratio ≈ 1.0)
+
+**Low data-ink examples:**
+- A bar chart with gradient fills, 3D effects, heavy gridlines, a border, a background image, and a
+  decorative legend — the data (bar heights) is maybe 10% of the total ink
+
+**The "erase" test:** For any element, ask "if I remove this, does the viewer lose data?" If no, remove it.
+Apply iteratively.
+
+**Range-frame concept:** Instead of drawing full axes that extend beyond the data range, draw axes only
+as far as the data extends. The axis endpoints themselves become data (showing the min and max).
+
+---
+
+## 3. Chartjunk — The Three Species in Detail
+
+### Moiré Vibration
+Pattern fills (hatching, cross-hatching, stippling) create optical interference that makes the eye vibrate.
+Common in charts from the 1970s–90s when printing was monochrome. In the digital age, there's no
+excuse — use solid colors, direct labels, or small multiples instead.
+
+### The Grid
+Gridlines are among the most common forms of chartjunk. They exist to help the reader estimate values,
+but if they're prominent, they compete with the data. Tufte's recommendation:
+- Start without gridlines
+- If needed, use the lightest possible grey (near-white)
+- Never darker than the data
+- Remove where direct labeling can replace grid-reading
+
+### The Duck
+Named after the Big Duck building on Long Island, this is decoration pretending to be substance.
+Examples: a chart about money shaped like a dollar bill, a chart about food with food photographs as
+backgrounds, 3D pie charts with perspective, pictograms where icon size doesn't match data proportions.
+
+**The key test:** Does the viewer learn more from the decoration, or is the decoration something they need
+to "see past" to read the data? If the latter, it's a duck.
+
+---
+
+## 4. Lie Factor — Worked Examples
+
+**Example 1 (from Tufte):** A 1978 New York Times chart showed fuel economy standards rising from
+18 mpg to 27.5 mpg (a 53% increase in data). But the graphic used road lines with perspective that made
+the visual increase appear to be 783%. Lie Factor = 783/53 = 14.8.
+
+**Example 2:** A bar chart with a y-axis starting at 50 instead of 0. Data values of 52 and 58 appear to
+show the second bar as 6× taller than the first, when the actual ratio is 58/52 ≈ 1.12. The Lie Factor
+is approximately 6/1.12 ≈ 5.4.
+
+**Example 3:** Bubble charts where diameter represents value but the eye reads area. A value that doubles
+(2×) appears as a bubble with 2× diameter but 4× area, creating a Lie Factor of 2.0. If using bubbles,
+scale by area, not diameter.
+
+---
+
+## 5. Small Multiples — When and How
+
+**The core idea:** Repeat the same graphic frame with different data slices. The constancy of design
+allows the viewer to focus on what changes (the data) rather than relearning the chart.
+
+**Ideal use cases:**
+- Time series: one panel per year/month/quarter
+- Geographic: one panel per region/country
+- Categorical: one panel per product/segment/demographic
+- Experimental: one panel per condition
+
+**Implementation rules:**
+- All panels MUST share the same axes and scales (otherwise comparison is broken)
+- Panel labels should be in a consistent position
+- Shared axis labels go on the outside edges, not repeated per panel
+- Arrange panels in a meaningful order (temporal, geographic, alphabetical as last resort)
+- The grid layout itself can encode information (rows = one variable, columns = another)
+
+**Anti-patterns:**
+- Different y-axis ranges per panel (the most common and most damaging error)
+- Interactive tabs/dropdowns that show one panel at a time (defeats comparison)
+- So many panels the individual graphics become illegible
+- Faceted charts where the faceting variable isn't clearly labeled
+
+---
+
+## 6. Sparklines — Design Specifications
+
+**Definition:** "Data-intense, design-simple, word-sized graphics" — Tufte, Beautiful Evidence (2006)
+
+**Key properties:**
+- Typically 1–2 line-heights tall, spanning perhaps 100–200 pixels wide
+- No axes, no gridlines, no tick marks, no frames
+- May include tiny reference markers: first/last value, high/low points
+- Scaling context comes from nearby text: "Revenue $4.2M ▃▅▆▇▅▃▂ $3.1M"
+- Data-pixel ratio ≈ 1.0 (every pixel is data)
+
+**Types:**
+- Line sparklines (most common) — show trend/trajectory
+- Bar/column sparklines — show discrete period comparisons
+- Win/loss sparklines — binary outcomes over time
+- Area sparklines — emphasize volume/magnitude
+
+**In tables:** Sparklines transform static number tables into rich analytical displays. A column of
+sparklines next to a column of current values gives both the shape of history and the present state.
+
+---
+
+## 7. Micro/Macro Design
+
+From Envisioning Information: a well-designed graphic works at both the macro level (overall pattern,
+trend, gestalt) and the micro level (individual data points, annotations, specific values).
+
+**The principle:** Don't sacrifice detail for overview or overview for detail. A great visualization gives
+both simultaneously.
+
+**Examples:**
+- A city map works at macro (neighborhood structure, rivers, highways) and micro (individual streets,
+  buildings)
+- A stock chart works at macro (overall trend direction) and micro (specific daily prices, events)
+- Vietnam Veterans Memorial works at macro (the scale of loss) and micro (individual names)
+
+**Implication for audit:** Check whether the visualization collapses to only one level. Does zooming in
+reveal nothing new? Does stepping back reveal no pattern? Either failure suggests a design opportunity.
+
+---
+
+## 8. Layering and Separation — Color and Grid Strategy
+
+**Color guidelines (from Tufte):**
+- Bright, saturated colors create "loud, unbearable effects" in large areas
+- Use bright colors sparingly — for data highlights — against muted backgrounds
+- Background color should be the lightest color in the graphic (typically white or near-white)
+- Color should encode data, not decoration
+- For sequential data: single-hue gradient (light = low, dark = high)
+- For diverging data: two-hue gradient with a neutral midpoint
+- Never rainbow/jet colormaps — they impose artificial boundaries and are not perceptually uniform
+
+**Grid and table strategy:**
+- Start with no gridlines at all
+- Add only what's needed, one line at a time
+- Thin rules > thick rules
+- Horizontal rules are usually sufficient; vertical rules are rarely needed
+- Every rule you add is non-data-ink — justify its presence
+
+**The 1+1=3 effect:** Two dark elements close together create a perceived third element (the white gap
+between them). This phantom is noise. Solutions: lighten elements, increase spacing, or remove one.
+
+---
+
+## 9. Maps — The Choropleth Problem
+
+**Core issue:** Choropleth maps equate visual weight with geographic area, not with the variable being
+displayed. Wyoming (97,813 sq mi, ~580,000 people) gets vastly more visual emphasis than Brooklyn
+(~70 sq mi, ~2,600,000 people).
+
+**Tufte's alternatives:**
+- **Mesh maps / grid maps:** Divide the geography into uniform cells, colorize by data value. Removes
+  the area-bias distortion.
+- **Dot-density maps:** One dot per N units (people, cases, dollars). Visual density maps to data density.
+- **Cartograms:** Distort geography so area represents the data variable (e.g., population). Preserves
+  adjacency but sacrifices familiar shapes.
+- **Small multiples of focused maps:** Instead of one national map, show regional panels at higher zoom.
+
+**The ecological correlation problem:** Aggregate geographic data can reverse individual-level patterns.
+Tufte warns that correlations at county/state level may not reflect individual behavior. Maps should
+acknowledge this limitation.
+
+---
+
+## 10. Minard's Napoleon Chart — The Gold Standard
+
+Tufte called Charles Joseph Minard's 1869 map of Napoleon's Russian campaign "probably the best
+statistical graphic ever drawn." It displays six variables simultaneously:
+
+1. Army size (line width)
+2. Latitude (y-axis position)
+3. Longitude (x-axis position)
+4. Direction of travel (color: gold = advance, black = retreat)
+5. Temperature (bottom scale, linked to geography)
+6. Date (linked to temperature and position)
+
+**Why it's the gold standard:**
+- Extremely high data density with no chartjunk
+- Multiple variables integrated into a single coherent narrative
+- The story (winter destroyed the army, not combat) is self-evident from the visual
+- Every visual element encodes data — no decoration
+- The temperature graph at the bottom is linked spatially to the map, creating a layered reading
+
+Use this as the aspirational benchmark when auditing — does the visualization being reviewed use its
+space and ink as efficiently as Minard used his?


### PR DESCRIPTION
## Summary
- Adds **tufte-audit** skill that audits data visualizations through Edward Tufte's principles (data-ink ratio, chartjunk, graphical integrity, small multiples, sparklines, heatmaps, calendars, maps, layering/interactivity). Produces 0-100 scored audit reports with severity-ranked findings and corrected code.
- Adds **iracing-to-lmu** skill that guides porting iRacing-specific features to Le Mans Ultimate. Includes a complete telemetry mapping reference (iRacing ↔ rF2 ↔ SimHub), rF2 shared memory enums, unit conversion tables, and code templates for the 5 critical LMU gaps (ABS, pit menu, multi-car arrays, flags, sectors).

## Benchmark Results

**tufte-audit:** 100% assertion pass rate with skill vs 83.3% without (3 test cases)
**iracing-to-lmu:** 100% assertion pass rate with skill vs 55.6% without (3 test cases on real codebase)

Key wins with the porting skill: prevented wrong rF2 property names, caught missing unit conversions (meters→percentage for lap distance), and ensured complete flag enum coverage.

## Test plan
- [ ] Verify skills trigger correctly when referenced in Claude Code / Cowork
- [ ] Run a sample Tufte audit on an existing dashboard component
- [ ] Use the LMU skill to port one of the documented gaps (e.g., ABS setting)
- [ ] Confirm the telemetry mapping reference matches live rF2 shared memory in an LMU session

Generated with Claude Code