### PR TITLE
Add minimal and minimal+ visual modes

### DIFF
--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -1,0 +1,322 @@
+# RaceCor Overlay — Visual Style Guide
+
+## Overview
+
+The RaceCor overlay supports three visual styles, each optimized for different viewing contexts:
+- **Standard** — full broadcasting aesthetic with effects and branding
+- **Minimal** — Tufte-pure data visualization, maximum clarity
+- **Minimal+** — racing-educated Tufte with essential data-reactive effects
+
+All three modes share the same underlying data and layout structure. Visual style is applied via CSS custom properties and body class toggles, with no HTML restructuring required.
+
+---
+
+## CSS Variable System
+
+The overlay defines a comprehensive CSS variable library for consistent theming:
+
+### Layout & Spacing
+```css
+--corner-r: 8px;          /* Primary border radius */
+--corner-r-sm: 5px;       /* Secondary border radius */
+--gap: 4px;               /* Intra-panel gaps */
+--panel-gap: 6px;         /* Inter-panel spacing */
+--edge: 10px;             /* Screen edge inset */
+--pad: 6px;               /* Padding inside panels */
+```
+
+### Colors
+```css
+--bg: hsla(0, 0%, 8%, 0.90);             /* Primary background */
+--bg-panel: hsla(0, 0%, 6%, 0.90);       /* Panel background */
+--bg-logo: hsla(0, 0%, 12%, 0.90);       /* Logo panel background */
+--border: hsla(0, 0%, 100%, 0.14);       /* Standard border color */
+
+--text-primary: hsla(0, 0%, 100%, 1.0);      /* Headings, values */
+--text-secondary: hsla(0, 0%, 100%, 0.69);   /* Labels, hints */
+--text-dim: hsla(0, 0%, 100%, 0.55);         /* Footnotes, muted */
+
+--red: #e53935;      /* Caution / Alert */
+--green: #43a047;    /* Optimal / Safe */
+--amber: #ffb300;    /* Warning / Flag */
+--blue: #1e88e5;     /* Info */
+--orange: #fb8c00;   /* Secondary alert */
+--cyan: #00acc1;     /* Accent */
+--purple: hsl(280,80%,70%);  /* Accent */
+```
+
+### Typography
+```css
+--ff: 'Barlow Condensed', 'Corbel', 'Segoe UI', system-ui, sans-serif;
+--ff-display: 'Cinzel Decorative', 'Georgia', serif;
+--ff-mono: 'JetBrains Mono', 'Consolas', 'SF Mono', monospace;
+
+--fs-xl: 20px;    /* Large headings */
+--fs-lg: 13px;    /* Panel titles */
+--fs-md: 11px;    /* Standard text */
+--fs-sm: 11px;    /* Labels */
+--fs-xs: 10px;    /* Fine print */
+
+--fw-black: 800;   /* Strongest emphasis */
+--fw-bold: 700;    /* Values, titles */
+--fw-semi: 600;    /* Emphasis */
+--fw-medium: 500;  /* Mid-weight */
+--fw-regular: 400; /* Body text */
+```
+
+### Animation & Transitions
+```css
+--t-fast: 180ms ease;
+--t-med: 350ms ease;
+--t-slow: 600ms ease-out;
+```
+
+### Data Visualization
+```css
+--sentiment-h: 0;      /* Commentary sentiment hue */
+--sentiment-s: 0%;     /* Sentiment saturation */
+--sentiment-l: 0%;     /* Sentiment lightness */
+--sentiment-alpha: 0;  /* Sentiment halo opacity */
+```
+
+---
+
+## Visual Modes
+
+### Standard Mode (Default)
+
+**Philosophy:** Broadcast-grade presentation with full cinematic effects. Maximum visual impact for streaming audiences.
+
+**Characteristics:**
+- Full panel borders: `--border: hsla(0,0%,100%,0.14)`
+- WebGL effects enabled: bloom, glow, ambient light sampling
+- Sentiment halo around dashboard (color-reactive based on commentary tone)
+- Animated stripe patterns on race control banner
+- Track map player dot glow with drop shadow
+- Car manufacturer logo visible (branding)
+- K10 logo visible (branding)
+- Game logo visible (branding)
+- Fuel bar: gradient green → amber → red
+- iRating: segmented bar + numeric value
+- Safety Rating: pie chart + numeric value
+- Commentary panel: 14px padding
+- G-force vignette at full intensity
+- Backdrop filter blur on panels (CSS)
+- All animations enabled
+
+**CSS Class:** (none — this is the root state)
+
+**Use Cases:**
+- Broadcast streams
+- Public viewing / esports venues
+- Premium viewing experience
+
+---
+
+### Minimal Mode
+
+**Philosophy:** Tufte-pure information visualization. Maximum data-ink ratio, zero decoration. All cognitive load goes to reading actual data values.
+
+**Characteristics:**
+- No panel borders: `--border: transparent`
+- WebGL effects disabled (all canvas/glow hidden)
+- No sentiment halo (alpha 0)
+- No animated stripe patterns on race control banner — solid color block only
+- No track map player dot glow — bright dot only
+- Tighter padding: `--pad: 4px`, `--gap: 3px`
+- Car manufacturer logo hidden
+- K10 branding logo hidden
+- Game logo hidden
+- Fuel bar: single-hue green darkening (no gradient)
+- iRating: number only, no bar
+- Safety Rating: number only, no pie chart
+- Commentary panel: hidden or minimal
+- Labels use regular weight, values use bold — maximum contrast
+- Label font sizes reduced by 1px
+- No backdrop-filter blur
+- No animations except essential state changes (toggles, transitions)
+- Drive mode: no background tints, pure black with bright data elements
+
+**CSS Class:** `body.mode-minimal`
+
+**Use Cases:**
+- Accessibility-first environments
+- Data archival / analysis overlays
+- Minimal distraction during intense racing
+- Testing and verification
+
+**CSS Variable Overrides:**
+```css
+body.mode-minimal {
+  --border: transparent;
+  --pad: 4px;
+  --gap: 3px;
+}
+```
+
+---
+
+### Minimal+ Mode
+
+**Philosophy:** Racing-educated Tufte. Preserves essential data-reactive effects that communicate urgency and state, while removing static decoration. A middle path: maximum clarity + racing context.
+
+**Characteristics:**
+- No panel borders: `--border: transparent`
+- WebGL effects enabled but reduced intensity (60% of standard)
+  - RPM tachometer bloom preserved (color-reactive)
+  - Ambient light off
+  - Glow canvas off (replaced by CSS-only glow)
+- Track map player dot glow preserved, tightened radius
+- Fuel bar: green → amber → red (racing color convention)
+- Safety Rating: pie chart visible + license-class threshold marks
+- Car manufacturer logo visible (contextual data for broadcast)
+- K10 branding logo hidden
+- Game logo hidden
+- Commentary panel visible with tighter padding (10px vs 14px)
+- Sentiment halo at 40% of standard alpha (subtle peripheral cue)
+- Flag banner: animated stripe on flag state change, settles after 4 seconds
+- G-force vignette at 50% intensity (peripheral safety cue)
+- Labels use regular weight, values use bold
+- Tighter padding: `--pad: 5px`, `--gap: 3px`
+
+**CSS Class:** `body.mode-minimal-plus`
+
+**Use Cases:**
+- Serious racing broadcasts (league play, esports)
+- Professional stream overlays with pro-audience context
+- Training / coaching scenarios (need urgency cues)
+
+**Key Difference from Minimal:**
+Data-reactive glow on tachometer stays because RPM heat is actively changing during driving and the color intensity (brighter at redline) encodes urgency that drivers train to perceive. Static decoration (ambient light, sentiment halo at full intensity) is removed.
+
+---
+
+## Feature Gates
+
+### Preset Buttons (Settings → Effects Tab)
+
+Three preset buttons appear at the top of the Effects settings tab:
+- **Minimal** — applies all Minimal mode toggles, gates to K10 Pro
+- **Minimal+** — applies all Minimal+ mode toggles, gates to K10 Pro
+- **Standard** — applies all Standard mode toggles, always available
+
+When K10 Pro is not connected, Minimal and Minimal+ buttons show a pro badge and trigger navigation to the Connections tab.
+
+### Per-Feature Toggles
+
+Individual effect toggles live in the Effects tab and can be mixed:
+- **Panel Borders** (default: on)
+- **WebGL Effects** (default: on)
+- **Ambient Light** (default: reflective)
+- **Sentiment Halo** (default: on)
+- **Commentary Glow** (default: on)
+- **Race Control Animation** (default: on)
+- **Track Map Glow** (default: on)
+- **Redline Flash** (default: on)
+- **Pit Limiter Bonkers** (default: on)
+
+The preset buttons set all toggles at once; individual toggles allow fine-tuning.
+
+---
+
+## Implementation Details
+
+### Body Classes
+
+Visual mode is applied via CSS body class:
+```html
+<!-- Standard (no class) -->
+<body>
+
+<!-- Minimal -->
+<body class="mode-minimal">
+
+<!-- Minimal+ -->
+<body class="mode-minimal-plus">
+```
+
+### Settings Storage
+
+Visual preset is stored in `_settings.visualPreset`:
+```javascript
+_settings.visualPreset = 'standard' | 'minimal' | 'minimal-plus';
+```
+
+Individual toggles are stored separately:
+```javascript
+_settings.showBorders = boolean;
+_settings.showWebGL = boolean;
+_settings.ambientMode = 'reflective' | 'matte' | 'plastic' | 'off';
+_settings.showSentimentHalo = boolean;
+_settings.showCommentaryGlow = boolean;
+_settings.showRcAnimation = boolean;
+_settings.showMapGlow = boolean;
+_settings.showRedlineFlash = boolean;
+_settings.showBonkers = boolean;
+_settings.showK10Logo = boolean;
+_settings.showCarLogo = boolean;
+_settings.showGameLogo = boolean;
+```
+
+### Drive Mode
+
+Drive mode follows Minimal principles by default:
+- Pure black background
+- No tints or atmospheric effects
+- Bright data elements floating on black
+- Optional redline flash (CSS property `--redline-flash: on/off`)
+- Color-coding preserved (data, not decoration)
+
+---
+
+## Accessibility
+
+### Color Contrast
+
+All text meets WCAG AAA standards (7:1 ratio minimum):
+- Primary text on dark background: `--text-primary` on `--bg`
+- Secondary text: `--text-secondary` has sufficient separation
+
+### Colorblind Safety
+
+- Gap ahead/behind uses direction AND color (left = behind, right = ahead)
+- Fuel state: green → amber → red uses hue AND saturation darkening
+- Tire temperature: color palette tested for deuteranopia and protanopia
+
+### Motion
+
+- All animations respect `prefers-reduced-motion`
+- Essential feedback (toggle state changes) use brief, direct transitions
+- The Minimal preset disables non-essential animations entirely
+
+---
+
+## Migration Guide
+
+### From Standard to Minimal
+
+Settings automatically collapse when "Minimal" preset is clicked:
+1. All glow/bloom effects hidden
+2. Panel borders removed
+3. Logos hidden
+4. Padding tightened
+5. Animations disabled (except essential state changes)
+
+No user data is lost — switching back to Standard restores all effects.
+
+### Custom Presets
+
+Users who want "Minimal but keep the fuel gradient" can:
+1. Click Minimal preset
+2. Manually toggle on `showWebGL` or individual toggles
+3. The preset updates the preset button to show "Custom" (not yet implemented, but possible)
+
+---
+
+## Future Enhancements
+
+- **Dark mode / Light mode** — standard CSS dark color scheme swap
+- **Custom color schemes** — user-defined hue ranges for alert colors
+- **High-contrast mode** — white text, black background, max saturation
+- **Dyslexia-friendly font** — OpenDyslexic or similar fallback
+- **Salient object detection** — AI-based glow routing to only the most critical data element per frame

