### PR TITLE
Tufte-pure minimal mode: redesign components, not just rearrange

### DIFF
--- a/racecor-overlay/modules/components/commentary.js
+++ b/racecor-overlay/modules/components/commentary.js
@@ -142,6 +142,33 @@
             font-family: var(--ff-mono);
             text-align: right;
           }
+
+          /* ── MINIMAL MODE — Tufte-pure: tight, no decoration ── */
+          :host-context(body.mode-minimal) .cm-panel {
+            padding: 6px;
+            border-width: 1px;
+            border-radius: 3px;
+            background: transparent;
+          }
+
+          :host-context(body.mode-minimal) .cm-icon {
+            display: none;
+          }
+
+          :host-context(body.mode-minimal) .cm-header {
+            margin-bottom: 4px;
+            gap: 4px;
+          }
+
+          :host-context(body.mode-minimal) .cm-body {
+            font-size: 11px;
+            line-height: 1.3;
+            margin-bottom: 4px;
+          }
+
+          :host-context(body.mode-minimal) .cm-meta {
+            font-size: 9px;
+          }
         </style>
 
         <div class="cm-panel">

--- a/racecor-overlay/modules/components/fuel-gauge.js
+++ b/racecor-overlay/modules/components/fuel-gauge.js
@@ -135,6 +135,47 @@
             font-weight: var(--fw-semi);
             color: var(--text-primary);
           }
+
+          /* ── MINIMAL MODE — Tufte-pure: flat bar, hero laps number ── */
+          :host-context(body.mode-minimal) .fg-bar-wrapper {
+            border: none;
+            border-radius: 2px;
+            height: 14px;
+          }
+
+          :host-context(body.mode-minimal) .fg-bar {
+            background: var(--green) !important;
+            background-image: none !important;
+          }
+
+          :host-context(body.mode-minimal) .fg-item {
+            background: transparent;
+            border: none;
+            border-radius: 0;
+            padding: 3px 0;
+          }
+
+          :host-context(body.mode-minimal) .fg-value {
+            font-size: 14px;
+            font-weight: var(--fw-black);
+          }
+
+          :host-context(body.mode-minimal) .fg-label {
+            font-size: 8px;
+            font-weight: var(--fw-medium);
+            color: var(--text-dim);
+          }
+
+          /* Laps remaining is the hero number — the most actionable data */
+          :host-context(body.mode-minimal) .fg-item:nth-child(3) .fg-value {
+            font-size: 20px;
+            color: var(--text-primary);
+          }
+
+          /* Status is redundant with fuel bar color — hide it */
+          :host-context(body.mode-minimal) .fg-item:nth-child(4) {
+            display: none;
+          }
         </style>
 
         <div class="fg-panel">

--- a/racecor-overlay/modules/components/gap-display.js
+++ b/racecor-overlay/modules/components/gap-display.js
@@ -212,6 +212,42 @@
             color: var(--text-secondary);
             white-space: nowrap;
           }
+
+          /* ── MINIMAL MODE — Tufte-pure: big numbers, directional arrows, no chrome ── */
+          :host-context(body.mode-minimal) .gap-item {
+            background: transparent;
+            border: none;
+            border-radius: 0;
+            padding: 2px 0;
+          }
+
+          :host-context(body.mode-minimal) .gap-item.gaining,
+          :host-context(body.mode-minimal) .gap-item.losing {
+            border: none;
+          }
+
+          :host-context(body.mode-minimal) .gap-time {
+            font-size: 20px;
+            font-weight: var(--fw-black);
+            font-variant-numeric: tabular-nums;
+          }
+
+          :host-context(body.mode-minimal) .gap-label {
+            font-size: 8px;
+            margin-bottom: 1px;
+          }
+
+          :host-context(body.mode-minimal) .gap-info {
+            font-size: 8px;
+          }
+
+          :host-context(body.mode-minimal) .gap-driver {
+            font-size: 8px;
+          }
+
+          :host-context(body.mode-minimal) .gap-ir {
+            font-size: 8px;
+          }
         </style>
 
         <div class="gaps-container">
