### PR TITLE
Restore bottom Y-adjust slider and logo subtitle

### DIFF
--- a/racecor-overlay/dashboard.html
+++ b/racecor-overlay/dashboard.html
@@ -883,6 +883,10 @@
     <div class="settings-tab-content" id="settingsTabBranding">
       <div class="settings-two-col">
       <div class="settings-row"><span class="settings-label">K10 Logo</span><div class="settings-toggle on" data-section="k10LogoSquare" data-key="showK10Logo" onclick="toggleSetting(this)"></div></div>
+      <div class="settings-row" data-pro-feature="branding">
+        <span class="settings-label">Logo Subtitle</span>
+        <input type="text" id="logoSubtitleInput" maxlength="30" placeholder="Your team name" class="settings-input" oninput="updateLogoSubtitle(this.value)">
+      </div>
       <div class="settings-row"><span class="settings-label">Car Manufacturer</span><div class="settings-toggle on" data-section="carLogoSquare" data-key="showCarLogo" onclick="toggleSetting(this)"></div></div>
       <div class="settings-row"><span class="settings-label">Game Logo</span><div class="settings-toggle on" data-key="showGameLogo" onclick="toggleGameLogo(this)"></div></div>
       </div>
@@ -957,6 +961,15 @@
         <div class="settings-range-row">
           <input class="settings-range" id="settingsZoom" type="range" min="100" max="200" step="5" value="165" oninput="previewZoom(this.value)" onchange="updateZoom(this.value)"/>
           <span class="settings-range-val" id="zoomVal">165%</span>
+        </div>
+      </div>
+
+      <div class="settings-group">
+        <div class="settings-group-label">Vertical Offset</div>
+        <div class="settings-row">
+          <span class="settings-label">Bottom Y-Adjust</span>
+          <input type="range" id="settingsBottomYOffset" min="0" max="200" step="10" value="0" class="settings-range" oninput="previewBottomYOffset(this.value)">
+          <span class="settings-value" id="bottomYOffsetVal">0px</span>
         </div>
       </div>
 

--- a/racecor-overlay/modules/js/config.js
+++ b/racecor-overlay/modules/js/config.js
@@ -585,7 +585,11 @@ const _defaultSettings = {
   dsShowFfb: true,
   dsShowDelta: true,
   dsShowTrackTemp: true,
-  dsShowFps: true
+  dsShowFps: true,
+  // Y-offset for bottom-positioned modules
+  bottomYOffset: 0,
+  // Logo subtitle text
+  logoSubtitle: ''
 };
 
 let _settings = Object.assign({}, _defaultSettings);

--- a/racecor-overlay/modules/js/connections.js
+++ b/racecor-overlay/modules/js/connections.js
@@ -12,7 +12,7 @@
   let _k10Connecting = false;
 
   // Pro features — keys map to setting toggles and sidebar items
-  const PRO_FEATURE_KEYS = ['commentary','incidents','spotter','leaderboard','datastream','webgl','reflections','modules','minimal','minimal-plus'];
+  const PRO_FEATURE_KEYS = ['commentary','incidents','spotter','leaderboard','datastream','webgl','reflections','modules','minimal','minimal-plus','branding'];
 
   function isProFeature(key) {
     const map = {
@@ -80,6 +80,9 @@
 
     // iRacing tab — enabled when K10 connected (was Discord)
     if (typeof updateIRacingTabState === 'function') updateIRacingTabState();
+
+    // Apply logo subtitle (updates when K10 connection state changes)
+    if (typeof applyLogoSubtitle === 'function') applyLogoSubtitle();
   }
 
   async function connectK10Pro() {
@@ -546,6 +549,48 @@
     if (window.updateGameLogo) window.updateGameLogo(window._currentGameId || 'iracing', !isOn);
   }
 
+  // ─── Logo subtitle ───
+  function updateLogoSubtitle(value) {
+    _settings.logoSubtitle = value;
+    applyLogoSubtitle();
+    saveSettings();
+  }
+  window.updateLogoSubtitle = updateLogoSubtitle;
+
+  function applyLogoSubtitle() {
+    var label = document.getElementById('k10SubtitleLabel');
+    var logo = document.getElementById('k10LogoSquare');
+    if (!logo) return;
+
+    // Create label element if it doesn't exist
+    if (!label) {
+      label = document.createElement('span');
+      label.id = 'k10SubtitleLabel';
+      label.className = 'logo-subtitle';
+      logo.parentNode.insertBefore(label, logo.nextSibling);
+    }
+
+    var text = _settings.logoSubtitle || '';
+    // Show subtitle only when K10 Pro is connected and text is set
+    if (text && _k10User) {
+      label.textContent = text;
+      label.style.display = 'block';
+      label.style.opacity = '1';
+    } else if (!_k10User && !text) {
+      // Teaser: show placeholder for logged-out users
+      label.textContent = 'K10 Motorsports';
+      label.style.display = 'block';
+      label.style.opacity = '0.3';
+    } else if (text && !_k10User) {
+      label.textContent = text;
+      label.style.display = 'block';
+      label.style.opacity = '0.3';
+    } else {
+      label.style.display = 'none';
+    }
+  }
+  window.applyLogoSubtitle = applyLogoSubtitle;
+
   // ─── Green screen mode ───
   async function toggleGreenScreen(el) {
     const isOn = el.classList.contains('on');
@@ -668,6 +713,20 @@
     // ── 6. Spotter: co-located with race control at top center ──
     // Positioning is handled entirely by CSS (top: 8px, left: 50%, transform).
     // No layout-dependent positioning needed.
+
+    // ── 7. Apply bottom Y-offset ──
+    // When layout is bottom-oriented, apply margin-bottom offset to relevant panels
+    var yOff = (_settings.bottomYOffset || 0) + 'px';
+    var secContainer = document.getElementById('secContainer');
+    var incPanel = document.getElementById('incidentsPanel');
+    var cmtCol = document.getElementById('commentaryCol');
+    var gameLogo = document.getElementById('gameLogoOverlay');
+    // Only apply when layout is bottom-oriented
+    var isBottomLayout = pos.startsWith('bottom');
+    if (secContainer) secContainer.style.marginBottom = isBottomLayout ? yOff : '';
+    if (incPanel) incPanel.style.marginBottom = isBottomLayout ? yOff : '';
+    if (cmtCol) cmtCol.style.marginBottom = isBottomLayout ? yOff : '';
+    if (gameLogo) gameLogo.style.marginBottom = isBottomLayout ? yOff : '';
   }
 
   function updateLayoutPosition(value) {
@@ -724,6 +783,14 @@
       if (settingsOverlay) settingsOverlay.style.zoom = scale;
     }
   }