--- a/racecor-overlay/dashboard.html
+++ b/racecor-overlay/dashboard.html
@@ -46,6 +46,7 @@
 <link rel="stylesheet" href="modules/styles/leaderboard.css">
 <link rel="stylesheet" href="modules/styles/datastream.css">
 <link rel="stylesheet" href="modules/styles/effects.css">
+<link rel="stylesheet" href="modules/styles/modes.css">
 <link rel="stylesheet" href="modules/styles/settings.css">
 <link rel="stylesheet" href="modules/styles/connections.css">
 <link rel="stylesheet" href="modules/styles/rally.css">
@@ -779,6 +780,7 @@
       <div class="settings-sidebar">
         <div class="settings-sidebar-item active" data-tab="sections" onclick="switchSettingsTab(this)">Dashboard</div>
         <div class="settings-sidebar-item" data-tab="branding" onclick="switchSettingsTab(this)">Branding</div>
+        <div class="settings-sidebar-item" data-tab="effects" onclick="switchSettingsTab(this)">Effects</div>
         <div class="settings-sidebar-item" data-tab="layout" onclick="switchSettingsTab(this)">Layout</div>
         <div class="settings-sidebar-item" data-tab="commentary" data-pro-tab="commentary" onclick="switchSettingsTab(this)">Commentary</div>
         <div class="settings-sidebar-item" data-tab="connections" onclick="switchSettingsTab(this)">Connections</div>
