### PR TITLE
ci: republish SimHub plugin on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Build & Release
+
+# Builds the SimHub plugin (C# net48) on a v* tag and attaches the
+# packed build/ tree as a release asset. Consumed by prodrive-windows'
+# release.yml, which downloads the latest plugin release zip and
+# bundles it into the combined installer.
+#
+# Homebridge plugin is published separately via npm and is not part
+# of this workflow — it has no role in the Windows installer.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-simhub:
+    name: Build SimHub Plugin
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Build plugin (Release)
+        shell: pwsh
+        run: |
+          dotnet build `
+            racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/RaceCorProDrive.Plugin.csproj `
+            -c Release
+          $dll = "racecor-plugin/simhub-plugin/build/RaceCorProDrive.dll"
+          if (-not (Test-Path $dll)) { throw "Plugin DLL not produced at $dll" }
+          Write-Host "Built: $((Get-Item $dll).Length) bytes"
+
+      - name: Pack build/ tree
+        shell: pwsh
+        run: |
+          Compress-Archive `
+            -Path racecor-plugin/simhub-plugin/build/* `
+            -DestinationPath simhub-plugin.zip
+          Write-Host "Packed: $((Get-Item simhub-plugin.zip).Length) bytes"
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: simhub-plugin.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds back `.github/workflows/release.yml` (deleted in [c252715](https://github.com/k10-motorsports/prodrive-plugin/commit/c252715) when the overlay was extracted) in slimmed-down form: just the SimHub plugin build, no overlay, no installer.
- On `v*` tag push: builds `RaceCorProDrive.Plugin.csproj` (net48), packs `racecor-plugin/simhub-plugin/build/` into `simhub-plugin.zip`, attaches it to the release.
- Homebridge plugin stays out — it ships via npm, not the Windows installer.

## Why

The combined Windows installer pipeline lives in [prodrive-windows](https://github.com/k10-motorsports/prodrive-windows/pull/1) now and consumes the latest plugin release on tag. Without this workflow, `v0.9.43` (and every future tag) produces no release artifact, so the windows pipeline has nothing to download.

## Test plan

- [ ] Merge, then re-tag `v0.9.43` (or push a new `v0.9.44`) and confirm a release with `simhub-plugin.zip` appears
- [ ] Verify the zip extracts to a flat tree containing `RaceCorProDrive.dll` + dependency DLLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)