### PR TITLE
feat: add CalcClient for web-api /api/v1/calc/* endpoints

### DIFF
--- a/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/Calc/CalcClient.cs
+++ b/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/Calc/CalcClient.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace RaceCorProDrive.Plugin.Calc
+{
+    // ───────────────────────────────────────────────────────────────
+    //  CALC CLIENT — wraps web-api /api/v1/calc/* endpoints.
+    //  Spec: prodrive-server/docs/native-app-integration.md
+    //
+    //  Replaces every locally-implemented calc engine in the plugin.
+    //  HttpClient is long-lived per the doc's recommendation; do not
+    //  instantiate per-call.
+    // ───────────────────────────────────────────────────────────────
+    public sealed class CalcClient : IDisposable
+    {
+        private static readonly Uri DefaultBaseUri = new Uri("https://api.prodrive.racecor.io");
+
+        private readonly HttpClient _http;
+        private readonly bool _ownsHttpClient;
+        private string _bearerToken;
+
+        private static readonly JsonSerializerSettings _jsonSettings = new JsonSerializerSettings
+        {
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            NullValueHandling = NullValueHandling.Ignore,
+            DateFormatHandling = DateFormatHandling.IsoDateFormat,
+            DateTimeZoneHandling = DateTimeZoneHandling.Utc
+        };
+
+        public CalcClient() : this(DefaultBaseUri, TimeSpan.FromSeconds(10)) { }
+
+        public CalcClient(Uri baseAddress, TimeSpan timeout)
+        {
+            _http = new HttpClient
+            {
+                BaseAddress = baseAddress ?? DefaultBaseUri,
+                Timeout = timeout
+            };
+            _http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            _ownsHttpClient = true;
+        }
+
+        // For tests / shared HttpClient reuse.
+        public CalcClient(HttpClient http)
+        {
+            _http = http ?? throw new ArgumentNullException(nameof(http));
+            _ownsHttpClient = false;
+        }
+
+        // Bearer is optional today (web-api is open). When Phase 9b
+        // lands, set this once on construction and every request picks
+        // it up — no per-call plumbing.
+        public void SetBearerToken(string token)
+        {
+            _bearerToken = token;
+        }
+
+        // ─── 1. Driver DNA ───────────────────────────────────────
+        public Task<DriverDnaResponse> FetchDriverDnaAsync(
+            IEnumerable<DnaSession> sessions,
+            IEnumerable<DnaRating> ratings,
+            CancellationToken ct = default)
+            => PostAsync<DriverDnaResponse>("/api/v1/calc/dna",
+                new { sessions = sessions ?? new List<DnaSession>(), ratings = ratings ?? new List<DnaRating>() },
+                ct);
+
+        // ─── 2. Mastery (tracks + cars) ──────────────────────────
+        public Task<MasteryResponse> FetchMasteryAsync(
+            IEnumerable<MasterySession> sessions,
+            CancellationToken ct = default)
+            => PostAsync<MasteryResponse>("/api/v1/calc/mastery",
+                new { sessions = sessions ?? new List<MasterySession>() },
+                ct);
+
+        // ─── 3. Notable moments ──────────────────────────────────
+        public Task<MomentsResponse> FetchMomentsAsync(
+            IEnumerable<MomentSession> sessions,
+            IEnumerable<MomentRating> ratings,
+            CancellationToken ct = default)
+            => PostAsync<MomentsResponse>("/api/v1/calc/moments",
+                new { sessions = sessions ?? new List<MomentSession>(), ratings = ratings ?? new List<MomentRating>() },
+                ct);
+
+        // ─── 4. Scatter buckets ──────────────────────────────────
+        public Task<ScatterResponse> FetchScatterAsync(
+            IEnumerable<ScatterSession> sessions,
+            string timeZone = null,
+            CancellationToken ct = default)
+        {
+            var body = string.IsNullOrEmpty(timeZone)
+                ? (object)new { sessions = sessions ?? new List<ScatterSession>() }
+                : new { sessions = sessions ?? new List<ScatterSession>(), timeZone };
+            return PostAsync<ScatterResponse>("/api/v1/calc/scatter", body, ct);
+        }
+
+        // ─── 5. When-engine ──────────────────────────────────────
+        public Task<WhenResponse> FetchWhenAsync(
+            IEnumerable<object> sessions,        // RaceSession shape; opaque pass-through
+            IEnumerable<object> ratings,         // RatingHistoryEntry shape; opaque pass-through
+            string timeZone = null,
+            CancellationToken ct = default)
+        {
+            var body = string.IsNullOrEmpty(timeZone)
+                ? (object)new { sessions = sessions ?? new List<object>(), ratings = ratings ?? new List<object>() }
+                : new { sessions = sessions ?? new List<object>(), ratings = ratings ?? new List<object>(), timeZone };
+            return PostAsync<WhenResponse>("/api/v1/calc/when", body, ct);
+        }
+
+        // ─── 6. Race-Now verdict ─────────────────────────────────
+        // Recommended cadence: once on plugin start, then once every
+        // 5–10 minutes (or on hour rollover). Verdict only changes on
+        // hour boundaries; faster polling is wasted.
+        public Task<RaceNowResponse> FetchRaceNowAsync(
+            object profile,                      // WhenProfile from /calc/when, or null
+            DateTimeOffset? now = null,
+            string timeZone = null,
+            IEnumerable<RaceNowSessionInput> sessions = null,
+            CancellationToken ct = default)
+        {
+            var body = new Dictionary<string, object> { ["profile"] = profile };
+            if (now.HasValue) body["now"] = now.Value.UtcDateTime;
+            if (!string.IsNullOrEmpty(timeZone)) body["timeZone"] = timeZone;
+            if (sessions != null) body["sessions"] = sessions;
+            return PostAsync<RaceNowResponse>("/api/v1/calc/race-now", body, ct);
+        }
+
+        // ─── 7. Race summary ─────────────────────────────────────
+        public Task<RaceSummaryResponse> FetchRaceSummaryAsync(
+            RaceSummaryRequest request,
+            CancellationToken ct = default)
+            => PostAsync<RaceSummaryResponse>("/api/v1/calc/race-summary",
+                request ?? new RaceSummaryRequest(),
+                ct);
+
+        // ─── 8. Next race ideas ──────────────────────────────────
+        public Task<NextRaceIdeasResponse> FetchNextRaceIdeasAsync(
+            NextRaceIdeasRequest request,
+            CancellationToken ct = default)
+            => PostAsync<NextRaceIdeasResponse>("/api/v1/calc/next-race-ideas",
+                request ?? new NextRaceIdeasRequest(),
+                ct);
+
+        // ─── Core POST helper ────────────────────────────────────
+        private async Task<T> PostAsync<T>(string path, object body, CancellationToken ct)
+        {
+            var json = JsonConvert.SerializeObject(body, _jsonSettings);
+            using (var content = new StringContent(json, Encoding.UTF8, "application/json"))
+            using (var req = new HttpRequestMessage(HttpMethod.Post, path) { Content = content })
+            {
+                if (!string.IsNullOrEmpty(_bearerToken))
+                {
+                    req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _bearerToken);
+                }
+
+                using (var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false))
+                {
+                    if (!resp.IsSuccessStatusCode)
+                    {
+                        var preview = "";
+                        try { preview = await resp.Content.ReadAsStringAsync().ConfigureAwait(false); } catch { }
+                        if (preview.Length > 500) preview = preview.Substring(0, 500);
+                        throw new CalcClientException(path, (int)resp.StatusCode, preview);
+                    }
+
+                    var stream = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    return JsonConvert.DeserializeObject<T>(stream, _jsonSettings);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_ownsHttpClient)
+            {
+                _http.Dispose();
+            }
+        }
+    }
+
+    public sealed class CalcClientException : Exception
+    {
+        public string Path { get; }
+        public int StatusCode { get; }
+        public string ResponseBodyPreview { get; }
+
+        public CalcClientException(string path, int statusCode, string preview)
+            : base($"calc-client {path} {statusCode}: {preview}")
+        {
+            Path = path;
+            StatusCode = statusCode;
+            ResponseBodyPreview = preview;
+        }
+    }
+}

--- a/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/Calc/Models.cs
+++ b/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/Calc/Models.cs
@@ -1,0 +1,327 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace RaceCorProDrive.Plugin.Calc
+{
+    // ───────────────────────────────────────────────────────────────
+    //  DTOs for /api/v1/calc/* request and response shapes.
+    //
+    //  Field ordering and naming match the contract in
+    //  prodrive-server/docs/native-app-integration.md. Newtonsoft camel-cases
+    //  property names via the contract resolver in CalcClient.
+    //
+    //  Heavily-nested or evolving response shapes (TrackMastery,
+    //  WhenProfile, ComposureReport, IRacingSchedule, etc.) are kept as
+    //  JObject so additive server changes don't require client redeploys.
+    //  Cast to a strong type at the call site if you need it.
+    // ───────────────────────────────────────────────────────────────
+
+    // ─── 1. Driver DNA ───────────────────────────────────────────────
+
+    public sealed class DnaSession
+    {
+        public int? FinishPosition { get; set; }
+        public int? IncidentCount { get; set; }
+        public IDictionary<string, object> Metadata { get; set; }
+        public string CarModel { get; set; }
+        public string TrackName { get; set; }
+        public string GameName { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+
+    public sealed class DnaRating
+    {
+        public double IRating { get; set; }
+        public double? PrevIRating { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+
+    public sealed class DriverDnaResponse
+    {
+        public DriverDnaScores Dna { get; set; }
+        public DriverDnaArchetype Archetype { get; set; }
+        public List<DriverDnaInsight> Insights { get; set; }
+        public int SampleSize { get; set; }
+        public double Confidence { get; set; }
+    }
+
+    public sealed class DriverDnaScores
+    {
+        public double Consistency { get; set; }
+        public double Racecraft { get; set; }
+        public double Cleanness { get; set; }
+        public double Endurance { get; set; }
+        public double Adaptability { get; set; }
+        public double Improvement { get; set; }
+        public double WetWeather { get; set; }
+        public double Experience { get; set; }
+    }
+
+    public sealed class DriverDnaArchetype
+    {
+        public string Major { get; set; }
+        public string Variant { get; set; }
+        public string MajorDescription { get; set; }
+        public string VariantDescription { get; set; }
+    }
+
+    public sealed class DriverDnaInsight
+    {
+        public string Dimension { get; set; }
+        public string Label { get; set; }
+        public double Value { get; set; }
+        public string Description { get; set; }
+        public string Trend { get; set; } // "improving" | "declining" | "stable"
+    }
+
+    // ─── 2. Mastery ──────────────────────────────────────────────────
+
+    public sealed class MasterySession
+    {
+        public string Id { get; set; }
+        public string CarModel { get; set; }
+        public string Manufacturer { get; set; } = "";
+        public string TrackName { get; set; }
+        public int? FinishPosition { get; set; }
+        public int IncidentCount { get; set; }
+        public IDictionary<string, object> Metadata { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public string GameName { get; set; } = "iracing";
+    }
+
+    public sealed class MasteryResponse
+    {
+        // TrackMastery + CarAffinity shapes are large and additive — kept as
+        // raw JObject so server-side additions don't break existing clients.
+        public List<JObject> Tracks { get; set; }
+        public List<JObject> Cars { get; set; }
+    }
+
+    // ─── 3. Moments ──────────────────────────────────────────────────
+
+    public sealed class MomentSession
+    {
+        public string Id { get; set; }
+        public string CarModel { get; set; }
+        public string TrackName { get; set; }
+        public int? FinishPosition { get; set; }
+        public int IncidentCount { get; set; }
+        public IDictionary<string, object> Metadata { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public string GameName { get; set; }
+        public string SessionType { get; set; }
+    }
+
+    public sealed class MomentRating
+    {
+        public double IRating { get; set; }
+        public double PrevIRating { get; set; }
+        public string PrevLicense { get; set; }
+        public string License { get; set; }
+        public string SessionType { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+
+    public sealed class MomentsResponse
+    {
+        public List<JObject> Moments { get; set; }
+    }
+
+    // ─── 4. Scatter ──────────────────────────────────────────────────
+
+    public sealed class ScatterSession
+    {
+        public DateTime Date { get; set; }
+        public double IRatingDelta { get; set; }
+        public double SrDelta { get; set; }
+        public int Incidents { get; set; }
+    }
+
+    public sealed class ScatterResponse
+    {
+        public List<ScatterBucket> Buckets { get; set; }
+    }
+
+    public sealed class ScatterBucket
+    {
+        public int Day { get; set; }    // 0=Sun, 6=Sat (JS convention)
+        public int Hour { get; set; }   // 0–23 in requested time zone
+        public int Count { get; set; }
+        public double IrDeltaSum { get; set; }
+        public double SrDeltaSum { get; set; }
+        public int IncidentsSum { get; set; }
+        public double AvgIncidents { get; set; }
+    }
+
+    // ─── 5. When-engine ──────────────────────────────────────────────
+
+    public sealed class WhenResponse
+    {
+        public JObject Profile { get; set; }     // WhenProfile
+        public List<JObject> Insights { get; set; }
+        public WhenPanelView Panel { get; set; }
+    }
+
+    public sealed class WhenPanelView
+    {
+        public WhenPanelSide Strengths { get; set; }
+        public WhenPanelSide WatchOut { get; set; }
+    }
+
+    public sealed class WhenPanelSide
+    {
+        public string Paragraph { get; set; }
+        public List<string> Bullets { get; set; }
+    }
+
+    // ─── 6. Race-Now verdict ─────────────────────────────────────────
+
+    public sealed class RaceNowSessionInput
+    {
+        public string TrackName { get; set; }
+        public string CarModel { get; set; }
+        public string Category { get; set; }
+        public int? IncidentCount { get; set; }
+        public int? CompletedLaps { get; set; }
+    }
+
+    public sealed class RaceNowResponse
+    {
+        public RaceNowEvaluation Evaluation { get; set; }
+        public List<RaceNowAlternative> Alternatives { get; set; }
+    }
+
+    public sealed class RaceNowEvaluation
+    {
+        public string Verdict { get; set; }   // "good" | "marginal" | "risky" | "insufficient"
+        public string Detail { get; set; }
+        public JObject Stats { get; set; }
+    }
+
+    public sealed class RaceNowAlternative
+    {
+        public string Label { get; set; }
+        public string TrackName { get; set; }
+        public string CarModel { get; set; }
+        public string Reason { get; set; }
+    }
+
+    // ─── 7. Race summary ─────────────────────────────────────────────
+
+    public sealed class RaceSummaryRequest
+    {
+        public WireSession Session { get; set; }
+        public List<JObject> Laps { get; set; } = new List<JObject>();
+        public JObject Behavior { get; set; }
+        public RaceSummaryTrackHistory TrackHistory { get; set; }
+        public RaceSummaryRatingContext RatingContext { get; set; }
+    }
+
+    public sealed class WireSession
+    {
+        public string Id { get; set; }
+        public string CarModel { get; set; }
+        public string Manufacturer { get; set; }
+        public string TrackName { get; set; }
+        public int? FinishPosition { get; set; }
+        public int IncidentCount { get; set; }
+        public string SessionType { get; set; }
+        public string Category { get; set; }
+        public IDictionary<string, object> Metadata { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+
+    public sealed class RaceSummaryTrackHistory
+    {
+        public List<WireSession> Sessions { get; set; }
+        public int? BestPosition { get; set; }
+        public double? AvgPosition { get; set; }
+        public double AvgIncidents { get; set; }
+        public int TotalRaces { get; set; }
+    }
+
+    public sealed class RaceSummaryRatingContext
+    {
+        public double? PreRaceIRating { get; set; }
+        public double? PostRaceIRating { get; set; }
+        public double? PreRaceSR { get; set; }
+        public double? PostRaceSR { get; set; }
+        public double? IrDelta { get; set; }
+        public double? SrDelta { get; set; }
+    }
+
+    public sealed class RaceSummaryResponse
+    {
+        public RaceSummary Summary { get; set; }
+    }
+
+    public sealed class RaceSummary
+    {
+        public string Headline { get; set; }
+        public string Subheadline { get; set; }
+        public string OverallVerdict { get; set; }   // "excellent" | "good" | "mixed" | "tough" | "learning"
+        public List<JObject> Strengths { get; set; }
+        public List<JObject> Improvements { get; set; }
+        public JObject LapAnalysis { get; set; }
+        public JObject ComposureReport { get; set; }
+        public JObject TrackContext { get; set; }
+        public JObject RatingImpact { get; set; }
+    }
+
+    // ─── 8. Next race ideas ──────────────────────────────────────────
+
+    public sealed class NextRaceIdeasRequest
+    {
+        public List<JObject> Sessions { get; set; } = new List<JObject>();
+        public List<JObject> Ratings { get; set; } = new List<JObject>();
+        public List<DriverRating> DriverRatings { get; set; } = new List<DriverRating>();
+        public List<JObject> Schedule { get; set; } = new List<JObject>();
+        public List<string> ActiveCategories { get; set; }
+        public string TimeZone { get; set; }
+    }
+
+    public sealed class DriverRating
+    {
+        public string Category { get; set; }       // "road" | "oval" | "dirt_oval" | "dirt_road" | "formula"
+        public double IRating { get; set; }
+        public string SafetyRating { get; set; }   // e.g. "3.45"
+        public string License { get; set; }        // "A" | "B" | "C" | "D" | "R"
+    }
+
+    public sealed class NextRaceIdeasResponse
+    {
+        public List<NextRaceIdea> Suggestions { get; set; }
+    }
+
+    public sealed class NextRaceIdea
+    {
+        public string SeriesName { get; set; }
+        public string TrackName { get; set; }
+        public string TrackConfig { get; set; }
+        public string Category { get; set; }
+        public string LicenseClass { get; set; }
+        public bool IsOfficial { get; set; }
+        public bool IsFixed { get; set; }
+        public double Score { get; set; }
+        public NextRaceStrategy Strategy { get; set; }
+        public string Commentary { get; set; }
+        public DateTime NextStartTime { get; set; }
+        public List<string> CarClassNames { get; set; }
+        public int SeasonId { get; set; }
+        public int SeriesId { get; set; }
+        public int? RaceLapLimit { get; set; }
+        public int? RaceTimeLimit { get; set; }
+        public JObject ScoreBreakdown { get; set; }
+    }
+
+    public sealed class NextRaceStrategy
+    {
+        public string Type { get; set; }   // "pitlane" | "conservative" | "careful" | "form" | "steady"
+
+        // Strategy carries free-form fields per type — keep extras opaque.
+        [JsonExtensionData]
+        public IDictionary<string, JToken> Extra { get; set; }
+    }
+}

--- a/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/RaceCorProDrive.Plugin.csproj
+++ b/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/RaceCorProDrive.Plugin.csproj
@@ -61,6 +61,8 @@
     <Reference Include="Microsoft.CSharp" />
     <!-- WMI — needed for Moza USB device discovery via Win32_PnPEntity -->
     <Reference Include="System.Management" />
+    <!-- HttpClient — net48 framework assembly, used by Calc.CalcClient -->
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
## Summary

Phase 9 of the calc-migration project. Scaffolds `RaceCorProDrive.Plugin.Calc.CalcClient` — an HTTP wrapper around the 8 web-api calc endpoints — so any future analytics feature in the SimHub plugin uses the canonical server-side calc layer instead of duplicating it in C#.

- `Calc/CalcClient.cs` — long-lived `HttpClient` (per the spec's guidance), Newtonsoft camelCase, UTC ISO dates, `SetBearerToken` for the Phase 9b auth layer.
- `Calc/Models.cs` — POCO DTOs. Heavily-nested or evolving response shapes (TrackMastery, WhenProfile, ComposureReport, IRacingSchedule, ScoreBreakdown) kept as `JObject` so additive server changes don't require client redeploys.
- `.csproj` — adds `<Reference Include="System.Net.Http" />` (HttpClient is a separate framework assembly on net48).

**No usages swapped.** The plugin has no local re-implementations of the 8 calc engines — the existing `CornerCoach`, `IncidentCoach`, `CommentaryEngine`, `Moza*` engines are telemetry / live-coaching, which the spec explicitly says to keep. This PR just makes the calc layer reachable from the plugin for whatever uses it next.

Spec: [`prodrive-server/docs/native-app-integration.md`](https://github.com/k10-motorsports/prodrive-server/blob/main/docs/native-app-integration.md)

Sibling PRs:
- prodrive-overlay: [#2](https://github.com/k10-motorsports/prodrive-overlay/pull/2) — actually swaps Next Race Ideas to use the calc client.
- prodrive-agents: spec doc for how the four native apps consume the calc API.

## Test plan

- [ ] Local `dotnet build` passes (verified during dev — net48, no errors)
- [ ] Existing `RaceCorProDrive.Tests` suite still builds and passes
- [ ] In a smoke test, instantiate `new CalcClient()` and call `FetchDriverDnaAsync(new[]{}, new[]{})` — expect a 200 with default-shaped response
- [ ] Verify `Calc/` files end up in the built `RaceCorProDrive.dll` (no project-glob regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)