@@ -278,11 +314,17 @@
       // Ahead gap
       if (this._aheadTimeEl) {
         const gapStr = this._formatGap(this._aheadGap);
-        this._aheadTimeEl.textContent = gapStr;
 
         // Determine color: green if gap is shrinking (approaching), red if growing (falling back)
-        const isGaining = this._prevAheadGap > 0 && this._aheadGap < this._prevAheadGap;
-        this._aheadTimeEl.className = 'gap-time ahead ' + (isGaining ? 'gaining' : this._aheadGap > this._prevAheadGap && this._prevAheadGap > 0 ? 'losing' : '');
+        const isGainingAhead = this._prevAheadGap > 0 && this._aheadGap < this._prevAheadGap;
+        const isLosingAhead = this._aheadGap > this._prevAheadGap && this._prevAheadGap > 0;
+
+        // Tufte: add directional arrows for colorblind accessibility in minimal mode
+        const isMinimal = document.body && document.body.classList.contains('mode-minimal');
+        const aheadArrow = isMinimal ? (isGainingAhead ? '↑ ' : isLosingAhead ? '↓ ' : '  ') : '';
+        this._aheadTimeEl.textContent = aheadArrow + gapStr;
+
+        this._aheadTimeEl.className = 'gap-time ahead ' + (isGainingAhead ? 'gaining' : isLosingAhead ? 'losing' : '');
         this._prevAheadGap = this._aheadGap;
 
         if (this._aheadCellEl) {
@@ -301,11 +343,17 @@
       // Behind gap
       if (this._behindTimeEl) {
         const gapStr = this._formatGap(this._behindGap);
-        this._behindTimeEl.textContent = gapStr;
 
         // For behind: green if gap is growing (pulling away), red if shrinking (being caught)
-        const isGaining = this._prevBehindGap > 0 && this._behindGap > this._prevBehindGap;
-        this._behindTimeEl.className = 'gap-time behind ' + (isGaining ? 'gaining' : this._behindGap < this._prevBehindGap && this._prevBehindGap > 0 ? 'losing' : '');
+        const isGainingBehind = this._prevBehindGap > 0 && this._behindGap > this._prevBehindGap;
+        const isLosingBehind = this._behindGap < this._prevBehindGap && this._prevBehindGap > 0;
+
+        // Tufte: directional arrows for colorblind-safe encoding
+        const isMinimalBehind = document.body && document.body.classList.contains('mode-minimal');
+        const behindArrow = isMinimalBehind ? (isGainingBehind ? '↑ ' : isLosingBehind ? '↓ ' : '  ') : '';
+        this._behindTimeEl.textContent = behindArrow + gapStr;
+
+        this._behindTimeEl.className = 'gap-time behind ' + (isGainingBehind ? 'gaining' : isLosingBehind ? 'losing' : '');
         this._prevBehindGap = this._behindGap;
 
         if (this._behindCellEl) {

--- a/racecor-overlay/modules/components/pedal-curves.js
+++ b/racecor-overlay/modules/components/pedal-curves.js
@@ -144,6 +144,30 @@
           .pc-label-value.throttle { color: hsl(120, 60%, 55%); }
           .pc-label-value.brake { color: hsl(0, 80%, 55%); }
           .pc-label-value.clutch { color: hsl(210, 60%, 55%); }
+
+          /* ── MINIMAL MODE — Tufte-pure: trace + big numbers, no chrome ── */
+          :host-context(body.mode-minimal) .pc-canvas-wrapper {
+            border: none;
+            border-radius: 0;
+          }
+
+          :host-context(body.mode-minimal) .pc-label {
+            background: transparent;
+            border: none;
+            border-radius: 0;
+            padding: 2px 0;
+          }
+
+          /* Color IS the label — remove redundant text labels */
+          :host-context(body.mode-minimal) .pc-label-name {
+            display: none;
+          }
+
+          /* Make the numbers count — they're all you've got now */
+          :host-context(body.mode-minimal) .pc-label-value {
+            font-size: 18px;
+            font-weight: var(--fw-black);
+          }
         </style>
 
         <div class="pc-panel">

--- a/racecor-overlay/modules/components/position-card.js
+++ b/racecor-overlay/modules/components/position-card.js
@@ -255,6 +255,51 @@
             font-size: 8px;
             color: var(--text-secondary);
           }
+
+          /* ── MINIMAL MODE — Tufte-pure: huge position, numbers only ── */
+          :host-context(body.mode-minimal) .card-container {
+            background: transparent;
+            border: none;
+            padding: 2px;
+          }
+
+          :host-context(body.mode-minimal) .pos-number {
+            font-size: 36px;
+            line-height: 0.9;
+          }
+
+          :host-context(body.mode-minimal) .pos-of-total {
+            font-size: 9px;
+            color: var(--text-dim);
+          }
+
+          :host-context(body.mode-minimal) .rating-value {
+            font-size: 16px;
+            font-weight: var(--fw-black);
+          }
+
+          :host-context(body.mode-minimal) .rating-bar,
+          :host-context(body.mode-minimal) .rating-bar-fill {
+            display: none !important;
+          }
+
+          /* SR: number only, no pie — color encodes threshold */
+          :host-context(body.mode-minimal) .sr-pie {
+            width: auto;
+            height: auto;
+            border-radius: 0;
+            background: none !important;
+            border: none;
+            font-size: 16px;
+            font-weight: var(--fw-black);
+            color: var(--text-primary);
+          }
+
+          :host-context(body.mode-minimal) .rating-label {
+            font-size: 8px;
+            font-weight: var(--fw-medium);
+            color: var(--text-dim);
+          }
         </style>
 
         <div class="card-container">
@@ -333,10 +378,20 @@
       }
 
       if (this._srPieEl && this._safetyRating > 0) {
-        // Safety rating goes from 0-4.0, map to pie angle
-        const srPct = Math.min(100, (this._safetyRating / 4.0) * 100);
-        const angle = (srPct / 100) * 360;
-        this._srPieEl.style.background = `conic-gradient(var(--green) 0deg ${angle}deg, var(--bg) ${angle}deg 360deg)`;
+        const isMinimal = document.body && document.body.classList.contains('mode-minimal');
+        if (isMinimal) {
+          // Tufte: no pie — color the number by license-class thresholds
+          const srColor = this._safetyRating >= 3.0 ? 'var(--green)'
+            : this._safetyRating >= 2.0 ? 'var(--amber)'
+            : 'var(--red)';
+          this._srPieEl.style.background = 'none';
+          this._srPieEl.style.color = srColor;
+        } else {
+          // Standard: pie chart encoding
+          const srPct = Math.min(100, (this._safetyRating / 4.0) * 100);
+          const angle = (srPct / 100) * 360;
+          this._srPieEl.style.background = `conic-gradient(var(--green) 0deg ${angle}deg, var(--bg) ${angle}deg 360deg)`;
+        }
       }
     }
 

--- a/racecor-overlay/modules/components/race-control.js
+++ b/racecor-overlay/modules/components/race-control.js
@@ -362,6 +362,43 @@
             0%   { box-shadow: 0 4px 24px hsla(0, 0%, 0%, 0.6), 0 0 8px hsla(0, 90%, 50%, 0.35); }
             100% { box-shadow: 0 4px 24px hsla(0, 0%, 0%, 0.6), 0 0 20px hsla(0, 90%, 50%, 0.70); }
           }
