### PR TITLE
Leaderboard: full field, focus-on-lead with lap times

### DIFF
--- a/racecor-overlay/modules/components/leaderboard.js
+++ b/racecor-overlay/modules/components/leaderboard.js
@@ -292,15 +292,42 @@
         if (isPlayer) classes.push('lb-player');
         if (pit) classes.push('lb-pit');
 
-        // Gap display
+        // Gap display based on focus mode
         let gapStr = '', gapClass = 'gap-player';
         if (!isPlayer) {
-          if (gap < 0) {
-            gapStr = '-' + Math.abs(gap).toFixed(1) + 's';
-            gapClass = 'gap-ahead';
-          } else if (gap > 0) {
-            gapStr = '+' + gap.toFixed(1) + 's';
-            gapClass = 'gap-behind';
+          if (this._focusMode === 'lead') {
+            // In 'lead' mode, show either lap time (P1) or gap to leader
+            if (pos === 1) {
+              // P1: show their last lap time formatted as mm:ss.fff
+              if (last > 0) {
+                const m = Math.floor(last / 60), s = last - m * 60;
+                gapStr = m + ':' + (s < 10 ? '0' : '') + s.toFixed(2);
+              }
+              gapClass = 'gap-leader';
+            } else {
+              // Others: show gap to P1 (first entry in drivers array)
+              const leader = this._drivers[0];
+              if (leader) {
+                const leaderLast = +leader[4]; // P1's lastLap
+                const gapToLeader = last > 0 && leaderLast > 0 ? last - leaderLast : 0;
+                if (gapToLeader > 0) {
+                  gapStr = '+' + gapToLeader.toFixed(1) + 's';
+                  gapClass = 'gap-behind';
+                } else if (gapToLeader < 0) {
+                  gapStr = Math.abs(gapToLeader).toFixed(1) + 's';
+                  gapClass = 'gap-ahead';
+                }
+              }
+            }
+          } else {
+            // 'me' mode: show gap to player (original behavior)
+            if (gap < 0) {
+              gapStr = '-' + Math.abs(gap).toFixed(1) + 's';
+              gapClass = 'gap-ahead';
+            } else if (gap > 0) {
+              gapStr = '+' + gap.toFixed(1) + 's';
+              gapClass = 'gap-behind';
+            }
           }
         }
 

--- a/racecor-overlay/modules/js/config.js
+++ b/racecor-overlay/modules/js/config.js
@@ -577,7 +577,7 @@ const _defaultSettings = {
   showRedlineFlash: true,
   // Leaderboard
   lbFocus: 'me',        // 'me' = center on player, 'lead' = show from P1
-  lbMaxRows: 5,         // max visible opponent rows
+  lbMaxRows: 10,        // max visible opponent rows (increased from 5 to show more of full field)
   lbExpandToFill: false, // override lbMaxRows to fill available screen space
   // Datastream field toggles
   dsShowGforce: true,

--- a/racecor-overlay/modules/js/leaderboard.js
+++ b/racecor-overlay/modules/js/leaderboard.js
@@ -126,18 +126,45 @@
       }
       if (pit) classes.push('lb-pit');
 
-      // Gap display
+      // Gap display based on focus mode
       let gapStr = '', gapClass = 'gap-player';
       if (isPlayer) {
         gapStr = '';
-      } else if (gap < 0) {
-        gapStr = '-' + Math.abs(gap).toFixed(1) + 's';
-        gapClass = 'gap-ahead';
-      } else if (gap > 0) {
-        gapStr = '+' + gap.toFixed(1) + 's';
-        gapClass = 'gap-behind';
+      } else if (focusMode === 'lead') {
+        // In 'lead' mode, show either lap time (P1) or gap to leader
+        if (pos === 1) {
+          // P1: show their last lap time formatted as mm:ss.fff
+          if (last > 0) {
+            const m = Math.floor(last / 60), s = last - m * 60;
+            gapStr = m + ':' + (s < 10 ? '0' : '') + s.toFixed(2);
+          }
+          gapClass = 'gap-leader';
+        } else {
+          // Others: show gap to P1 (first entry in raw array)
+          const leader = raw[0];
+          if (leader) {
+            const leaderLast = +leader[4]; // P1's lastLap
+            const gapToLeader = last > 0 && leaderLast > 0 ? last - leaderLast : 0;
+            if (gapToLeader > 0) {
+              gapStr = '+' + gapToLeader.toFixed(1) + 's';
+              gapClass = 'gap-behind';
+            } else if (gapToLeader < 0) {
+              gapStr = Math.abs(gapToLeader).toFixed(1) + 's';
+              gapClass = 'gap-ahead';
+            }
+          }
+        }
       } else {
-        gapStr = '';
+        // 'me' mode: show gap to player (original behavior)
+        if (gap < 0) {
+          gapStr = '-' + Math.abs(gap).toFixed(1) + 's';
+          gapClass = 'gap-ahead';
+        } else if (gap > 0) {
+          gapStr = '+' + gap.toFixed(1) + 's';
+          gapClass = 'gap-behind';
+        } else {
+          gapStr = '';
+        }
       }
 
       // iRating shorthand

--- a/racecor-plugin/simhub-plugin/plugin/K10Motorsports.Plugin/Plugin.cs
+++ b/racecor-plugin/simhub-plugin/plugin/K10Motorsports.Plugin/Plugin.cs
@@ -731,18 +731,11 @@ namespace K10Motorsports.Plugin
                     return pa.CompareTo(pb);
                 });
 
-                // Window: 3 ahead of player, player, 3 behind
-                int playerIdx = entries.FindIndex(e =>
-                {
-                    int lastComma = e.LastIndexOf(',');
-                    return e[lastComma + 1] == '1';
-                });
-                if (playerIdx < 0) playerIdx = 0;
-                int start = Math.Max(0, playerIdx - 3);
-                int end = Math.Min(entries.Count, playerIdx + 4); // +4 = player + 3 behind
-                var window = entries.GetRange(start, end - start);
+                // Send all drivers (no windowing — let the JS decide what to display)
+                // Limit to a reasonable max (60 drivers) to avoid excessive data transfer
+                if (entries.Count > 60) entries = entries.GetRange(0, 60);
 
-                return "[" + string.Join(",", window) + "]";
+                return "[" + string.Join(",", entries) + "]";
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary

This PR fixes the leaderboard to show the full field and implements focus-based gap display modes.

### Changes

1. **C# Plugin (Plugin.cs)**
   - Removed the 7-driver window (3 ahead + player + 3 behind)
   - Now sends all drivers in the field (capped at 60 for safety)
   - Leaderboard stays sorted by position

2. **Leaderboard Display (leaderboard.js & web component)**
   - **'me' mode (focus on player)**: Shows gap to player (relative times) - existing behavior
   - **'lead' mode (focus on leader)**: Shows P1's last lap time, others show gap to P1
   - Enables broadcasters to see absolute performance picture

3. **Configuration**
   - Default `lbMaxRows` increased from 5 to 10 (now that full field is available)
   - `lbExpandToFill` option works to dynamically fill available screen space

### Testing

- Verify full field is transmitted from plugin
- Test gap display in both focus modes
- Confirm rows expand/collapse based on lbMaxRows setting