### PR TITLE
fix(plugin): unbreak SimHub WS telemetry build

### DIFF
--- a/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/Plugin.cs
+++ b/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/Plugin.cs
@@ -514,7 +514,9 @@ namespace RaceCorProDrive.Plugin
                         _leaderboardJson,
                         _screenColorSampler,
                         _mozaSerial,
-                        _pedalProfiles);
+                        _pedalProfiles,
+                        _lightsPhase,
+                        _lastRawTrackSlug);
                     _wsPublisher.Tick(telemetryDict);
                 }
                 catch (Exception ex)

--- a/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/Transport/TelemetryFrame.cs
+++ b/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/Transport/TelemetryFrame.cs
@@ -25,6 +25,8 @@ namespace RaceCorProDrive.Plugin.Transport
         /// <param name="screenColorSampler">Screen color sampler (for ambient light).</param>
         /// <param name="mozaSerial">Moza hardware manager (nullable).</param>
         /// <param name="pedalProfiles">Pedal profile manager (nullable).</param>
+        /// <param name="lightsPhase">Formation-lights phase (0=off, 1-5=building reds, 6=all-red, 7=green, 8=fade). Tracked at plugin scope, not on the snapshot.</param>
+        /// <param name="trackSlug">Raw SimHub TrackId (e.g. "nurburgring gp"). Tracked at plugin scope, not on the snapshot.</param>
         /// <returns>Flat dictionary of wire keys → values.</returns>
         public static Dictionary<string, object> BuildDict(
             TelemetrySnapshot s,
@@ -37,7 +39,9 @@ namespace RaceCorProDrive.Plugin.Transport
             string leaderboardJson = null,
             Engine.ScreenColorSampler screenColorSampler = null,
             Engine.Moza.MozaSerialManager mozaSerial = null,
-            Engine.PedalProfileManager pedalProfiles = null)
+            Engine.PedalProfileManager pedalProfiles = null,
+            int lightsPhase = 0,
+            string trackSlug = null)
         {
             if (s == null) throw new ArgumentNullException(nameof(s));
 
@@ -48,8 +52,10 @@ namespace RaceCorProDrive.Plugin.Transport
             pitboxCounters = pitboxCounters ?? new int[7];
             leaderboardJson = leaderboardJson ?? "[]";
 
-            // Demo telemetry reference (use engine's DemoTelemetry if engine is non-null, otherwise s)
-            var dt = engine?.DemoTelemetry ?? s;
+            // Demo telemetry reference. Field surface differs from TelemetrySnapshot
+            // (e.g. Rpm vs. Rpms, Fuel vs. FuelLevel, LatG vs. LatAccel) — Demo wire keys
+            // below MUST use DemoTelemetryProvider's names to match the HTTP path.
+            var dt = engine?.DemoTelemetry ?? new Engine.DemoTelemetryProvider();
 
             // ── Game data (live telemetry from snapshot) ──
             dict["DataCorePlugin.GameRunning"] = (demo || s.GameRunning) ? 1 : 0;
@@ -362,14 +368,14 @@ namespace RaceCorProDrive.Plugin.Transport
             // Demo mode
             dict["RaceCorProDrive.Plugin.DemoMode"] = demo ? 1 : 0;
             dict["RaceCorProDrive.Plugin.Demo.Gear"] = Escape(dt.Gear ?? "N");
-            dict["RaceCorProDrive.Plugin.Demo.Rpm"] = dt.Rpms;
+            dict["RaceCorProDrive.Plugin.Demo.Rpm"] = dt.Rpm;
             dict["RaceCorProDrive.Plugin.Demo.MaxRpm"] = dt.MaxRpm;
             dict["RaceCorProDrive.Plugin.Demo.SpeedMph"] = dt.SpeedMph;
             dict["RaceCorProDrive.Plugin.Demo.Throttle"] = dt.Throttle * 100;
             dict["RaceCorProDrive.Plugin.Demo.Brake"] = dt.Brake * 100;
             dict["RaceCorProDrive.Plugin.Demo.Clutch"] = dt.Clutch * 100;
-            dict["RaceCorProDrive.Plugin.Demo.Fuel"] = dt.FuelLevel;
-            dict["RaceCorProDrive.Plugin.Demo.MaxFuel"] = dt.FuelMaxCapacity;
+            dict["RaceCorProDrive.Plugin.Demo.Fuel"] = dt.Fuel;
+            dict["RaceCorProDrive.Plugin.Demo.MaxFuel"] = dt.MaxFuel;
             dict["RaceCorProDrive.Plugin.Demo.FuelPerLap"] = dt.FuelPerLap;
             dict["RaceCorProDrive.Plugin.Demo.RemainingLaps"] = dt.RemainingLaps;
             dict["RaceCorProDrive.Plugin.Demo.TyreTempFL"] = dt.TyreTempFL;
@@ -405,8 +411,8 @@ namespace RaceCorProDrive.Plugin.Transport
             dict["RaceCorProDrive.Plugin.Demo.IRBehind"] = dt.IRBehind;
 
             // Demo Datastream
-            dict["RaceCorProDrive.Plugin.Demo.DS.LatG"] = dt.LatAccel;
-            dict["RaceCorProDrive.Plugin.Demo.DS.LongG"] = dt.LongAccel;
+            dict["RaceCorProDrive.Plugin.Demo.DS.LatG"] = dt.LatG;
+            dict["RaceCorProDrive.Plugin.Demo.DS.LongG"] = dt.LongG;
             dict["RaceCorProDrive.Plugin.Demo.DS.YawRate"] = dt.YawRate;
             dict["RaceCorProDrive.Plugin.Demo.DS.SteerTorque"] = dt.SteerTorque;
             dict["RaceCorProDrive.Plugin.Demo.DS.TrackTemp"] = dt.TrackTemp;
@@ -441,7 +447,7 @@ namespace RaceCorProDrive.Plugin.Transport
             dict["RaceCorProDrive.Plugin.Grid.GriddedCars"] = s.GriddedCars;
             dict["RaceCorProDrive.Plugin.Grid.TotalCars"] = s.TotalCars;
             dict["RaceCorProDrive.Plugin.Grid.PaceMode"] = s.PaceMode;
-            dict["RaceCorProDrive.Plugin.Grid.LightsPhase"] = s.LightsPhase;
+            dict["RaceCorProDrive.Plugin.Grid.LightsPhase"] = lightsPhase;
             dict["RaceCorProDrive.Plugin.Grid.StartType"] = Escape(s.IsStandingStart ? "standing" : "rolling");
             dict["RaceCorProDrive.Plugin.Grid.TrackCountry"] = Escape(s.TrackCountry ?? "");
 
@@ -468,7 +474,7 @@ namespace RaceCorProDrive.Plugin.Transport
             {
                 dict["RaceCorProDrive.Plugin.TrackMap.Ready"] = trackMap.IsReady ? 1 : 0;
                 dict["RaceCorProDrive.Plugin.TrackMap.TrackName"] = Escape(trackMap.TrackName ?? "");
-                dict["RaceCorProDrive.Plugin.TrackMap.TrackSlug"] = Escape(s.TrackId ?? "");
+                dict["RaceCorProDrive.Plugin.TrackMap.TrackSlug"] = Escape(trackSlug ?? "");
                 dict["RaceCorProDrive.Plugin.TrackMap.SvgPath"] = Escape(trackMap.SvgPath ?? "");
                 dict["RaceCorProDrive.Plugin.TrackMap.PlayerX"] = trackMap.PlayerX;
                 dict["RaceCorProDrive.Plugin.TrackMap.PlayerY"] = trackMap.PlayerY;
@@ -479,7 +485,7 @@ namespace RaceCorProDrive.Plugin.Transport
             {
                 dict["RaceCorProDrive.Plugin.TrackMap.Ready"] = 0;
                 dict["RaceCorProDrive.Plugin.TrackMap.TrackName"] = "";
-                dict["RaceCorProDrive.Plugin.TrackMap.TrackSlug"] = Escape(s.TrackId ?? "");
+                dict["RaceCorProDrive.Plugin.TrackMap.TrackSlug"] = Escape(trackSlug ?? "");
                 dict["RaceCorProDrive.Plugin.TrackMap.SvgPath"] = "";
                 dict["RaceCorProDrive.Plugin.TrackMap.PlayerX"] = 0.0;
                 dict["RaceCorProDrive.Plugin.TrackMap.PlayerY"] = 0.0;

--- a/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/Transport/WsServer.cs
+++ b/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/Transport/WsServer.cs
@@ -171,7 +171,7 @@ namespace RaceCorProDrive.Plugin.Transport
                 Socket = socket;
             }
 
-            public bool IsOpen => Socket?.IsOpen ?? false;
+            public bool IsOpen => Socket?.IsAvailable ?? false;
 
             public void Send(byte[] data)
             {


### PR DESCRIPTION
## Summary

Fixes the SimHub plugin build, which broke when the PR-1 WebSocket telemetry transport landed (commit 82614bb). Two transport files referenced fields and APIs that don't exist on the types they were calling.

## Root causes

**1. `TelemetryFrame.BuildDict` referenced snapshot fields that don't exist**

- `s.TrackId` (lines 471, 482) — `TelemetrySnapshot` has no `TrackId`. The canonical wire source for `RaceCorProDrive.Plugin.TrackMap.TrackSlug` is `_lastRawTrackSlug`, a plugin-scope field captured in `Plugin.cs:725-729`.
- `s.LightsPhase` (line 444) — also not on the snapshot. The canonical wire source for `RaceCorProDrive.Plugin.Grid.LightsPhase` is `_lightsPhase`, the plugin-scope state machine maintained around `Plugin.cs:600-635`.

Fix: added `int lightsPhase = 0` and `string trackSlug = null` parameters to `BuildDict` and threaded them through from the only call site in `Plugin.cs`.

**2. Demo-telemetry fallback mixed two unrelated types**

`var dt = engine?.DemoTelemetry ?? s` tried to coalesce a `DemoTelemetryProvider` with a `TelemetrySnapshot`. The compiler rejected the `??` operator because neither is assignable to the other. Replaced the snapshot fallback with `?? new Engine.DemoTelemetryProvider()` so `dt` is always the same type.

This change exposed five latent field-name bugs in the demo block — the author had used `TelemetrySnapshot` field names where `DemoTelemetryProvider`'s differ:

| Wrong | Correct |
| --- | --- |
| `dt.Rpms` | `dt.Rpm` |
| `dt.FuelLevel` | `dt.Fuel` |
| `dt.FuelMaxCapacity` | `dt.MaxFuel` |
| `dt.LatAccel` | `dt.LatG` |
| `dt.LongAccel` | `dt.LongG` |

The corrected names match the wire format produced by the HTTP path in `Plugin.cs:1768-1814`, so overlay parity is preserved.

**3. Fleck 1.2.0 API mismatch in `WsServer`**

`Socket?.IsOpen` (WsServer.cs:174) doesn't exist — Fleck 1.2.0's `IWebSocketConnection` exposes `IsAvailable`. Verified by inspecting the symbols in `~/.nuget/packages/fleck/1.2.0/lib/net45/Fleck.dll`. The plugin's own `IWsConnection.IsOpen` interface contract (used by `WsTelemetryPublisher`) is unchanged — only the Fleck adapter property was wrong.

## Reviewer notes

- I was unable to compile locally (net48 + Windows-only `SimHub.Plugins` / `SimHub.Logging` references), so CI is the source of truth for build correctness.
- The wire format is unchanged — every key still emits the same value the HTTP path emits, just sourced from the right field.

## Test plan

- [ ] CI: `Build SimHub Plugin` workflow goes green on this branch
- [ ] In SimHub on Windows: overlay reports the same `TrackMap.TrackSlug`, `Grid.LightsPhase`, and `Demo.*` values it did before the WS transport PR
- [ ] WebSocket client connecting to `ws://localhost:8890/racecor` receives a snapshot frame and stays connected (verifies `IsAvailable` adapter)