+
+          /* ── MINIMAL MODE — Tufte-pure: solid color, big text, zero chartjunk ── */
+          :host-context(body.mode-minimal) .rc-inner {
+            background: hsla(0, 0%, 3%, 0.95);
+            padding: 12px 24px 14px 20px;
+            box-shadow: none !important;
+            animation: none !important;
+          }
+
+          /* Remove animated stripes — first species of chartjunk (moiré) */
+          :host-context(body.mode-minimal) .rc-inner::after {
+            display: none !important;
+          }
+
+          /* Remove accent bar — decoration, not data */
+          :host-context(body.mode-minimal) .rc-inner::before {
+            display: none !important;
+          }
+
+          /* Remove icon — text + color communicate the flag state */
+          :host-context(body.mode-minimal) .rc-icon {
+            display: none;
+          }
+
+          /* The message IS the data — make it large and unmissable */
+          :host-context(body.mode-minimal) .rc-title {
+            font-size: 36px;
+            letter-spacing: 0.15em;
+          }
+
+          :host-context(body.mode-minimal) .rc-detail {
+            font-size: 14px;
+          }
+
+          :host-context(body.mode-minimal) .rc-banner.rc-visible .rc-inner {
+            animation: none !important;
+          }
         </style>
 
         <div class="rc-banner" id="rcBanner">

