### PR TITLE
fix(plugin): use 'using static' for SimHub.Logging in WS transport

### DIFF
--- a/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/Transport/WsServer.cs
+++ b/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/Transport/WsServer.cs
@@ -3,7 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using Fleck;
-using SimHub.Logging;
+using static SimHub.Logging;
 
 namespace RaceCorProDrive.Plugin.Transport
 {

--- a/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/Transport/WsTelemetryPublisher.cs
+++ b/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/Transport/WsTelemetryPublisher.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using MessagePack;
-using SimHub.Logging;
+using static SimHub.Logging;
 
 namespace RaceCorProDrive.Plugin.Transport
 {


### PR DESCRIPTION
## Summary

`SimHub.Logging` is a **static class**, not a namespace, so `using SimHub.Logging;` fails with CS7007. The two transport files added in [#179](https://github.com/k10-motorsports/prodrive-plugin/pull/179) (the PR1 ws-server work) reference \`Logging.Current\` unqualified, so the right directive is `using static SimHub.Logging;`.

Every other file in the plugin already qualifies as `SimHub.Logging.Current.Info(...)` and doesn't need a directive — only these two new files do.

## Why it slipped through

The pre-tag CI (\`simhub-ci.yml\`) doesn't actually compile the C# plugin in MSBuild form (it runs Python tests). The first compile happened on the new tag-triggered \`release.yml\` for \`v0.9.43\`, which surfaced the bug.

## Test plan

- [ ] CI \`Build SimHub Plugin\` step passes on this PR
- [ ] After merge, push a new tag and confirm \`simhub-plugin.zip\` lands on the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)