@@ -877,12 +879,32 @@
 
     </div>
 
-    <!-- ── Tab: Branding — logos, effects, ambient light ── -->
+    <!-- ── Tab: Branding — logos only ── -->
     <div class="settings-tab-content" id="settingsTabBranding">
       <div class="settings-two-col">
       <div class="settings-row"><span class="settings-label">K10 Logo</span><div class="settings-toggle on" data-section="k10LogoSquare" data-key="showK10Logo" onclick="toggleSetting(this)"></div></div>
       <div class="settings-row"><span class="settings-label">Car Manufacturer</span><div class="settings-toggle on" data-section="carLogoSquare" data-key="showCarLogo" onclick="toggleSetting(this)"></div></div>
       <div class="settings-row"><span class="settings-label">Game Logo</span><div class="settings-toggle on" data-key="showGameLogo" onclick="toggleGameLogo(this)"></div></div>
+      </div>
+    </div>
+
+    <!-- ── Tab: Effects — visual styles, lighting, glow, animations ── -->
+    <div class="settings-tab-content" id="settingsTabEffects">
+      <div class="settings-two-col">
+
+      <!-- Visual Style Presets -->
+      <div class="settings-group-label">Visual Style</div>
+      <div class="settings-preset-row">
+        <button class="settings-preset-btn" data-preset="minimal" data-pro-feature="modules" onclick="applyVisualPreset('minimal')">Minimal</button>
+        <button class="settings-preset-btn" data-preset="minimal-plus" data-pro-feature="modules" onclick="applyVisualPreset('minimal-plus')">Minimal+</button>
+        <button class="settings-preset-btn active" data-preset="standard" onclick="applyVisualPreset('standard')">Standard</button>
+      </div>
+      <div class="settings-hint">Minimal and Minimal+ require K10 Pro connection</div>
+
+      <div class="settings-row"><span class="settings-label">Panel Borders</span><div class="settings-toggle on" data-key="showBorders" onclick="toggleSetting(this)"></div></div>
+
+      <!-- Lighting -->
+      <div class="settings-group-label">Lighting</div>
       <div class="settings-row"><span class="settings-label">WebGL Effects</span><div class="settings-toggle on" data-key="showWebGL" data-pro-feature="webgl" onclick="toggleWebGL(this)"></div></div>
       <div class="settings-row"><span class="settings-label">Ambient Light</span>
         <select class="settings-select" id="settingsAmbientMode" data-pro-feature="reflections" onchange="updateAmbientMode(this.value)">
