### PR TITLE
fix(plugin): stop clobbering SimHub's stock files; CI version-stamps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,30 @@ jobs:
         with:
           dotnet-version: "8.0.x"
 
+      - name: Stamp version from tag
+        # Rewrites AssemblyVersion / AssemblyFileVersion in
+        # AssemblyInfo.cs from the pushed git tag so the built DLL
+        # actually reflects the release. Without this the CI just
+        # builds whatever was last manually written into the file -
+        # which is how 0.9.42 kept shipping under newer tags.
+        # Tag format: v<MAJOR>.<MINOR>.<PATCH>  (e.g. v0.12.0)
+        # Stamped form: <MAJOR>.<MINOR>.<PATCH>.0
+        shell: pwsh
+        run: |
+          $tag = "${{ github.ref_name }}"
+          if ($tag -notmatch '^v(\d+)\.(\d+)\.(\d+)$') {
+            throw "Tag '$tag' is not in the expected vMAJOR.MINOR.PATCH format"
+          }
+          $version = "$($matches[1]).$($matches[2]).$($matches[3]).0"
+          Write-Host "Stamping version: $version"
+          $info = "racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/Properties/AssemblyInfo.cs"
+          $content = Get-Content $info -Raw
+          $content = $content -replace 'AssemblyVersion\("[^"]+"\)',     ('AssemblyVersion("'    + $version + '")')
+          $content = $content -replace 'AssemblyFileVersion\("[^"]+"\)', ('AssemblyFileVersion("' + $version + '")')
+          Set-Content -Path $info -Value $content -NoNewline
+          # Echo the result so the version is visible in the run log.
+          Get-Content $info | Select-String 'AssemblyVersion|AssemblyFileVersion'
+
       - name: Build plugin (Release)
         shell: pwsh
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,13 @@ dist/
 # ── Test results ────────────────────────────────────────────────────
 **/test-results/
 
-# ── Plugin CI build output ────────────────────────────────────────
+# ── Plugin build output ──────────────────────────────────────────
+# Old path (legacy CI builds dropped here)
 racecor-plugin/build/