+
+  function previewBottomYOffset(val) {
+    document.getElementById('bottomYOffsetVal').textContent = val + 'px';
+    _settings.bottomYOffset = parseInt(val, 10);
+    applyLayout();
+    saveSettings();
+  }
+  window.previewBottomYOffset = previewBottomYOffset;
 
   function updateForceFlag(val) {
     _forceFlagState = val;

--- a/racecor-overlay/modules/js/settings.js
+++ b/racecor-overlay/modules/js/settings.js
@@ -70,6 +70,18 @@
     if (zoomLabel) zoomLabel.textContent = zoomVal + '%';
     applyZoom(zoomVal);
 
+    // Bottom Y-Offset
+    var ySlider = document.getElementById('settingsBottomYOffset');
+    if (ySlider) {
+      ySlider.value = _settings.bottomYOffset || 0;
+      document.getElementById('bottomYOffsetVal').textContent = (_settings.bottomYOffset || 0) + 'px';
+    }
+
+    // Logo Subtitle
+    var subInput = document.getElementById('logoSubtitleInput');
+    if (subInput) subInput.value = _settings.logoSubtitle || '';
+    if (typeof applyLogoSubtitle === 'function') applyLogoSubtitle();
+
     // Force flag
     _forceFlagState = _settings.forceFlag || '';
     const flagSelect = document.getElementById('settingsForceFlag');

--- a/racecor-overlay/modules/styles/dashboard.css
+++ b/racecor-overlay/modules/styles/dashboard.css
@@ -452,6 +452,22 @@
   }
   .car-model-label:empty { display: none; }
 
+  .logo-subtitle {
+    display: block;
+    text-align: center;
+    font-family: var(--ff);
+    font-size: 9px;
+    font-weight: 500;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    margin-top: 2px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
+  }
+
   /* ═══════════════════════════════════════════════
      TACH — gear top-left, RPM top-right, speed+MPH beneath RPM
      segments fill bottom


### PR DESCRIPTION
## Summary

This PR restores two lost features from previous commits:

- **Bottom Y-Adjust Slider (from commit 5a152ea)**: Layout settings now include a vertical offset slider to adjust the bottom position of modules when using bottom corner layouts
- **Logo Subtitle Text (from fix/dashboard-functional-pr2 commit bd86b10)**: Branding tab now includes a Pro feature to add custom subtitle text below the K10 logo

## Changes

### Feature 1: Bottom Y-Adjust
- Added `bottomYOffset` setting (default 0px)
- Y-Adjust slider in Layout tab (0-200px, 10px steps)
- Real-time preview via `previewBottomYOffset()`
- Margin-bottom applied only when layout is bottom-oriented
- Affects: secondary container, incidents panel, commentary, game logo

### Feature 2: Logo Subtitle
- Added `logoSubtitle` setting (pro-gated, default empty)
- Input field in Branding settings (max 30 chars)
- Conditional display:
  * Shows custom text when K10 Pro connected
  * Shows faded 'K10 Motorsports' teaser when logged out
  * Hides when text is empty
- Updates on K10 connection state changes
- Styled with .logo-subtitle CSS class

## Files Modified
- config.js: Added default settings
- connections.js: Added PRO_FEATURE_KEYS entry, bottom Y-offset logic, subtitle functions
- dashboard.html: Added Y-Adjust slider and Subtitle input UI
- dashboard.css: Added .logo-subtitle styling
- settings.js: Added initialization and value loading