@@ -900,7 +922,20 @@
         <div id="ambientPreviewSwatch" style="width:100%;height:40px;border-radius:4px;background:#111;border:1px solid hsla(0,0%,100%,0.1);"></div>
         <div class="ambient-preview-info" id="ambientPreviewInfo">No capture active</div>
       </div>
-      </div>
+
+      <!-- Glow & Animation -->
+      <div class="settings-group-label">Glow & Animation</div>
+      <div class="settings-row"><span class="settings-label">Sentiment Halo</span><div class="settings-toggle on" data-key="showSentimentHalo" onclick="toggleSetting(this)"></div></div>
+      <div class="settings-row"><span class="settings-label">Commentary Glow</span><div class="settings-toggle on" data-key="showCommentaryGlow" onclick="toggleSetting(this)"></div></div>
+      <div class="settings-row"><span class="settings-label">Race Control Animation</span><div class="settings-toggle on" data-key="showRcAnimation" onclick="toggleSetting(this)"></div></div>
+      <div class="settings-row"><span class="settings-label">Track Map Glow</span><div class="settings-toggle on" data-key="showMapGlow" onclick="toggleSetting(this)"></div></div>
+      <div class="settings-row"><span class="settings-label">Redline Flash</span><div class="settings-toggle on" data-key="showRedlineFlash" onclick="toggleSetting(this)"></div></div>
+
+      <!-- Fun -->
+      <div class="settings-group-label">Fun</div>
+      <div class="settings-row"><span class="settings-label">Pit Limiter Bonkers</span><div class="settings-toggle on" data-key="showBonkers" id="bonkersToggle" onclick="toggleBonkers(this)"></div></div>
+
+      </div><!-- /settings-two-col -->
     </div>
 
     <!-- ── Tab: Layout — positioning and spacing for all module groups ── -->

--- a/racecor-overlay/modules/js/config.js
+++ b/racecor-overlay/modules/js/config.js
@@ -567,6 +567,14 @@ const _defaultSettings = {
   discordUser: null,
   rallyMode: false,
   driveMode: false,
+  // Visual modes and effects
+  visualPreset: 'standard',  // 'standard', 'minimal', 'minimal-plus'
+  showBorders: true,
+  showSentimentHalo: true,
+  showCommentaryGlow: true,
+  showRcAnimation: true,
+  showMapGlow: true,
+  showRedlineFlash: true,
   // Leaderboard
   lbFocus: 'me',        // 'me' = center on player, 'lead' = show from P1
   lbMaxRows: 5,         // max visible opponent rows

--- a/racecor-overlay/modules/js/connections.js
+++ b/racecor-overlay/modules/js/connections.js
@@ -12,7 +12,7 @@
   let _k10Connecting = false;
 
   // Pro features — keys map to setting toggles and sidebar items
-  const PRO_FEATURE_KEYS = ['commentary','incidents','spotter','leaderboard','datastream','webgl','reflections','modules'];
+  const PRO_FEATURE_KEYS = ['commentary','incidents','spotter','leaderboard','datastream','webgl','reflections','modules','minimal','minimal-plus'];
 
   function isProFeature(key) {
     const map = {

--- a/racecor-overlay/modules/js/settings.js
+++ b/racecor-overlay/modules/js/settings.js
@@ -103,6 +103,20 @@
     if (_settings.logoOnlyStart !== false) {
       document.body.classList.add('logo-only');
     }
+
+    // Visual mode classes
+    const preset = _settings.visualPreset || 'standard';
+    document.body.classList.remove('mode-minimal', 'mode-minimal-plus');
+    if (preset === 'minimal') {
+      document.body.classList.add('mode-minimal');
+    } else if (preset === 'minimal-plus') {
+      document.body.classList.add('mode-minimal-plus');
+    }
+
+    // Sync preset button active states
+    document.querySelectorAll('.settings-preset-btn').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.preset === preset);
+    });
   }
 
   // Called by poll-engine when session goes active (game running + session state > 0).