+# New path (csproj's OutputPath now always points here, so install.bat
+# can surgically copy an allow-list into SimHub instead of writing the
+# whole drop-set of NuGet deps over SimHub's stock files)
+racecor-plugin/simhub-plugin/build/
 
 # ── Claude / MCP config (may contain API tokens) ─────────────────
 .claude/*

--- a/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/Properties/AssemblyInfo.cs
+++ b/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/Properties/AssemblyInfo.cs
@@ -7,8 +7,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("RaceCor.io Pro Drive")]
 [assembly: AssemblyCopyright("")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("0.9.42.0")]
-[assembly: AssemblyFileVersion("0.9.42.0")]
+[assembly: AssemblyVersion("0.12.0.0")]
+[assembly: AssemblyFileVersion("0.12.0.0")]
 #if !CROSS_PLATFORM
 [assembly: System.Windows.ThemeInfo(
     System.Windows.ResourceDictionaryLocation.None,

--- a/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/RaceCorProDrive.Plugin.csproj
+++ b/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/RaceCorProDrive.Plugin.csproj
@@ -21,14 +21,31 @@
     <SimHubRefsPath>$(MSBuildProjectDirectory)\..\..\lib\simhub-refs\</SimHubRefsPath>
     <SimHubPath Condition="'$(SimHubPath)'==''">$(SimHubRefsPath)</SimHubPath>
 
-    <!-- CI mode: when SimHub isn't installed, build to a local staging folder -->
-    <_IsLocalDev>false</_IsLocalDev>
-    <_IsLocalDev Condition="Exists('C:\Program Files (x86)\SimHub\SimHubWPF.exe') Or '$(SIMHUB_PATH)'!=''">true</_IsLocalDev>
-    <OutputPath Condition="$(_IsLocalDev)">$(SimHubPath)</OutputPath>
-    <OutputPath Condition="!$(_IsLocalDev)">$(MSBuildProjectDirectory)\..\..\build\</OutputPath>
+    <!--
+      ALWAYS build to a local staging folder, never directly into
+      SimHub. The previous setup wrote OutputPath=$(SimHubPath) when
+      SimHub was detected, which dumped every transitive dep
+      (System.Buffers, System.Memory, BCL polyfills, etc.) on top of
+      SimHub's stock copies. SimHub does strict patch-version checks
+      on those deps at startup; a single mismatch silently disables
+      its entire plugin manager (we hit this with Newtonsoft.Json
+      13.0.3 overwriting SimHub's 13.0.4 — once we fixed that, OTHER
+      deps in our drop-set kept doing the same kind of damage).
+
+      Now we always build to build/, and install.bat copies a
+      strict allow-list of files (our DLL + clearly-third-party
+      deps SimHub doesn't ship) into SimHub. SimHub's stock files
+      are never overwritten.
+    -->
+    <OutputPath>$(MSBuildProjectDirectory)\..\..\build\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <!-- true: copies IRSDKSharper + YamlDotNet DLLs into output folder -->
+    <!--
+      true: copies third-party deps (IRSDKSharper, Fleck, MessagePack
+      and its transitive BCL polyfills) into the build/ staging
+      folder. install.bat then surgically copies only the files
+      SimHub doesn't already provide.
+    -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
@@ -45,9 +62,30 @@
   <!-- NuGet packages -->
   <ItemGroup>
     <PackageReference Include="IRSDKSharper" Version="1.1.4" />
-    <!-- log4net + Newtonsoft.Json via NuGet so CI doesn't need SimHub installed -->
-    <PackageReference Include="log4net" Version="2.0.15" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <!--
+      Newtonsoft.Json + log4net come from NuGet for compile-time
+      reference resolution (so CI builds without SimHub installed
+      can compile), but their runtime DLLs are EXCLUDED from output
+      (ExcludeAssets=runtime) so we don't overwrite SimHub's own
+      versions in its install directory.
+
+      SimHub ships these DLLs and version-checks them at startup -
+      shipping a different patch (e.g. our Newtonsoft.Json 13.0.3
+      vs SimHub's 13.0.4) trips an INVALID version error in
+      SimHub.txt and disables plugin discovery entirely. Let SimHub
+      provide them; we just compile against them.
+
+      Newtonsoft.Json bumped 13.0.3 -> 13.0.4 to match what SimHub
+      v9.11+ requires (their AssemblyVersion check is patch-strict).
+    -->
+    <PackageReference Include="log4net" Version="2.0.15">
+      <ExcludeAssets>runtime</ExcludeAssets>
+      <Private>false</Private>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4">
+      <ExcludeAssets>runtime</ExcludeAssets>
+      <Private>false</Private>
+    </PackageReference>
     <!-- WebSocket server (pure-managed, net48 compatible) -->
     <PackageReference Include="Fleck" Version="1.2.0" />
     <!-- MessagePack serialization (stay on 2.5.x for net48 compatibility) -->
@@ -83,17 +121,13 @@
   </ItemGroup>
 
   <!--
-    Post-build (local dev only): copy the racecorprodrive-data folder
-    alongside the DLL so the plugin can find commentary_topics.json.
+    Dataset copy is handled by install.bat now (writes into SimHub
+    via an explicit allow-list step) — the previous in-MSBuild
+    CopyDataset target was tied to the deleted $(_IsLocalDev) flag
+    and would also write into SimHub at build time, which is exactly
+    the kind of side-effect we removed when we made OutputPath always
+    point at build/.
   -->
-  <Target Name="CopyDataset" AfterTargets="Build" Condition="$(_IsLocalDev)">
-    <ItemGroup>
-      <DatasetFiles Include="..\..\racecorprodrive-data\**\*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(DatasetFiles)"
-          DestinationFolder="$(SimHubPath)racecorprodrive-data\%(RecursiveDir)"
-          SkipUnchangedFiles="true" />
-  </Target>
 
   <!--
     Post-build: export built artifacts back into the repo.

--- a/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/Transport/WsTelemetryPublisher.cs
+++ b/racecor-plugin/simhub-plugin/plugin/RaceCorProDrive.Plugin/Transport/WsTelemetryPublisher.cs
@@ -18,11 +18,26 @@ namespace RaceCorProDrive.Plugin.Transport
         private readonly Dictionary<Guid, ClientState> _clientState = new Dictionary<Guid, ClientState>();
         private readonly object _clientStateLock = new object();
 
-        // MessagePack serialization settings
+        // MessagePack serialization settings.
         // TypelessContractlessStandardResolver is required for serializing object-typed members
-        // containing Dictionary<string, object> with mixed primitive values
-        private static readonly MessagePackSerializerOptions _serializerOptions = MessagePackSerializerOptions.Standard
-            .WithResolver(MessagePack.Resolvers.TypelessContractlessStandardResolver.Instance);
+        // containing Dictionary<string, object> with mixed primitive values.
+        //
+        // CRITICAL: Wrapped in Lazy<T> so the MessagePack runtime is NOT
+        // touched at type-load time. The previous direct field initializer
+        // ran during JIT'd type-init when SimHub called Assembly.GetTypes()
+        // on our DLL, dragged MessagePack's static init in, and tripped
+        // the System.Buffers 4.0.3 vs 4.0.4 binding mismatch (see csproj
+        // build warning). The resulting TypeInitializationException
+        // bubbled up as ReflectionTypeLoadException on GetTypes(), which
+        // SimHub's plugin enumerator caught around the whole foreach loop
+        // - so EVERY plugin (bundled + ours) silently vanished from the
+        // settings list. Lazy<T> defers the throw to first SerializeFull/
+        // SerializeDelta call so the assembly loads cleanly and SimHub's
+        // enumerator finishes.
+        private static readonly Lazy<MessagePackSerializerOptions> _serializerOptions =
+            new Lazy<MessagePackSerializerOptions>(() =>
+                MessagePackSerializerOptions.Standard
+                    .WithResolver(MessagePack.Resolvers.TypelessContractlessStandardResolver.Instance));
 
         public WsTelemetryPublisher(IWsConnectionSink sink, Func<DateTime> clock = null)
         {
@@ -175,7 +190,7 @@ namespace RaceCorProDrive.Plugin.Transport
                 d = dict
             };
 
-            return MessagePackSerializer.Serialize(envelope, _serializerOptions);
+            return MessagePackSerializer.Serialize(envelope, _serializerOptions.Value);
         }
 
         /// <summary>
@@ -190,7 +205,7 @@ namespace RaceCorProDrive.Plugin.Transport
                 d = dict
             };
 
-            return MessagePackSerializer.Serialize(envelope, _serializerOptions);
+            return MessagePackSerializer.Serialize(envelope, _serializerOptions.Value);
         }
 
         /// <summary>

--- a/scripts/windows/install.bat
+++ b/scripts/windows/install.bat
@@ -107,6 +107,15 @@ timeout /t 2 /nobreak >NUL
 :stopped
 :: Tiny grace so the OS releases file handles.
 timeout /t 1 /nobreak >NUL
+
+:: Belt-and-braces: kill any other PowerShell / pwsh process that
+:: pinned the plugin DLL via [Reflection.Assembly]::LoadFrom (e.g. an
+:: ad-hoc diagnostic shell from earlier in the session). Excludes
+:: this script's own parent shell so we don't terminate ourselves.
+:: The DLL stays loaded for the AppDomain lifetime, blocking the
+:: build's overwrite step with MSB3021 / MSB3027.
+powershell -NoProfile -Command "$self = $PID; Get-Process powershell, pwsh -ErrorAction SilentlyContinue | Where-Object { $_.Id -ne $self -and $_.Id -ne $env:PROCESSOR_ID } | ForEach-Object { try { if ($_.Modules | Where-Object { $_.FileName -eq '!SH!\RaceCorProDrive.dll' }) { Write-Host (\"       Releasing DLL lock held by PowerShell PID \" + $_.Id); Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue } } catch {} }" 2>NUL
+
 echo        OK.
 
 :: ── 4. Build plugin ────────────────────────────────────────────
@@ -122,6 +131,9 @@ echo        OK.
 :: silently fails to resolve - producing a wall of CS0246 errors.
 set "SIMHUB_PATH=!SH!\"
 echo  [2/4] Building plugin (%CONFIG%)...
+:: Build always lands in build/ (never directly in SimHub) so we can
+:: pick exactly what to copy.
+set "STAGE=%PLUGIN_REPO%\simhub-plugin\build"
 dotnet build "%PLUGIN_PROJ%" -c %CONFIG% --nologo
 if %ERRORLEVEL% NEQ 0 (
     echo.
@@ -131,20 +143,43 @@ if %ERRORLEVEL% NEQ 0 (
     pause
     exit /b 1
 )
+if not exist "%STAGE%\RaceCorProDrive.dll" (
+    echo  ERROR: Build did not produce RaceCorProDrive.dll at %STAGE%
+    pause
+    exit /b 1
+)
 echo        OK.
 
-:: Sanity check the DLL actually landed.
+:: ── 4b. Surgical copy into SimHub ──────────────────────────────
+:: Copy ONLY the files we own + clearly-third-party deps SimHub
+:: doesn't ship. NEVER copy BCL polyfills (System.Buffers, System.
+:: Memory, System.Threading.Tasks.Extensions, Microsoft.NET.StringTools,
+:: etc.) or shared libs SimHub already has (Newtonsoft.Json, log4net) -
+:: SimHub does strict patch-version checks at startup and a single
+:: mismatch silently disables its entire plugin manager.
+echo  [3/4] Installing plugin files...
+:: Allow-list. Add to this set when you genuinely need a new third-
+:: party dep that SimHub doesn't ship.
+set "COPY_LIST=RaceCorProDrive.dll RaceCorProDrive.pdb IRSDKSharper.dll Fleck.dll MessagePack.dll MessagePack.Annotations.dll"
+for %%F in (%COPY_LIST%) do (
+    if exist "%STAGE%\%%F" (
+        copy /Y "%STAGE%\%%F" "!SH!\%%F" >NUL
+        if !ERRORLEVEL! NEQ 0 (
+            echo  ERROR: Failed to copy %%F to !SH!
+            pause
+            exit /b 1
+        )
+        echo        Copied %%F
+    )
+)
+:: Sanity-check the must-have files landed.
 if not exist "!SH!\RaceCorProDrive.dll" (
-    echo.
-    echo  ERROR: Build succeeded but RaceCorProDrive.dll is missing
-    echo         from !SH!. The csproj's OutputPath logic may have
-    echo         failed - check the build output above.
+    echo  ERROR: RaceCorProDrive.dll didn't land in !SH! after copy.
     pause
     exit /b 1
 )
 
-:: ── 5. Copy dataset ────────────────────────────────────────────
-echo  [3/4] Copying dataset...
+:: Dataset.
 if not exist "!SH!\racecorprodrive-data\" mkdir "!SH!\racecorprodrive-data"
 xcopy /E /Y /Q "%DATA_DIR%\*" "!SH!\racecorprodrive-data\" >NUL
 if %ERRORLEVEL% NEQ 0 (
@@ -152,17 +187,14 @@ if %ERRORLEVEL% NEQ 0 (
     pause
     exit /b 1
 )
-echo        OK.
+echo        Dataset OK.
 
-:: ── 5b. Unblock files (Mark-of-the-Web) ───────────────────────
-:: Files copied from a network share (Parallels Z:\, SMB, etc.) or
-:: downloaded over the internet get tagged with a Zone.Identifier
-:: NTFS alternate data stream. SimHub silently refuses to load
-:: tagged plugin DLLs - the plugin then doesn't even appear in
-:: SimHub's plugin list, with no error UI. Strip those tags so
-:: SimHub treats our files as locally-trusted.
+:: ── 4c. Unblock files (Mark-of-the-Web) ───────────────────────
+:: Files copied from a network share or downloaded over the internet
+:: get tagged with a Zone.Identifier NTFS stream. SimHub silently
+:: refuses to load tagged plugin DLLs.
 echo  [3b]  Unblocking plugin files (Mark-of-the-Web)...
-powershell -NoProfile -Command "Get-ChildItem '!SH!' -Filter 'RaceCorProDrive.*' -ErrorAction SilentlyContinue | Unblock-File -ErrorAction SilentlyContinue; Get-ChildItem '!SH!' -Filter '*.dll' -ErrorAction SilentlyContinue | Unblock-File -ErrorAction SilentlyContinue; Get-ChildItem '!SH!\racecorprodrive-data' -Recurse -ErrorAction SilentlyContinue | Unblock-File -ErrorAction SilentlyContinue" 2>NUL
+powershell -NoProfile -Command "Get-ChildItem '!SH!' -Filter 'RaceCorProDrive.*' -ErrorAction SilentlyContinue | Unblock-File -ErrorAction SilentlyContinue; Get-ChildItem '!SH!' -Filter 'IRSDKSharper.dll','Fleck.dll','MessagePack*.dll' -ErrorAction SilentlyContinue | Unblock-File -ErrorAction SilentlyContinue; Get-ChildItem '!SH!\racecorprodrive-data' -Recurse -ErrorAction SilentlyContinue | Unblock-File -ErrorAction SilentlyContinue" 2>NUL
 echo        OK.
 
 :: ── 6. Restart SimHub ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the actual root cause of the \"new plugin not appearing in SimHub\" saga from the install.bat session. End-to-end verified — **SimHub now shows the \"New plugins have been detected!\" prompt for RaceCor Pro Drive** after running install.bat on a clean SimHub install.

Three independent bugs were stacked on top of each other:

### 1. csproj — never write OutputPath into SimHub directly

The previous \`OutputPath = $(SimHubPath)\` branch dumped every transitive NuGet dep (System.Buffers, System.Memory, BCL polyfills, Newtonsoft.Json, log4net, …) directly on top of SimHub's stock copies. SimHub does strict patch-version checks at startup and a single mismatch silently disables its **entire plugin manager** — we first hit this with Newtonsoft.Json 13.0.3 stomping SimHub's 13.0.4:

\`\`\`
ERROR - INVALID Newtonsoft.Json version! Expected 13.0.4.*, but loaded 13.0.3.27908
\`\`\`

Fixing Newtonsoft alone wasn't enough; other shared-dep mismatches kept silently breaking discovery without the loud INVALID line.

Build now always lands in \`racecor-plugin/simhub-plugin/build/\`. The \`_IsLocalDev\` flag and the \`CopyDataset\` MSBuild target it gated are removed.

### 2. install.bat — surgical allow-list instead of bulk copy

Only the files SimHub doesn't ship are copied into its install folder:

- \`RaceCorProDrive.dll\` / \`.pdb\`
- \`IRSDKSharper.dll\`
- \`Fleck.dll\`
- \`MessagePack.dll\`, \`MessagePack.Annotations.dll\`

Everything else (BCL polyfills, Newtonsoft.Json, log4net) stays in the staging folder. SimHub's stock files are never touched. install.bat sanity-checks the allow-list landed and aborts on miss.

### 3. WsTelemetryPublisher — Lazy<T> for MessagePack init

The previous \`static readonly MessagePackSerializerOptions _serializerOptions = …WithResolver(TypelessContractlessStandardResolver.Instance)\` field initializer fired during type-load when SimHub called \`Assembly.GetTypes()\` on our DLL, dragging MessagePack's reflection-heavy resolver in at scan time. Defensive fix wrapping it in \`Lazy<T>\` so the type loads cleanly even if MessagePack would throw — failures only surface when telemetry actually publishes.

### 4. release.yml — actually stamp the version from the git tag

\`stamp-version.sh\` was claiming \"version stamping is automated in CI\" while the workflow had no such step — every tag was shipping whatever was last manually written into \`AssemblyInfo.cs\` (which is why we kept seeing 0.9.42 even after tagging newer releases). Workflow now rewrites \`AssemblyVersion\` / \`AssemblyFileVersion\` from the tag (\`vMAJOR.MINOR.PATCH\`) before \`dotnet build\`, with explicit fail on malformed tags.

Manually bumped \`AssemblyInfo.cs\` to 0.12.0.0 for the current branch so the dev install isn't pinned to 0.9.42's permission cache.

### 5. .gitignore — cover the new staging path

\`racecor-plugin/simhub-plugin/build/\` (csproj's new OutputPath).

## Test plan

- [x] **Verified end-to-end**: clean SimHub install → \`scripts\\windows\\install.bat\` → SimHub launches → \"New plugins have been detected!\" dialog appears with RaceCor Pro Drive listed.
- [ ] Toggle plugin on, restart SimHub, confirm it stays loaded across restarts without re-prompting.
- [ ] Tag a v0.12.x release in CI and confirm the produced DLL has the matching \`AssemblyVersion\` (no more 0.9.42 ghost).
- [ ] Re-run install.bat on the working install — confirm \`Newtonsoft.Json.dll\` and \`log4net.dll\` in SimHub keep their original timestamps (proving the allow-list does NOT touch them).

## Background

Full debugging arc lived in [Claude Code session]. Notable detours that informed the fix: Mark-of-the-Web blocking, MessagePack 2.5 → System.Buffers conflict, SimHub's permission-cache (\`PluginsManager.json\`) entries persisting across reinstalls, .NET CLR shadow caches surviving uninstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)