--- a/racecor-overlay/modules/components/tachometer.js
+++ b/racecor-overlay/modules/components/tachometer.js
@@ -273,6 +273,62 @@
             0% { opacity: 0.84; }
             100% { opacity: 1; }
           }
+
+          /* ── MINIMAL MODE — Tufte-pure: flat segments, bigger numbers ── */
+          :host-context(body.mode-minimal) .tacho-gear {
+            font-size: 80px;
+          }
+
+          :host-context(body.mode-minimal) .speed-value {
+            font-size: 28px;
+            font-weight: var(--fw-black);
+          }
+
+          :host-context(body.mode-minimal) .tacho-rpm {
+            font-size: 16px;
+            text-shadow: none !important;
+            transform: none !important;
+          }
+
+          :host-context(body.mode-minimal) .tacho-seg {
+            border: none;
+            box-shadow: none !important;
+            border-radius: 1px 1px 0 0;
+            transition: background 60ms linear, height 60ms linear;
+          }
+
+          :host-context(body.mode-minimal) .tacho-seg.lit-green {
+            background: var(--green);
+            box-shadow: none;
+            border: none;
+          }
+
+          :host-context(body.mode-minimal) .tacho-seg.lit-yellow {
+            background: var(--amber);
+            box-shadow: none;
+            border: none;
+          }
+
+          :host-context(body.mode-minimal) .tacho-seg.lit-red {
+            background: var(--red);
+            box-shadow: none;
+            border: none;
+          }
+
+          :host-context(body.mode-minimal) .tacho-seg.lit-redline {
+            background: var(--red);
+            box-shadow: none;
+            border: none;
+            animation: none;
+            opacity: 1;
+          }
+
+          :host-context(body.mode-minimal) .tacho-rpm.rpm-pulse-green,
+          :host-context(body.mode-minimal) .tacho-rpm.rpm-pulse-yellow,
+          :host-context(body.mode-minimal) .tacho-rpm.rpm-pulse-red {
+            text-shadow: none !important;
+            transform: none !important;
+          }
         </style>
 
         <div class="tacho-container">

--- a/racecor-overlay/modules/components/tire-grid.js
+++ b/racecor-overlay/modules/components/tire-grid.js
@@ -201,8 +201,60 @@
             color: var(--text-dim);
             margin-top: 2px;
           }
+
+          /* Optimal range annotation — shown only in minimal mode */
+          .tire-opt-range {
+            display: none;
+            font-size: 8px;
+            color: var(--text-dim);
+            text-align: center;
+            margin-bottom: 2px;
+            font-family: var(--ff-mono);
+            letter-spacing: 0.03em;
+          }
+
+          /* ── MINIMAL MODE — Tufte-pure: big temps, no chrome, spatial = label ── */
+          :host-context(body.mode-minimal) .tire-opt-range {
+            display: block;
+          }
+
+          :host-context(body.mode-minimal) .tire-cell {
+            background: transparent;
+            border: none;
+            border-radius: 0;
+            padding: 2px;
+            min-width: 40px;
+            min-height: 36px;
+          }
+
+          /* Spatial position IS the label — remove redundant text labels */
+          :host-context(body.mode-minimal) .tire-position {
+            display: none;
+          }
+
+          :host-context(body.mode-minimal) .tire-temp {
+            font-size: 22px;
+            font-weight: var(--fw-black);
+            margin-bottom: 0;
+          }
+
+          :host-context(body.mode-minimal) .tire-unit {
+            font-size: 10px;
+          }
+
+          /* Wear bar is redundant with the wear label number */
+          :host-context(body.mode-minimal) .tire-wear-outer {
+            display: none;
+          }
+
+          :host-context(body.mode-minimal) .tire-wear-label {
+            font-size: 7px;
+            color: var(--text-dim);
+            margin-top: 0;
+          }
         </style>
 