@@ -197,6 +211,75 @@
       const key = el.dataset.dsField;
       const show = _settings[key] !== false;
       el.style.display = show ? '' : 'none';
+    });
+  }
+
+  // ── Visual mode presets (Minimal, Minimal+, Standard) ──
+  function applyVisualPreset(preset) {
+    // Feature gate: minimal/minimal+ require K10 Pro connection
+    if (preset !== 'standard' && !_k10User) {
+      navigateToConnections();
+      return;
+    }
+
+    _settings.visualPreset = preset;
+
+    // Remove all mode classes
+    document.body.classList.remove('mode-minimal', 'mode-minimal-plus');
+
+    if (preset === 'minimal') {
+      document.body.classList.add('mode-minimal');
+      // Set all effect toggles to off for Minimal mode
+      _settings.showWebGL = false;
+      _settings.ambientMode = 'off';
+      _settings.showBorders = false;
+      _settings.showSentimentHalo = false;
+      _settings.showCommentaryGlow = false;
+      _settings.showRcAnimation = false;
+      _settings.showMapGlow = false;
+      _settings.showRedlineFlash = false;
+      _settings.showBonkers = false;
+      _settings.showK10Logo = false;
+      _settings.showCarLogo = false;
+      _settings.showGameLogo = false;
+    } else if (preset === 'minimal-plus') {
+      document.body.classList.add('mode-minimal-plus');
+      // Racing-educated Tufte: data-reactive effects on, static decoration off
+      _settings.showWebGL = true;  // but CSS reduces intensity to 60%
+      _settings.ambientMode = 'off';
+      _settings.showBorders = false;
+      _settings.showSentimentHalo = true;  // but CSS reduces to 40% alpha
+      _settings.showCommentaryGlow = false;
+      _settings.showRcAnimation = true;    // flag animation settles after 4s
+      _settings.showMapGlow = true;
+      _settings.showRedlineFlash = true;
+      _settings.showBonkers = false;
+      _settings.showK10Logo = false;
+      _settings.showCarLogo = true;  // contextual data for broadcast
+      _settings.showGameLogo = false;
+    } else {
+      // Standard — restore defaults
+      _settings.showWebGL = true;
+      _settings.ambientMode = 'reflective';
+      _settings.showBorders = true;
+      _settings.showSentimentHalo = true;
+      _settings.showCommentaryGlow = true;
+      _settings.showRcAnimation = true;
+      _settings.showMapGlow = true;
+      _settings.showRedlineFlash = true;
+      _settings.showBonkers = true;
+      _settings.showK10Logo = true;
+      _settings.showCarLogo = true;
+      _settings.showGameLogo = true;
+    }
+
+    // Sync UI toggles and save
+    applySettings();
+    saveSettings();
+
+    // Update preset button active states
+    document.querySelectorAll('.settings-preset-btn').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.preset === preset);
     });
   }
 

