### PR TITLE
Fix effects mode HUD vanishing and game logo positioning

### DIFF
--- a/racecor-overlay/modules/js/game-logo.js
+++ b/racecor-overlay/modules/js/game-logo.js
@@ -50,7 +50,9 @@
 
   function updatePosition() {
     if (!_logoEl) return;
-    var layoutPos = (window._settings && window._settings.layoutPosition) || 'top-right';
+    // Read from global _settings object (not window._settings)
+    // _settings is exposed as a global from config.js
+    var layoutPos = (_settings && _settings.layoutPosition) || 'top-right';
     var logoPos = OPPOSITE_CORNER[layoutPos] || 'bottom-left';
     var style = POS_STYLES[logoPos] || POS_STYLES['bottom-left'];
     // Reset all positioning
@@ -138,4 +140,17 @@
   }
   // Also listen for settings changes
   window.addEventListener('k10-layout-changed', updatePosition);
+
+  // Ensure position is updated when applySettings is called
+  // (which loads _settings from localStorage)
+  var _origApplySettings = window.applySettings;
+  if (typeof _origApplySettings === 'function') {
+    window.applySettings = function() {
+      _origApplySettings.apply(this, arguments);
+      // Update logo position after settings are applied
+      if (_logoEl) {
+        updatePosition();
+      }
+    };
+  }
 })();

--- a/racecor-overlay/modules/js/settings.js
+++ b/racecor-overlay/modules/js/settings.js
@@ -132,6 +132,12 @@
   }
 
   function _collapseParentColumns() {
+    // When a visual preset mode is active, CSS rules in modes.css handle all
+    // visibility. Skip the section-hidden collapse logic to avoid interfering.
+    if (document.body.classList.contains('mode-minimal') || document.body.classList.contains('mode-minimal-plus')) {
+      return;
+    }
+
     // Controls + Pedals share controls-pedals-block
     const cpBlock = document.querySelector('.controls-pedals-block');
     if (cpBlock) {
@@ -271,6 +277,9 @@
       _settings.showK10Logo = true;
       _settings.showCarLogo = true;
       _settings.showGameLogo = true;
+      // When switching back to standard, ensure mode classes are removed
+      // so _collapseParentColumns() can properly restore column states
+      document.body.classList.remove('mode-minimal', 'mode-minimal-plus');
     }
 
     // Sync UI toggles and save


### PR DESCRIPTION
## Summary
Fixes two critical bugs affecting effects mode and game logo positioning:

1. **Effects mode switching causes HUD to disappear** - When switching to minimal/minimal+ mode, `applyVisualPreset()` would trigger `_collapseParentColumns()` which applied `display: none !important` to columns, combined with `transition: none` in modes.css, causing HUD to vanish permanently.

2. **Game logo always stuck in bottom-left** - The logo position function read from `window._settings.layoutPosition` which may not be populated at initialization, causing the logo to always appear in bottom-left corner regardless of layout setting.

## Changes
- **settings.js**: Modified `_collapseParentColumns()` to skip JS-driven collapse logic when visual preset modes are active, letting CSS rules in modes.css handle visibility. Also ensure mode classes are removed when switching back to standard.
- **game-logo.js**: Changed to read from global `_settings` object instead of `window._settings`. Added monkey-patch of `applySettings()` to call `updatePosition()` after settings load, ensuring logo position is correct on initialization.

## Testing
- Verify switching between standard/minimal/minimal+ modes keeps HUD visible
- Verify switching back to standard mode restores proper column layout
- Verify game logo appears in the correct corner matching the layout position setting