### PR TITLE
Add track display names

### DIFF
--- a/racecor-overlay/modules/js/drive-hud.js
+++ b/racecor-overlay/modules/js/drive-hud.js
@@ -373,10 +373,15 @@
       }
     }
 
-    // Track name
+    // Track name — prefer K10 display name, fall back to game name
     var nameEl = document.getElementById('dhMapName');
-    var trackName = p['DataCorePlugin.GameData.TrackName'] || '';
-    if (nameEl && trackName) nameEl.textContent = trackName;
+    var trackName = p['K10Motorsports.Plugin.TrackMap.TrackName']
+                 || p['DataCorePlugin.GameData.TrackName'] || '';
+    if (nameEl && trackName) {
+      var resolved = typeof _trackDisplayNameCache !== 'undefined' && _trackDisplayNameCache[trackName];
+      nameEl.textContent = resolved || trackName;
+      if (!resolved && typeof resolveTrackDisplayName === 'function') resolveTrackDisplayName(trackName);
+    }
   }
   window.updateDriveHud = updateDriveHud;
 

--- a/racecor-overlay/modules/js/poll-engine.js
+++ b/racecor-overlay/modules/js/poll-engine.js
@@ -41,6 +41,31 @@
     return 0;
   }
 
+  // ─── Track display name resolver ───
+  // Fetches user-customized display names from the K10 API.
+  // Falls back to the game-provided name if no custom name is set or API is unreachable.
+  const _trackDisplayNameCache = {};    // { gameTrackName → displayName }
+  const _trackDisplayNamePending = {};  // { gameTrackName → true } (in-flight requests)
+  const K10_DISPLAY_NAME_API = 'https://drive.racecor.io/api/tracks';
+
+  function resolveTrackDisplayName(gameTrackName) {
+    if (_trackDisplayNameCache[gameTrackName] || _trackDisplayNamePending[gameTrackName]) return;
+    _trackDisplayNamePending[gameTrackName] = true;
+    fetch(K10_DISPLAY_NAME_API + '?trackName=' + encodeURIComponent(gameTrackName))
+      .then(function(r) { return r.ok ? r.json() : null; })
+      .then(function(data) {
+        // displayName from API already falls back to trackName server-side
+        _trackDisplayNameCache[gameTrackName] = (data && data.displayName) || gameTrackName;
+      })
+      .catch(function() {
+        // API unreachable — use the game name
+        _trackDisplayNameCache[gameTrackName] = gameTrackName;
+      })
+      .finally(function() {
+        delete _trackDisplayNamePending[gameTrackName];
+      });
+  }
+
   // ─── Data fetch loop (runs on setInterval — decoupled from display) ───
   async function pollUpdate() {
     if (_pollActive) return;
@@ -1038,13 +1063,22 @@
     const mapHeading = +v('K10Motorsports.Plugin.TrackMap.PlayerHeading') || 0;
     // Use plugin path if available; show no track when map isn't ready
     updateTrackMap(mapPath, mapPX, mapPY, mapOpp, speed, mapHeading);
-    // Full map label: show track name instead of "Full"
+    // Full map label: show display name (from K10 API) or fall back to game name
     const fullMapLbl = document.getElementById('fullMapLabel');
     if (fullMapLbl) {
       const trackName = vs('K10Motorsports.Plugin.TrackMap.TrackName')
                      || vs('DataCorePlugin.GameData.TrackName')
                      || '';
-      if (trackName && trackName !== fullMapLbl.textContent) fullMapLbl.textContent = trackName;
+      if (trackName) {
+        const resolved = _trackDisplayNameCache[trackName];
+        if (resolved) {
+          if (resolved !== fullMapLbl.textContent) fullMapLbl.textContent = resolved;
+        } else {
+          // Show game name immediately, then upgrade if K10 returns a display name
+          if (trackName !== fullMapLbl.textContent) fullMapLbl.textContent = trackName;
+          resolveTrackDisplayName(trackName);
+        }
+      }
     }
 
     // ─── Datastream ───

--- a/web/drizzle/0002_track_display_name.sql
+++ b/web/drizzle/0002_track_display_name.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "track_maps" ADD COLUMN IF NOT EXISTS "display_name" varchar(256);

--- a/web/scripts/seed-track-maps.ts
+++ b/web/scripts/seed-track-maps.ts
@@ -24,18 +24,18 @@ const CSV_DIR = path.resolve(
   '../../racecor-plugin/simhub-plugin/k10-motorsports-data/trackmaps'
 )
 
-const TRACK_META: Record<string, { gameName?: string; trackLengthKm?: number }> = {
-  'barber 2026':            { gameName: 'iracing', trackLengthKm: 3.7 },
-  'bathurst':               { gameName: 'iracing', trackLengthKm: 6.213 },
-  'miami gp':               { gameName: 'iracing', trackLengthKm: 5.412 },
-  'nurburgring combined':   { gameName: 'iracing', trackLengthKm: 25.378 },
-  'nurburgring nordschleife': { gameName: 'iracing', trackLengthKm: 20.832 },
-  'oschersleben gp':        { gameName: 'iracing', trackLengthKm: 3.696 },
-  'oulton international':   { gameName: 'iracing', trackLengthKm: 4.307 },
-  'sebring international':  { gameName: 'iracing', trackLengthKm: 6.019 },
-  'spa 2024 up':            { gameName: 'iracing', trackLengthKm: 7.004 },
-  'stpete':                 { gameName: 'iracing', trackLengthKm: 2.89 },
-  'virginia 2022 full':     { gameName: 'iracing', trackLengthKm: 5.263 },
+const TRACK_META: Record<string, { gameName?: string; trackLengthKm?: number; displayName?: string }> = {
+  'barber 2026':              { gameName: 'iracing', trackLengthKm: 3.7,    displayName: 'Barber Motorsports Park' },
+  'bathurst':                 { gameName: 'iracing', trackLengthKm: 6.213,  displayName: 'Mount Panorama' },
+  'miami gp':                 { gameName: 'iracing', trackLengthKm: 5.412,  displayName: 'Miami International Autodrome' },
+  'nurburgring combined':     { gameName: 'iracing', trackLengthKm: 25.378, displayName: 'Nürburgring Combined' },
+  'nurburgring nordschleife': { gameName: 'iracing', trackLengthKm: 20.832, displayName: 'Nürburgring Nordschleife' },
+  'oschersleben gp':          { gameName: 'iracing', trackLengthKm: 3.696,  displayName: 'Oschersleben' },
+  'oulton international':     { gameName: 'iracing', trackLengthKm: 4.307,  displayName: 'Oulton Park International' },
+  'sebring international':    { gameName: 'iracing', trackLengthKm: 6.019,  displayName: 'Sebring International Raceway' },
+  'spa 2024 up':              { gameName: 'iracing', trackLengthKm: 7.004,  displayName: 'Spa-Francorchamps' },
+  'stpete':                   { gameName: 'iracing', trackLengthKm: 2.89,   displayName: 'St. Petersburg' },
+  'virginia 2022 full':       { gameName: 'iracing', trackLengthKm: 5.263,  displayName: 'Virginia International Raceway' },
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -69,21 +69,23 @@ async function main() {
   const sql = neon(dbUrl)
   const db = drizzle(sql)
 
-  // Ensure the track_maps table exists (run migration inline)
-  const migrationPath = path.resolve(__dirname, '../drizzle/0001_track_maps.sql')
-  if (fs.existsSync(migrationPath)) {
-    console.log('Running track_maps migration...')
-    const migrationSql = fs.readFileSync(migrationPath, 'utf-8')
-    // Neon can't run multiple statements in one call — split on semicolons
-    const statements = migrationSql
-      .split(';')
-      .map(s => s.trim())
-      .filter(s => s.length > 0)
-    for (const stmt of statements) {
-      await sql.query(stmt, [])
+  // Run migrations inline (each split on semicolons for Neon)
+  const migrationFiles = ['0001_track_maps.sql', '0002_track_display_name.sql']
+  for (const migFile of migrationFiles) {
+    const migrationPath = path.resolve(__dirname, '../drizzle', migFile)
+    if (fs.existsSync(migrationPath)) {
+      console.log(`Running migration: ${migFile}`)
+      const migrationSql = fs.readFileSync(migrationPath, 'utf-8')
+      const statements = migrationSql
+        .split(';')
+        .map(s => s.trim())
+        .filter(s => s.length > 0)
+      for (const stmt of statements) {
+        await sql.query(stmt, [])
+      }
     }
-    console.log('Migration applied (or table already exists).\n')
   }
+  console.log('Migrations applied.\n')
 
   const csvFiles = fs.readdirSync(CSV_DIR).filter(f => f.endsWith('.csv'))
   console.log(`Found ${csvFiles.length} track CSV files in ${CSV_DIR}\n`)
@@ -118,6 +120,7 @@ async function main() {
       await db.insert(trackMaps).values({
         trackId,
         trackName,
+        displayName: meta.displayName ?? null,
         svgPath,
         pointCount,
         rawCsv,

--- a/web/src/app/api/admin/tracks/route.ts
+++ b/web/src/app/api/admin/tracks/route.ts
@@ -14,6 +14,7 @@ export async function GET() {
       id: schema.trackMaps.id,
       trackId: schema.trackMaps.trackId,
       trackName: schema.trackMaps.trackName,
+      displayName: schema.trackMaps.displayName,
       svgPath: schema.trackMaps.svgPath,
       pointCount: schema.trackMaps.pointCount,
       gameName: schema.trackMaps.gameName,
@@ -34,7 +35,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json()
-    const { trackId, trackName, rawCsv, gameName, trackLengthKm } = body
+    const { trackId, trackName, displayName, rawCsv, gameName, trackLengthKm } = body
 
     if (!trackId || !trackName || !rawCsv) {
       return NextResponse.json(
@@ -60,6 +61,7 @@ export async function POST(request: NextRequest) {
         .update(schema.trackMaps)
         .set({
           trackName: trackName.trim(),
+          displayName: displayName?.trim() || null,
           svgPath,
           pointCount,
           rawCsv: rawCsv.trim(),
@@ -84,6 +86,7 @@ export async function POST(request: NextRequest) {
       .values({
         trackId: normalizedTrackId,
         trackName: trackName.trim(),
+        displayName: displayName?.trim() || null,
         svgPath,
         pointCount,
         rawCsv: rawCsv.trim(),
@@ -100,6 +103,41 @@ export async function POST(request: NextRequest) {
       mapId: result[0].id,
       pointCount,
     }, { status: 201 })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Invalid request'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}
+
+/** PATCH /api/admin/tracks — Update track display name */
+export async function PATCH(request: NextRequest) {
+  const session = await requireAdmin()
+  if (!session) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  try {
+    const body = await request.json()
+    const { trackId, displayName } = body
+
+    if (!trackId) {
+      return NextResponse.json({ error: 'trackId required' }, { status: 400 })
+    }
+
+    const normalizedId = trackId.toLowerCase().trim()
+
+    const updated = await db
+      .update(schema.trackMaps)
+      .set({
+        displayName: displayName?.trim() || null,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.trackMaps.trackId, normalizedId))
+      .returning({ id: schema.trackMaps.id, trackId: schema.trackMaps.trackId, displayName: schema.trackMaps.displayName })
+
+    if (updated.length === 0) {
+      return NextResponse.json({ error: 'Track map not found' }, { status: 404 })
+    }
+
+    return NextResponse.json({ success: true, ...updated[0] })
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Invalid request'
     return NextResponse.json({ error: message }, { status: 400 })

--- a/web/src/app/api/tracks/route.ts
+++ b/web/src/app/api/tracks/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { db, schema } from '@/db'
+import { eq } from 'drizzle-orm'
+
+/**
+ * GET /api/tracks?trackName=xxx — Resolve display name for a track.
+ *
+ * Public endpoint (no auth) used by the overlay to show user-defined
+ * display names instead of raw game-provided track names.
+ *
+ * Returns: { trackName, displayName, trackId }
+ * displayName is null if no custom name has been set.
+ */
+export async function GET(request: NextRequest) {
+  const trackName = request.nextUrl.searchParams.get('trackName')
+
+  if (!trackName) {
+    return NextResponse.json({ error: 'trackName query param required' }, { status: 400 })
+  }
+
+  // Try exact match on trackName first (game-provided name)
+  let results = await db
+    .select({
+      trackId: schema.trackMaps.trackId,
+      trackName: schema.trackMaps.trackName,
+      displayName: schema.trackMaps.displayName,
+    })
+    .from(schema.trackMaps)
+    .where(eq(schema.trackMaps.trackName, trackName.trim()))
+    .limit(1)
+
+  // Fall back to trackId slug match
+  if (results.length === 0) {
+    const slug = trackName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+    results = await db
+      .select({
+        trackId: schema.trackMaps.trackId,
+        trackName: schema.trackMaps.trackName,
+        displayName: schema.trackMaps.displayName,
+      })
+      .from(schema.trackMaps)
+      .where(eq(schema.trackMaps.trackId, slug))
+      .limit(1)
+  }
+
+  if (results.length === 0) {
+    return NextResponse.json({ trackName, displayName: trackName, trackId: null })
+  }
+
+  const track = results[0]
+  return NextResponse.json({
+    ...track,
+    displayName: track.displayName || track.trackName,
+  })
+}

--- a/web/src/db/schema.ts
+++ b/web/src/db/schema.ts
@@ -41,6 +41,7 @@ export const trackMaps = pgTable('track_maps', {
   id: uuid('id').defaultRandom().primaryKey(),
   trackId: varchar('track_id', { length: 128 }).notNull().unique(),
   trackName: varchar('track_name', { length: 256 }).notNull(),
+  displayName: varchar('display_name', { length: 256 }),
   svgPath: text('svg_path').notNull(),
   pointCount: integer('point_count').notNull(),
   rawCsv: text('raw_csv').notNull(),


### PR DESCRIPTION
## Summary
- Add `display_name` column to `track_maps` table (nullable, falls back to game-provided `trackName`)
- Admin API: PATCH endpoint to update display names, GET/POST include displayName
- Public API: `GET /api/tracks?trackName=xxx` resolves display name for the overlay
- Overlay: poll-engine and drive-hud fetch display names from K10 API, fall back to game name when not connected or no custom name set
- Seed script updated with proper display names for all 11 bundled tracks (e.g. "spa 2024 up" → "Spa-Francorchamps")

## Test plan
- [ ] Run seed script — verify display names appear in DB
- [ ] PATCH a display name via admin API, confirm it persists
- [ ] Load overlay with K10 connected — verify custom display name appears on map label
- [ ] Load overlay without K10 — verify game-provided name still shows
- [ ] Clear a display name (set to null) — verify fallback to trackName

🤖 Generated with [Claude Code](https://claude.com/claude-code)