--- a/racecor-overlay/modules/styles/ambient.css
+++ b/racecor-overlay/modules/styles/ambient.css
@@ -321,6 +321,55 @@ body.opaque-mode .spotter-panel::before {
 }
 
 /* ═══════════════════════════════════════════════
+   PRESET BUTTONS (Minimal, Minimal+, Standard)
+   ═══════════════════════════════════════════════ */
+.settings-preset-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.settings-preset-btn {
+  flex: 1;
+  background: hsla(0, 0%, 100%, 0.08);
+  color: hsla(0, 0%, 100%, 0.7);
+  border: 1px solid hsla(0, 0%, 100%, 0.15);
+  border-radius: 4px;
+  padding: 8px 12px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 200ms ease, border-color 200ms ease, color 200ms ease;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  position: relative;
+}
+.settings-preset-btn:hover {
+  background: hsla(0, 0%, 100%, 0.12);
+  border-color: hsla(0, 0%, 100%, 0.3);
+  color: hsla(0, 0%, 100%, 0.9);
+}
+.settings-preset-btn.active {
+  background: hsla(280, 80%, 70%, 0.25);
+  border-color: hsl(280, 80%, 70%);
+  color: hsl(280, 80%, 80%);
+}
+.settings-preset-btn.pro-locked {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.settings-preset-btn.pro-locked::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 12px;
+  height: 12px;
+  background: no-repeat center;
+  background-size: 10px;
+  opacity: 0.6;
+}
+
+/* ═══════════════════════════════════════════════
    AMBIENT CAPTURE PREVIEW (in settings panel)
    ═══════════════════════════════════════════════ */
 .ambient-preview-container {

--- a/racecor-overlay/modules/styles/modes.css
+++ b/racecor-overlay/modules/styles/modes.css
@@ -1,0 +1,358 @@
+/* ═══════════════════════════════════════════════════════════════════════════════
+   VISUAL MODES — Minimal, Minimal+, and Standard CSS overrides
+   ═══════════════════════════════════════════════════════════════════════════════ */
+
+/* ───────────────────────────────────────────────────────────────────────────────
+   MINIMAL MODE — Tufte-pure, maximum data-ink ratio
+   ─────────────────────────────────────────────────────────────────────────────── */
+
+body.mode-minimal {
+  --border: transparent;
+  --pad: 4px;
+  --gap: 3px;
+}
+
+/* Remove all panel borders */
+body.mode-minimal .panel,
+body.mode-minimal [class*="panel"],
+body.mode-minimal .module,
+body.mode-minimal .section {
+  border: none !important;
+  border-color: transparent !important;
+}
+
+/* Hide WebGL effects canvas layers */
+body.mode-minimal .gl-overlay,
+body.mode-minimal .ambient-canvas,
+body.mode-minimal .glare-canvas,
+body.mode-minimal .webgl-context {
+  display: none !important;
+}
+
+/* Hide sentiment halo on dashboard */
+body.mode-minimal .dashboard::before {
+  opacity: 0 !important;
+  display: none !important;
+}
+
+/* Remove animated stripes from race control banner */
+body.mode-minimal .rc-inner::after {
+  opacity: 0 !important;
+  display: none !important;
+}
+
+/* Remove track map player dot glow */
+body.mode-minimal .map-player {
+  filter: none !important;
+  drop-shadow: none !important;
+  text-shadow: none !important;
+}
+
+/* Simplify fuel bar to single-hue green darkening (no gradient) */
+body.mode-minimal .fuel-bar,
+body.mode-minimal .fuel-fill {
+  background: var(--green) !important;
+  background-image: none !important;
+  transition: background-color var(--t-med);
+}
+
+/* Fuel depleting: darken the green */
+body.mode-minimal .fuel-fill.low {
+  background-color: darken(var(--green), 20%) !important;
+}
+
+body.mode-minimal .fuel-fill.critical {
+  background-color: var(--red) !important;
+}
+
+/* iRating: number only, hide the bar */
+body.mode-minimal .irating-bar,
+body.mode-minimal .irating-progress,
+body.mode-minimal [class*="irating-seg"],
+body.mode-minimal [class*="rating-bar"] {
+  display: none !important;
+}
+
+/* Safety Rating: number only, hide the pie */
+body.mode-minimal .safety-pie,
+body.mode-minimal .sr-circle,
+body.mode-minimal .sr-pie,
+body.mode-minimal [class*="safety-chart"],
+body.mode-minimal [class*="sr-chart"] {
+  display: none !important;
+}
+
+/* Commentary panel: hidden */
+body.mode-minimal .commentary-col,
+body.mode-minimal .commentary-panel {
+  display: none !important;
+}
+
+/* Labels regular, values bold — maximum contrast */
+body.mode-minimal [class*="label"],
+body.mode-minimal .tag,
+body.mode-minimal .legend {
+  font-weight: var(--fw-regular) !important;
+}
+
+body.mode-minimal [class*="value"],
+body.mode-minimal [class*="data"],
+body.mode-minimal .number {
+  font-weight: var(--fw-bold) !important;
+}
+
+/* Reduce label font sizes by 1px */
+body.mode-minimal .label {
+  font-size: calc(var(--fs-sm) - 1px) !important;
+}
+
+/* No backdrop-filter blur */
+body.mode-minimal .panel {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
+/* No CSS glow on panels */
+body.mode-minimal .panel,
+body.mode-minimal .dashboard {
+  box-shadow: none !important;
+  text-shadow: none !important;
+}
+
+/* Disable animations except essential state changes */
+body.mode-minimal * {
+  animation: none !important;
+  transition: none !important;
+}
+
+/* Re-enable essential state transitions (toggles, shows/hides) */
+body.mode-minimal .settings-toggle,
+body.mode-minimal [role="switch"],
+body.mode-minimal .section-hidden,
+body.mode-minimal .hidden {
+  transition: opacity var(--t-fast) !important;
+}
+
+/* Hide car manufacturer logo */
+body.mode-minimal .carLogoSquare,
+body.mode-minimal [data-section="carLogoSquare"],
+body.mode-minimal .car-logo,
+body.mode-minimal .manufacturer-logo {
+  display: none !important;
+}
+
+/* Hide K10 branding logo */
+body.mode-minimal .k10LogoSquare,
+body.mode-minimal [data-section="k10LogoSquare"],
+body.mode-minimal .k10-logo,
+body.mode-minimal .k10-branding {
+  display: none !important;
+}
+
+/* Hide game logo */
+body.mode-minimal .game-logo,
+body.mode-minimal [data-section="game-logo"],
+body.mode-minimal .game-logo-panel {
+  display: none !important;
+}
+
+/* ───────────────────────────────────────────────────────────────────────────────
+   MINIMAL+ MODE — Racing-educated Tufte, preserved data-reactive effects
+   ─────────────────────────────────────────────────────────────────────────────── */
+
+body.mode-minimal-plus {
+  --border: transparent;
+  --pad: 5px;
+  --gap: 3px;
+}
+
+/* Remove all panel borders */
+body.mode-minimal-plus .panel,
+body.mode-minimal-plus [class*="panel"],
+body.mode-minimal-plus .module,
+body.mode-minimal-plus .section {
+  border: none !important;
+  border-color: transparent !important;
+}
+
+/* Hide static WebGL effects (ambient light), keep RPM bloom data-reactive */
+body.mode-minimal-plus .ambient-canvas,
+body.mode-minimal-plus .glare-canvas,
+body.mode-minimal-plus .webgl-context {
+  display: none !important;
+}
+
+/* Tachometer RPM bloom at 60% intensity — this is data-reactive */
+body.mode-minimal-plus .gl-overlay {
+  opacity: 0.6 !important;
+  display: block !important;
+}
+
+/* Track map player dot glow: preserved, tightened radius */
+body.mode-minimal-plus .map-player {
+  filter: drop-shadow(0 0 8px rgba(255, 255, 255, 0.4)) !important;
+}
+
+/* Fuel bar: racing color convention (green → amber → red) */
+body.mode-minimal-plus .fuel-fill {
+  background: linear-gradient(90deg, var(--green), var(--amber), var(--red)) !important;
+}
+
+/* Safety Rating: pie chart visible with threshold marks */
+body.mode-minimal-plus .safety-pie,
+body.mode-minimal-plus .sr-circle,
+body.mode-minimal-plus .sr-pie,
+body.mode-minimal-plus [class*="safety-chart"],
+body.mode-minimal-plus [class*="sr-chart"] {
+  display: block !important;
+}
+
+/* Commentary panel visible with tighter padding (10px vs 14px) */
+body.mode-minimal-plus .commentary-col,
+body.mode-minimal-plus .commentary-panel {
+  display: block !important;
+  padding: 10px !important;
+}
+
+/* Commentary inner background */
+body.mode-minimal-plus .commentary-inner {
+  padding: 10px !important;
+}
+
+/* Sentiment halo at 40% of standard alpha — subtle peripheral cue */
+body.mode-minimal-plus .dashboard::before {
+  opacity: 0.4 !important;
+}
+
+/* Flag banner: animated stripes settle after 4 seconds */
+body.mode-minimal-plus .rc-banner {
+  /* Animation will be controlled by JavaScript to settle after 4s */
+}
+
+body.mode-minimal-plus .rc-inner::after {
+  opacity: 1 !important;
+  animation: rc-flag-scroll 1.5s linear 0s 1, rc-flag-settle 0.5s ease 4s forwards;
+}
+
+@keyframes rc-flag-settle {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.15;
+  }
+}
+
+/* G-force vignette at 50% intensity — peripheral safety cue */
+body.mode-minimal-plus .g-vignette,
+body.mode-minimal-plus .datastream-gvignette {
+  opacity: 0.5 !important;
+}
+
+/* Labels regular, values bold */
+body.mode-minimal-plus [class*="label"],
+body.mode-minimal-plus .tag,
+body.mode-minimal-plus .legend {
+  font-weight: var(--fw-regular) !important;
+}
+
+body.mode-minimal-plus [class*="value"],
+body.mode-minimal-plus [class*="data"],
+body.mode-minimal-plus .number {
+  font-weight: var(--fw-bold) !important;
+}
+
+/* Car manufacturer logo visible (contextual data) */
+body.mode-minimal-plus .carLogoSquare,
+body.mode-minimal-plus [data-section="carLogoSquare"],
+body.mode-minimal-plus .car-logo,
+body.mode-minimal-plus .manufacturer-logo {
+  display: block !important;
+}
+
+/* Hide K10 branding logo */
+body.mode-minimal-plus .k10LogoSquare,
+body.mode-minimal-plus [data-section="k10LogoSquare"],
+body.mode-minimal-plus .k10-logo,
+body.mode-minimal-plus .k10-branding {
+  display: none !important;
+}
+
+/* Hide game logo */
+body.mode-minimal-plus .game-logo,
+body.mode-minimal-plus [data-section="game-logo"],
+body.mode-minimal-plus .game-logo-panel {
+  display: none !important;
+}
+
+/* Preserve animations for state changes */
+body.mode-minimal-plus * {
+  animation: none !important;
+  transition: none !important;
+}
+
+/* Re-enable essential transitions */
+body.mode-minimal-plus .settings-toggle,
+body.mode-minimal-plus [role="switch"],
+body.mode-minimal-plus .section-hidden,
+body.mode-minimal-plus .hidden {
+  transition: opacity var(--t-fast) !important;
+}
+
+/* ───────────────────────────────────────────────────────────────────────────────
+   DRIVE MODE — Tufte principles (Minimal-like, no atmospheric effects)
+   ─────────────────────────────────────────────────────────────────────────────── */
+
+body.drive-mode-active {
+  background: #000 !important;
+}
+
+/* Remove background tints from drive mode panels */
+body.drive-mode-active .dh-map,
+body.drive-mode-active .dh-right,
+body.drive-mode-active .dh-sector {
+  background: transparent !important;
+  background-image: none !important;
+}
+
+/* Remove drop shadow from map player in drive mode */
+body.drive-mode-active .map-player {
+  filter: none !important;
+  text-shadow: none !important;
+}
+
+/* Tighten sector boxes: remove border-radius, reduce padding */
+body.drive-mode-active .dh-sector {
+  border-radius: 0 !important;
+  padding: 4px !important;
+}
+
+/* Keep color-coding system (it's data, not decoration) */
+body.drive-mode-active [class*="sector-1"],
+body.drive-mode-active [class*="sector-2"],
+body.drive-mode-active [class*="sector-3"],
+body.drive-mode-active .gap-ahead,
+body.drive-mode-active .gap-behind {
+  /* Color remains — it encodes data */
+}
+
+/* Optional redline flash can be toggled */
+body.drive-mode-active[data-redline-flash="on"] .tachometer {
+  --redline-flash: on;
+}
+
+/* ───────────────────────────────────────────────────────────────────────────────
+   UTILITY: Accessibility — respects prefers-reduced-motion
+   ─────────────────────────────────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  body {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  body.mode-minimal-plus .rc-inner::after {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Summary

Implements a comprehensive visual mode system for the RaceCor overlay with three distinct styles:
- **Standard** — full broadcast-grade presentation with cinematic effects
- **Minimal** — Tufte-pure data visualization, maximum clarity (Pro feature)
- **Minimal+** — racing-educated Tufte with data-reactive effects preserved (Pro feature)

## Changes

### Documentation
- **STYLEGUIDE.md** — comprehensive guide to visual modes, CSS variable system, and design philosophy

### CSS
- **modes.css** — body class overrides for each visual mode:
  - `body.mode-minimal` — removes borders, effects, decoration; maximizes data-ink ratio
  - `body.mode-minimal-plus` — removes static decoration; preserves data-reactive effects (RPM bloom, map glow)
  - Drive mode — Tufte principles with color-coding preserved as data

### Settings UI
- **New Effects Tab** — moved WebGL/Ambient Light from Branding tab; added organized groupings:
  - Visual Style (preset buttons: Minimal / Minimal+ / Standard)
  - Lighting (WebGL, Ambient modes, capture area)
  - Glow & Animation (sentiment halo, commentary glow, race control animation, map glow, redline flash)
  - Fun (Pit Limiter Bonkers)

### JavaScript
- **applyVisualPreset(preset)** — sets all effect toggles for a preset mode; requires K10 Pro for minimal/minimal+
- **New default settings** — visualPreset, showBorders, showSentimentHalo, showCommentaryGlow, showRcAnimation, showMapGlow, showRedlineFlash
- **Feature gating** — minimal/minimal-plus added to PRO_FEATURE_KEYS; preset buttons locked until K10 Pro connected

### Design Principles
- **Minimal** follows Edward Tufte's principles: maximum information density, zero chartjunk, high data-ink ratio
- **Minimal+** adds racing context: preserves lap-relevant visual cues (tachometer bloom, safety rating pie, fuel gradient)
- All modes share the same HTML/layout structure — visual style is pure CSS/settings

## Test Plan

- [ ] Settings panel loads with new Effects tab visible after Branding
- [ ] Three preset buttons styled as segmented control; "Standard" active by default
- [ ] Clicking "Minimal" with K10 disconnected → navigates to Connections tab
- [ ] Clicking "Standard" enables all effects; UI toggles reflect changes
- [ ] Switching to Minimal mode: panel borders disappear, WebGL hidden, logos hidden, iRating bar hidden, Safety pie hidden, Commentary hidden, Sentiment halo invisible
- [ ] Switching to Minimal+: borders hidden, WebGL at 60%, car logo visible, commentary visible, sentiment halo at 40% alpha, fuel bar has gradient, safety pie visible
- [ ] Drive mode applies Tufte principles (no background tints, pure black, bright data)
- [ ] Settings persist across reload
- [ ] Switching back to Standard restores all effects

🤖 Generated with Claude Code