+        <div class="tire-opt-range">opt 80–95°C</div>
         <div class="tire-grid">
           <div class="tire-cell" data-pos="fl">
             <div class="tire-position">FL</div>

--- a/racecor-overlay/modules/styles/modes.css
+++ b/racecor-overlay/modules/styles/modes.css
@@ -31,6 +31,10 @@ body.mode-minimal {
   --border: transparent;
   --pad: 4px;
   --gap: 3px;
+  --corner-r: 2px;
+  --corner-r-sm: 1px;
+  --panel-gap: 4px;
+  --edge: 6px;
 }
 
 /* Panel borders removed: transparent color preserves gap spacing */
@@ -192,6 +196,15 @@ body.mode-minimal [class*="value"],
 body.mode-minimal [class*="data"],
 body.mode-minimal .number {
   font-weight: var(--fw-bold) !important;
+}
+
+/* ── Remove backdrop-filter everywhere — pure Tufte, no glass effects ── */
+body.mode-minimal [class*="panel"],
+body.mode-minimal [class*="cell"],
+body.mode-minimal [class*="item"],
+body.mode-minimal [class*="card"] {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
 }
 
 /* ── Animations: Disable all except essential state changes ── */


### PR DESCRIPTION
## Summary

- **Redesigns 8 components from the inside out** in minimal mode using `:host-context(body.mode-minimal)` Shadow DOM rules — not just hiding elements, but changing how data is presented to match Tufte's exact audit recommendations
- **Increases data-ink ratio** by enlarging every critical number (gear 64→80px, position 20→36px, gap times 13→20px, tire temps 13→22px, pedal % 11→18px) while stripping all non-data ink (gradients, glows, box-shadows, borders, backgrounds, redundant labels)
- **Adds colorblind-safe ↑/↓ arrows** to gap display, **threshold-colored SR number** replacing the pie chart, **"opt 80–95°C" tire reference annotation**, and **spatial-position-as-label** on the tire grid — all Tufte audit findings now implemented as component behavior, not just CSS toggles

### Per-component changes

| Component | What changed |
|-----------|-------------|
| **Tachometer** | Flat solid-color segments (no gradients/glows/box-shadows), gear 80px, speed 28px, RPM 16px |
| **Fuel gauge** | "Laps remaining" hero number at 20px, stripped cell chrome, hidden redundant "Status" readout |
| **Position card** | 36px position, iRating bar → number only, SR pie → threshold-colored number (JS render change) |
| **Gap display** | 20px times with ↑/↓ colorblind arrows (JS render change), stripped borders |
| **Tire grid** | 22px temps, position labels hidden (spatial = label), wear bars hidden, new opt range annotation |
| **Pedal curves** | Text labels hidden (color = label), 18px percentages, canvas border stripped |
| **Race control** | Animated stripes killed (moiré chartjunk), icon hidden, title 36px, all glow animations removed |
| **Commentary** | 6px padding, icon hidden, transparent background |

**Zero impact on standard mode.** All changes scoped to `body.mode-minimal`.

## Test plan

- [ ] Toggle to Minimal mode — verify all components render with enlarged numbers and stripped chrome
- [ ] Toggle back to Standard — verify zero visual regression, all effects/pies/bars/animations intact
- [ ] Check gap display arrows appear only in minimal mode
- [ ] Check SR shows colored number (no pie) in minimal, pie in standard
- [ ] Check tire grid shows "opt 80-95C" annotation only in minimal
- [ ] Check pedal labels hidden in minimal, visible in standard
- [ ] Check race control banner has no stripes/glow in minimal
- [ ] Verify Minimal+ mode is unaffected

Generated with [Claude Code](https://claude.com/claude-code)